### PR TITLE
[Feat]: best-soeat-card 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/best-soeat-card/README.md
+++ b/src/components/common/best-soeat-card/README.md
@@ -1,0 +1,104 @@
+# BestSoeatCard
+
+모임 정보(이미지, 제목, 장소, 날짜·시간)를 표시하는 공통 카드 컴포넌트입니다.
+
+---
+
+## 📁 파일 구조
+
+```
+components/
+  └── common/
+        └── best-soeat-card/
+              ├── index.ts
+              ├── best-soeat-card.tsx
+              ├── best-soeat-card.types.ts
+              ├── best-soeat-card.test.tsx
+              └── best-soeat-card.stories.tsx
+```
+
+---
+
+## ⚙️ Props
+
+```ts
+// BestSoeatCard.types.ts
+export interface BestSoeatCardProps {
+  title: string;
+  region: string;
+  meetingAt: string;
+  thumbnailUrl?: string;
+  thumbnailAlt?: string;
+  className?: string;
+  onClick?: () => void;
+}
+```
+
+| Prop           | Type                  | 기본값          | 필수 | 설명                                |
+| -------------- | --------------------- | --------------- | ---- | ----------------------------------- |
+| `title`        | `string`              | —               | ✅   | 모임 제목                           |
+| `location`     | `string`              | —               | ✅   | 모임 장소 (예: 서울 강남구)         |
+| `meetingAt`    | `string`              | —               | ✅   | 모임 날짜·시간 (예: 3/15(일) 18:30) |
+| `thumbnailUrl` | `string \| undefined` | `undefined`     |      | 썸네일 이미지 URL                   |
+| `thumbnailAlt` | `string`              | `"모임 이미지"` |      | 이미지 alt 텍스트                   |
+| `className`    | `string \| undefined` | `undefined`     |      | 외부 스타일 오버라이드              |
+| `onClick`      | `() => void`          | —               |      | 카드 클릭 이벤트 핸들러             |
+
+---
+
+## 🚀 사용 예시
+
+```tsx
+import BestSoeatCard from '@/components/common/BestSoeatCard';
+
+// 기본 사용
+<BestSoeatCard
+  title="강남 고기집 같이 가실 분!"
+  resion="서울 강남구"
+  meetingAt="3/15(일) 18:30"
+  thumbnailUrl={post.thumbnailUrl}
+  onClick={() => router.push(`/posts/${post.id}`)}
+/>
+
+// 너비 오버라이드
+<BestSoeatCard
+  title="강남 고기집 같이 가실 분!"
+  location="서울 강남구"
+  meetingAt="3/15(일) 18:30"
+  className="w-full"
+  onClick={() => router.push(`/posts/${post.id}`)}
+/>
+```
+
+---
+
+## 🔧 확장 방법
+
+`BestSoeatCardProps`를 `extends`해서 변형 컴포넌트를 만들 수 있습니다.
+
+```ts
+// 예시 — 이미지 없는 텍스트 전용 카드
+export interface MinimalSoeatCardProps extends Omit<
+  BestSoeatCardProps,
+  'thumbnailUrl' | 'thumbnailAlt'
+> {
+  // 추가 prop
+}
+```
+
+---
+
+## ⚠️ 주의사항
+
+- 클릭 시 라우팅은 `onClick` prop으로 위임합니다. 컴포넌트 내부에서 `router.push` 호출을 금지합니다.
+- `thumbnailUrl` 미제공 시 placeholder 이미지가 표시됩니다.
+
+---
+
+## 🚫 의도적으로 제외한 기능
+
+| 기능                       | 사유                                    |
+| -------------------------- | --------------------------------------- |
+| 참여 인원 현황 (예: 3/5명) | 추후 별도 배지 컴포넌트로 분리 예정     |
+| 북마크/찜 버튼             | 별도 오버레이 액션 컴포넌트로 처리 예정 |
+| 카테고리/태그 뱃지         | 추후 확장 시 추가 예정                  |

--- a/src/components/common/best-soeat-card/best-soeat-card.stories.tsx
+++ b/src/components/common/best-soeat-card/best-soeat-card.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { BestSoeatCard } from './best-soeat-card';
+
+const meta = {
+  title: 'components/common/best-soeat-card',
+  component: BestSoeatCard,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    title: '강남 고기집 같이 가실 분!',
+    region: '서울 강남구',
+    meetingAt: '3/15(일) 18:30',
+  },
+} satisfies Meta<typeof BestSoeatCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본 (썸네일 없음)',
+};
+
+export const WithThumbnail: Story = {
+  name: '썸네일 있음',
+  args: {
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&q=80&w=400',
+    thumbnailAlt: '맛있는 음식',
+  },
+};
+
+export const WithClick: Story = {
+  name: '클릭 가능',
+  args: {
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1555939594-58d7cb561ad1?auto=format&fit=crop&q=80&w=400',
+    onClick: () => alert('카드 클릭!'),
+  },
+};
+
+export const LongTitle: Story = {
+  name: '긴 제목 (line-clamp-2)',
+  args: {
+    title: '주말 저녁 분위기 좋은 이탈리안 레스토랑에서 파스타 같이 드실 분 모집합니다!',
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1493770348161-369560ae357d?auto=format&fit=crop&q=80&w=400',
+  },
+};

--- a/src/components/common/best-soeat-card/best-soeat-card.test.tsx
+++ b/src/components/common/best-soeat-card/best-soeat-card.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BestSoeatCard } from './best-soeat-card';
+
+const DEFAULT_PROPS = {
+  title: '강남 고기집 같이 가실 분!',
+  region: '서울 강남구',
+  meetingAt: '3/15(일) 18:30',
+};
+
+describe('BestSoeatCard', () => {
+  it('제목, 지역, 날짜가 렌더링된다', () => {
+    render(<BestSoeatCard {...DEFAULT_PROPS} />);
+
+    expect(screen.getByText('강남 고기집 같이 가실 분!')).toBeInTheDocument();
+    expect(screen.getByText('서울 강남구')).toBeInTheDocument();
+    expect(screen.getByText('3/15(일) 18:30')).toBeInTheDocument();
+  });
+
+  it('thumbnailUrl 제공 시 이미지가 렌더링된다', () => {
+    render(
+      <BestSoeatCard
+        {...DEFAULT_PROPS}
+        thumbnailUrl="https://example.com/food.jpg"
+        thumbnailAlt="음식 사진"
+      />
+    );
+
+    expect(screen.getByAltText('음식 사진')).toBeInTheDocument();
+  });
+
+  it('thumbnailAlt 미제공 시 기본값 "모임 이미지"가 사용된다', () => {
+    render(<BestSoeatCard {...DEFAULT_PROPS} thumbnailUrl="https://example.com/food.jpg" />);
+
+    expect(screen.getByAltText('모임 이미지')).toBeInTheDocument();
+  });
+
+  it('onClick 제공 시 클릭 이벤트가 호출된다', async () => {
+    const handleClick = jest.fn();
+    const user = userEvent.setup();
+
+    const { container } = render(<BestSoeatCard {...DEFAULT_PROPS} onClick={handleClick} />);
+
+    await user.click(container.firstChild as HTMLElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/common/best-soeat-card/best-soeat-card.tsx
+++ b/src/components/common/best-soeat-card/best-soeat-card.tsx
@@ -35,8 +35,8 @@ export function BestSoeatCard({
       </div>
 
       {/* 카드 정보 */}
-      <CardContent className="flex flex-col gap-1 p-3">
-        <CardTitle className="line-clamp-2 text-sm leading-(--text-base--line-height) font-semibold">
+      <CardContent className="flex flex-col p-3">
+        <CardTitle className="mb-1.5 line-clamp-2 text-sm leading-(--text-xs--line-height) font-bold">
           {title}
         </CardTitle>
         <div className="text-sosoeat-gray-700 flex items-center gap-1 text-xs">

--- a/src/components/common/best-soeat-card/best-soeat-card.tsx
+++ b/src/components/common/best-soeat-card/best-soeat-card.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+
+import { Clock, MapPin } from 'lucide-react';
+
+import { Card, CardContent, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import type { BestSoeatCardProps } from './best-soeat-card.types';
+
+export function BestSoeatCard({
+  title,
+  region,
+  meetingAt,
+  thumbnailUrl,
+  thumbnailAlt = '모임 이미지',
+  className,
+  onClick,
+}: BestSoeatCardProps) {
+  return (
+    <Card
+      className={cn(
+        'border-sosoeat-gray-400 h-[200px] w-[220px] gap-0 border py-0 ring-0',
+        onClick && 'cursor-pointer transition-transform hover:scale-[1.02] active:scale-[0.98]',
+        className
+      )}
+      onClick={onClick}
+    >
+      {/* 썸네일 */}
+      <div className="bg-muted relative w-full flex-1">
+        <Image
+          src={thumbnailUrl ?? '/images/placeholder-food.png'}
+          alt={thumbnailAlt}
+          fill
+          className="object-cover"
+          sizes="220px"
+        />
+      </div>
+
+      {/* 카드 정보 */}
+      <CardContent className="flex flex-col gap-1 p-3">
+        <CardTitle className="line-clamp-2 text-sm leading-(--text-base--line-height) font-semibold">
+          {title}
+        </CardTitle>
+        <div className="text-sosoeat-gray-700 flex items-center gap-1 text-xs">
+          <MapPin className="h-2.5 w-2.5 shrink-0" />
+          <span className="truncate">{region}</span>
+        </div>
+        <div className="text-sosoeat-gray-700 flex items-center gap-1 text-xs">
+          <Clock className="h-2.5 w-2.5 shrink-0" />
+          <span className="truncate">{meetingAt}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/common/best-soeat-card/best-soeat-card.tsx
+++ b/src/components/common/best-soeat-card/best-soeat-card.tsx
@@ -13,15 +13,13 @@ export function BestSoeatCard({
   meetingAt,
   thumbnailUrl,
   thumbnailAlt = '모임 이미지',
-  className,
   onClick,
 }: BestSoeatCardProps) {
   return (
     <Card
       className={cn(
         'border-sosoeat-gray-400 h-[200px] w-[220px] gap-0 border py-0 ring-0',
-        onClick && 'cursor-pointer transition-transform hover:scale-[1.02] active:scale-[0.98]',
-        className
+        onClick && 'cursor-pointer transition-transform hover:scale-[1.02] active:scale-[0.98]'
       )}
       onClick={onClick}
     >

--- a/src/components/common/best-soeat-card/best-soeat-card.types.ts
+++ b/src/components/common/best-soeat-card/best-soeat-card.types.ts
@@ -4,6 +4,5 @@ export interface BestSoeatCardProps {
   meetingAt: string;
   thumbnailUrl?: string;
   thumbnailAlt?: string;
-  className?: string;
   onClick?: () => void;
 }

--- a/src/components/common/best-soeat-card/best-soeat-card.types.ts
+++ b/src/components/common/best-soeat-card/best-soeat-card.types.ts
@@ -1,0 +1,9 @@
+export interface BestSoeatCardProps {
+  title: string;
+  region: string;
+  meetingAt: string;
+  thumbnailUrl?: string;
+  thumbnailAlt?: string;
+  className?: string;
+  onClick?: () => void;
+}

--- a/src/components/common/best-soeat-card/index.ts
+++ b/src/components/common/best-soeat-card/index.ts
@@ -1,0 +1,2 @@
+export { BestSoeatCard } from './best-soeat-card';
+export type { BestSoeatCardProps } from './best-soeat-card.types';


### PR DESCRIPTION
### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [x] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등
 
### 📝 변경 사항 (Changes)
 
- #21 이슈에 따라 `BestSoeatCard` 공통 컴포넌트를 구현했습니다.
- 모임 썸네일 이미지, 제목(2줄 clamp), 지역, 모임 일시를 표시하는 카드 UI를 제공합니다.
- `onClick` prop을 통해 클릭 인터랙션(hover/active 스케일 애니메이션)을 선택적으로 적용할 수 있습니다.
- Storybook 스토리 및 Jest 테스트 코드를 추가했습니다.
- 컴포넌트 명세 README를 작성했습니다.
- 타이틀 하단 간격을 `6px`로 조정했습니다.
 
### 🧪 테스트 방법 (How to Test)
 
1. 로컬 환경에서 Storybook을 실행합니다.
   ```bash
   npm run storybook
   ```
2. `Common/BestSoeatCard` 스토리로 이동합니다.
3. `Default`, `WithClick`, `LongTitle`, `NoThumbnail` 등 각 스토리에서 카드가 올바르게 렌더링되는지 확인합니다.
4. `onClick`이 있는 스토리에서 hover/active 시 스케일 애니메이션이 동작하는지 확인합니다.
 
### 📸 스크린샷 또는 영상 (Optional)

- 기본 (썸네일 있음)
<img width="255" height="227" alt="image" src="https://github.com/user-attachments/assets/c3479718-90e5-4d48-9dcc-c396d64e2419" />

- 긴 제목
<img width="271" height="224" alt="image" src="https://github.com/user-attachments/assets/4f5c6ae4-ba6c-4d2b-9a5d-fda5163af1f3" />


### 🚨 기타 참고 사항 (Notes)
- [x] **사용자가 썸네일 이미지를 업로드하지 않을 것을 대비해 기본 이미지가 필요합니다.**
- [x] **`next/image`의 `fill` 모드를 사용하므로 부모 컨테이너에 `position: relative`가 필요합니다.**