### PR TITLE
feat: add sosotalk-banner component 소소토크 반응형 배너 컴포넌트

### DIFF
--- a/src/app/sosotalk/_components/sosotalk-banner/index.ts
+++ b/src/app/sosotalk/_components/sosotalk-banner/index.ts
@@ -1,0 +1,2 @@
+export * from './sosotalk-banner';
+export * from './sosotalk-banner.types';

--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.stories.tsx
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { SosoTalkBanner } from './sosotalk-banner';
+
+const meta = {
+  title: 'SosoTalk/SosoTalkBanner',
+  component: SosoTalkBanner,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof SosoTalkBanner>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    imageUrl:
+      'https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=1200&auto=format&fit=crop',
+    alt: '소소토크 배너 이미지',
+  },
+};

--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
@@ -1,5 +1,5 @@
+import Image from 'next/image';
 import { cn } from '@/lib/utils';
-
 import { SosoTalkBannerProps } from './sosotalk-banner.types';
 
 export const SosoTalkBanner = ({
@@ -12,10 +12,10 @@ export const SosoTalkBanner = ({
       <div
         className={cn(
           'relative h-[60px] w-full overflow-hidden rounded-none md:h-[200px] xl:max-w-[1280px] xl:rounded-[16px]',
-          className,
+          className
         )}
       >
-        <image src={imageUrl} alt={alt} className="h-full w-full object-cover" />
+        <Image src={imageUrl} alt={alt} className="h-full w-full object-cover" />
         <div className="absolute inset-0 bg-black/50" />
       </div>
     </section>

--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
@@ -1,0 +1,18 @@
+import { SosoTalkBannerProps } from './sosotalk-banner.types';
+
+export function SosoTalkBanner({
+  imageUrl,
+  alt = '소소토크 배너 이미지',
+  className,
+}: SosoTalkBannerProps) {
+  return (
+    <section className="flex justify-center">
+      <div
+        className={`relative h-[60px] w-full overflow-hidden rounded-none md:h-[200px] xl:max-w-[1280px] xl:rounded-[16px] ${className ?? ''}`}
+      >
+        <img src={imageUrl} alt={alt} className="h-full w-full object-cover" />
+        <div className="absolute inset-0 bg-black/50" />
+      </div>
+    </section>
+  );
+}

--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
@@ -1,18 +1,23 @@
+import { cn } from '@/lib/utils';
+
 import { SosoTalkBannerProps } from './sosotalk-banner.types';
 
-export function SosoTalkBanner({
+export const SosoTalkBanner = ({
   imageUrl,
   alt = '소소토크 배너 이미지',
   className,
-}: SosoTalkBannerProps) {
+}: SosoTalkBannerProps) => {
   return (
     <section className="flex justify-center">
       <div
-        className={`relative h-[60px] w-full overflow-hidden rounded-none md:h-[200px] xl:max-w-[1280px] xl:rounded-[16px] ${className ?? ''}`}
+        className={cn(
+          'relative h-[60px] w-full overflow-hidden rounded-none md:h-[200px] xl:max-w-[1280px] xl:rounded-[16px]',
+          className,
+        )}
       >
         <img src={imageUrl} alt={alt} className="h-full w-full object-cover" />
         <div className="absolute inset-0 bg-black/50" />
       </div>
     </section>
   );
-}
+};

--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
@@ -15,7 +15,7 @@ export const SosoTalkBanner = ({
           className,
         )}
       >
-        <img src={imageUrl} alt={alt} className="h-full w-full object-cover" />
+        <image src={imageUrl} alt={alt} className="h-full w-full object-cover" />
         <div className="absolute inset-0 bg-black/50" />
       </div>
     </section>

--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.types.ts
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.types.ts
@@ -1,0 +1,5 @@
+export type SosoTalkBannerProps = {
+  imageUrl: string;
+  alt?: string;
+  className?: string;
+};


### PR DESCRIPTION
## PR 제목: [Feat]: #28 sosotalk-banner / 소소토크 상단 배너 컴포넌트 구현

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- #28 이슈와 관련된 소소토크 상단 배너 컴포넌트를 구현했습니다.
- 소소토크 페이지 전용 배너 컴포넌트를 추가했습니다.
- 배너 이미지를 표시하고, 이미지 위에 어두운 오버레이가 적용되도록 구현했습니다.
- 반응형 대응을 위해 모바일에서는 높이 60px, 태블릿 이상에서는 높이 200px이 적용되도록 구현했습니다.
- 큰 화면에서는 최대 너비 1280px을 유지하고, 화면과 맞닿는 구간에서는 라운드가 제거되도록 처리했습니다.
- Storybook에서 배너 컴포넌트를 독립적으로 확인할 수 있도록 스토리 파일을 추가했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 `npm install` 후 `npm run storybook` 또는 `npm run dev`를 실행합니다.
2. Storybook에서 `SosoTalk / SosoTalkBanner` 경로로 이동하거나, 소소토크 페이지에서 배너가 정상적으로 렌더링되는지 확인합니다.
3. 데스크탑 환경에서 배너가 최대 너비 1280px로 표시되고 라운드가 적용되는지 확인합니다.
4. 화면 크기를 줄여 태블릿 크기에서 높이 200px이 유지되는지 확인합니다.
5. 모바일 크기에서 배너 높이가 60px로 변경되고, 좌우 폭에 맞게 자연스럽게 줄어드는지 확인합니다.
6. 이미지 위에 어두운 오버레이가 정상적으로 적용되는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)
<img width="1056" height="659" alt="image" src="https://github.com/user-attachments/assets/a21f3b7d-108f-45a8-a014-f8c0d5b0fc38" />

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|        -         |    첨부 예정    |

### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
  - 배너의 반응형 높이 변경 방식과 `xl` 구간에서의 최대 너비/라운드 처리 방식이 적절한지 확인 부탁드립니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**