### PR TITLE
[Feat]: 소소톡 글쓰기 에디터 UI 및 상호작용 구현

### DIFF
--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/image-upload-field.tsx
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/image-upload-field.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Image from 'next/image';
+
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import { ImageUploadFieldProps } from './image-upload-field.types';
+
+export function ImageUploadField({
+  className,
+  imageUrl,
+  imageName,
+  disabled = false,
+  onRemove,
+}: ImageUploadFieldProps) {
+  if (!imageUrl) {
+    return null;
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <div className="relative h-[134px] w-[134px] overflow-hidden rounded-[14px] bg-[#D9D9D9]">
+        <Image
+          src={imageUrl}
+          alt={imageName ?? '업로드한 이미지'}
+          fill
+          unoptimized
+          className="object-cover"
+        />
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={disabled}
+          className="absolute top-8 right-8 flex h-5 w-5 items-center justify-center rounded-full bg-black/70 text-white transition-opacity hover:opacity-85 disabled:pointer-events-none disabled:opacity-50"
+          aria-label="업로드한 이미지 삭제"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/image-upload-field.types.ts
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/image-upload-field.types.ts
@@ -1,0 +1,7 @@
+export interface ImageUploadFieldProps {
+  className?: string;
+  imageUrl?: string;
+  imageName?: string;
+  disabled?: boolean;
+  onRemove?: () => void;
+}

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/index.ts
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/index.ts
@@ -1,0 +1,2 @@
+export { ImageUploadField } from './image-upload-field';
+export type { ImageUploadFieldProps } from './image-upload-field.types';

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/hooks/use-sosotalk-post-editor.ts
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/hooks/use-sosotalk-post-editor.ts
@@ -1,0 +1,250 @@
+'use client';
+
+import type { ChangeEvent, FormEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH,
+  SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH,
+} from '../sosotalk-post-editor.constants';
+import type { SosoTalkPostEditorProps } from '../sosotalk-post-editor.types';
+import {
+  calculateEffectiveContentLength,
+  extractTextFromHtml,
+  normalizePlainText,
+  toInitialHtml,
+} from '../sosotalk-post-editor.utils';
+
+type ActiveKey =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'unorderedList'
+  | 'orderedList'
+  | 'alignLeft'
+  | 'alignCenter';
+
+type ActiveFormats = Record<ActiveKey, boolean>;
+
+const DEFAULT_ACTIVE_FORMATS: ActiveFormats = {
+  bold: false,
+  italic: false,
+  underline: false,
+  unorderedList: false,
+  orderedList: false,
+  alignLeft: true,
+  alignCenter: false,
+};
+
+type UseSosoTalkPostEditorParams = Pick<
+  SosoTalkPostEditorProps,
+  'initialTitle' | 'initialContent' | 'initialImageUrl' | 'onSubmit'
+>;
+
+export const useSosoTalkPostEditor = ({
+  initialTitle = '',
+  initialContent = '',
+  initialImageUrl = '',
+  onSubmit,
+}: UseSosoTalkPostEditorParams) => {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const lastValidHtmlRef = useRef(toInitialHtml(initialContent));
+  const lastValidTextRef = useRef(normalizePlainText(initialContent));
+  const lastValidEffectiveLengthRef = useRef(normalizePlainText(initialContent).length);
+
+  const [title, setTitle] = useState(initialTitle);
+  const [contentHtml, setContentHtml] = useState(toInitialHtml(initialContent));
+  const [contentText, setContentText] = useState(normalizePlainText(initialContent));
+  const [effectiveContentLength, setEffectiveContentLength] = useState(
+    normalizePlainText(initialContent).length
+  );
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreviewUrl, setImagePreviewUrl] = useState(initialImageUrl);
+  const [activeFormats, setActiveFormats] = useState<ActiveFormats>(DEFAULT_ACTIVE_FORMATS);
+
+  useEffect(() => {
+    setTitle(initialTitle);
+  }, [initialTitle]);
+
+  useEffect(() => {
+    const nextHtml = toInitialHtml(initialContent);
+    const nextText = normalizePlainText(initialContent);
+    const nextEffectiveLength = nextText.length;
+
+    setContentHtml(nextHtml);
+    setContentText(nextText);
+    setEffectiveContentLength(nextEffectiveLength);
+    lastValidHtmlRef.current = nextHtml;
+    lastValidTextRef.current = nextText;
+    lastValidEffectiveLengthRef.current = nextEffectiveLength;
+
+    if (editorRef.current) {
+      editorRef.current.innerHTML = nextHtml;
+    }
+  }, [initialContent]);
+
+  useEffect(() => {
+    setImagePreviewUrl(initialImageUrl);
+  }, [initialImageUrl]);
+
+  useEffect(() => {
+    if (!imageFile) {
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(imageFile);
+    setImagePreviewUrl(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [imageFile]);
+
+  const updateToolbarState = () => {
+    if (!editorRef.current || typeof document === 'undefined') {
+      return;
+    }
+
+    const selection = window.getSelection();
+    const anchorNode = selection?.anchorNode;
+    const isInsideEditor = anchorNode ? editorRef.current.contains(anchorNode) : false;
+
+    if (!isInsideEditor) {
+      setActiveFormats(DEFAULT_ACTIVE_FORMATS);
+      return;
+    }
+
+    setActiveFormats({
+      bold: document.queryCommandState('bold'),
+      italic: document.queryCommandState('italic'),
+      underline: document.queryCommandState('underline'),
+      unorderedList: document.queryCommandState('insertUnorderedList'),
+      orderedList: document.queryCommandState('insertOrderedList'),
+      alignLeft: !document.queryCommandState('justifyCenter'),
+      alignCenter: document.queryCommandState('justifyCenter'),
+    });
+  };
+
+  useEffect(() => {
+    document.addEventListener('selectionchange', updateToolbarState);
+
+    return () => {
+      document.removeEventListener('selectionchange', updateToolbarState);
+    };
+  }, []);
+
+  const syncEditorState = () => {
+    const nextHtml = editorRef.current?.innerHTML ?? '';
+    const nextText = extractTextFromHtml(nextHtml);
+    const nextEffectiveLength = calculateEffectiveContentLength(nextText, editorRef.current);
+
+    if (nextEffectiveLength > SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH) {
+      if (editorRef.current) {
+        editorRef.current.innerHTML = lastValidHtmlRef.current;
+      }
+
+      setContentHtml(lastValidHtmlRef.current);
+      setContentText(lastValidTextRef.current);
+      setEffectiveContentLength(lastValidEffectiveLengthRef.current);
+      updateToolbarState();
+      return;
+    }
+
+    lastValidHtmlRef.current = nextHtml;
+    lastValidTextRef.current = nextText;
+    lastValidEffectiveLengthRef.current = nextEffectiveLength;
+
+    setContentHtml(nextHtml);
+    setContentText(nextText);
+    setEffectiveContentLength(nextEffectiveLength);
+    updateToolbarState();
+  };
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value.slice(0, SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH));
+  };
+
+  const handleEditorInput = () => {
+    if (!editorRef.current) {
+      return;
+    }
+
+    syncEditorState();
+  };
+
+  const handleToolbarAction = (command?: string, value?: string, isImage?: boolean) => {
+    if (isImage) {
+      fileInputRef.current?.click();
+      return;
+    }
+
+    editorRef.current?.focus();
+
+    if (command) {
+      document.execCommand(command, false, value);
+      syncEditorState();
+    }
+  };
+
+  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextFile = event.target.files?.[0] ?? null;
+    setImageFile(nextFile);
+
+    if (!nextFile) {
+      setImagePreviewUrl('');
+    }
+  };
+
+  const handleImageRemove = () => {
+    setImageFile(null);
+    setImagePreviewUrl('');
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (
+      title.trim().length === 0 ||
+      contentText.trim().length === 0 ||
+      effectiveContentLength > SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH
+    ) {
+      return;
+    }
+
+    onSubmit?.({
+      title: title.trim(),
+      contentHtml,
+      contentText,
+      imageFile,
+      imagePreviewUrl,
+    });
+  };
+
+  return {
+    activeFormats,
+    contentLengthWithoutSpaces: contentText.replace(/\s/g, '').length,
+    contentText,
+    editorRef,
+    effectiveContentLength,
+    fileInputRef,
+    handleEditorInput,
+    handleImageChange,
+    handleImageRemove,
+    handleSubmit,
+    handleTitleChange,
+    handleToolbarAction,
+    imageFile,
+    imagePreviewUrl,
+    isSubmitDisabled:
+      title.trim().length === 0 ||
+      contentText.trim().length === 0 ||
+      effectiveContentLength > SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH,
+    title,
+    syncEditorState,
+  };
+};

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/index.ts
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/index.ts
@@ -1,0 +1,5 @@
+export { SosoTalkPostEditor } from './sosotalk-post-editor';
+export type {
+  SosoTalkPostEditorProps,
+  SosoTalkPostSubmitPayload,
+} from './sosotalk-post-editor.types';

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.constants.ts
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.constants.ts
@@ -1,0 +1,7 @@
+export const SOSOTALK_POST_EDITOR_WIDTH = 860;
+export const SOSOTALK_POST_EDITOR_MIN_HEIGHT = 780;
+export const SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH = 30;
+export const SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH = 680;
+export const SOSOTALK_POST_EDITOR_IMAGE_MAX_COUNT = 1;
+export const SOSOTALK_POST_EDITOR_ACCEPTED_IMAGE_TYPES =
+  'image/png,image/jpeg,image/webp,image/gif';

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.stories.tsx
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { SosoTalkPostEditor } from './sosotalk-post-editor';
+
+const meta = {
+  title: 'SosoTalk/Write/SosoTalkPostEditor',
+  component: SosoTalkPostEditor,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: {
+      default: 'lightGray',
+      values: [{ name: 'lightGray', value: '#F6F7FB' }],
+    },
+  },
+} satisfies Meta<typeof SosoTalkPostEditor>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    initialTitle: '',
+    initialContent: '',
+  },
+};
+
+export const WithImagePreview: Story = {
+  args: {
+    initialTitle: '모임 추천 부탁드립니다 :D',
+    initialContent:
+      '안녕하세요! 요즘 모임을 찾아보고 있는데, 어떤 모임이 좋을지 모르겠어요.\n\n저는 자연, 풍경 보는 걸 좋아하고 강아지에 관심이 많습니다!\n혹시 해보신 모임 중에서 괜찮았던 모임이나 주의할 점 있으면 자유롭게 댓글 달아주세요.',
+    initialImageUrl:
+      'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?q=80&w=800&auto=format&fit=crop',
+  },
+};

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.test.tsx
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SosoTalkPostEditor } from './sosotalk-post-editor';
+import {
+  SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH,
+  SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH,
+} from './sosotalk-post-editor.constants';
+
+beforeEach(() => {
+  document.execCommand = jest.fn();
+  document.queryCommandState = jest.fn().mockReturnValue(false);
+});
+
+describe('SosoTalkPostEditor', () => {
+  it('제목은 최대 30자까지만 입력된다', async () => {
+    const user = userEvent.setup();
+
+    render(<SosoTalkPostEditor />);
+
+    const titleInput = screen.getByLabelText('게시글 제목');
+    const longTitle = '가'.repeat(SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH + 5);
+
+    await user.type(titleInput, longTitle);
+
+    expect(titleInput).toHaveValue('가'.repeat(SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH));
+  });
+
+  it('제목과 본문 초기값이 모두 있으면 등록 버튼이 활성화된다', () => {
+    render(
+      <SosoTalkPostEditor initialTitle="모임 추천 부탁드립니다" initialContent="본문 내용입니다." />
+    );
+
+    expect(screen.getByRole('button', { name: '등록' })).not.toBeDisabled();
+  });
+
+  it('초기 이미지가 있으면 삭제 버튼으로 제거할 수 있다', async () => {
+    const user = userEvent.setup();
+
+    render(<SosoTalkPostEditor initialImageUrl="https://example.com/image.jpg" />);
+
+    expect(screen.getByAltText('업로드한 이미지')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '업로드한 이미지 삭제' }));
+
+    expect(screen.queryByAltText('업로드한 이미지')).not.toBeInTheDocument();
+  });
+
+  it('본문 공백 포함 글자 수 제한을 넘기면 마지막 유효 상태를 유지한다', () => {
+    render(
+      <SosoTalkPostEditor initialContent={'가'.repeat(SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH)} />
+    );
+
+    const editor = screen.getByRole('textbox');
+
+    editor.innerHTML = `<p>${'가'.repeat(SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH + 1)}</p>`;
+    fireEvent.input(editor);
+
+    expect(
+      screen.getByText(new RegExp(`공백포함 : 총 ${SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH}자`))
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.tsx
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import type { ComponentType } from 'react';
+
+import {
+  AlignCenter,
+  AlignLeft,
+  Bold,
+  ImagePlus,
+  Italic,
+  List,
+  ListOrdered,
+  Pilcrow,
+  Underline,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+import { ImageUploadField } from './_components/image-upload-field';
+import { useSosoTalkPostEditor } from './hooks/use-sosotalk-post-editor';
+import {
+  SOSOTALK_POST_EDITOR_ACCEPTED_IMAGE_TYPES,
+  SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH,
+  SOSOTALK_POST_EDITOR_MIN_HEIGHT,
+  SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH,
+} from './sosotalk-post-editor.constants';
+import type { SosoTalkPostEditorProps } from './sosotalk-post-editor.types';
+
+type ActiveKey =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'unorderedList'
+  | 'orderedList'
+  | 'alignLeft'
+  | 'alignCenter';
+
+type ToolbarAction = {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  command?: string;
+  value?: string;
+  isImage?: boolean;
+  activeKey?: ActiveKey;
+};
+
+const TOOLBAR_ACTIONS: ToolbarAction[] = [
+  { label: '굵게', icon: Bold, command: 'bold', activeKey: 'bold' },
+  { label: '기울임', icon: Italic, command: 'italic', activeKey: 'italic' },
+  { label: '밑줄', icon: Underline, command: 'underline', activeKey: 'underline' },
+  { label: '본문', icon: Pilcrow, command: 'formatBlock', value: 'p' },
+  { label: '좌측 정렬', icon: AlignLeft, command: 'justifyLeft', activeKey: 'alignLeft' },
+  { label: '가운데 정렬', icon: AlignCenter, command: 'justifyCenter', activeKey: 'alignCenter' },
+  { label: '목록', icon: List, command: 'insertUnorderedList', activeKey: 'unorderedList' },
+  { label: '번호 목록', icon: ListOrdered, command: 'insertOrderedList', activeKey: 'orderedList' },
+  { label: '이미지 추가', icon: ImagePlus, isImage: true },
+];
+
+export const SosoTalkPostEditor = ({
+  className,
+  initialTitle = '',
+  initialContent = '',
+  initialImageUrl = '',
+  submitLabel = '등록',
+  onSubmit,
+}: SosoTalkPostEditorProps) => {
+  const {
+    activeFormats,
+    contentLengthWithoutSpaces,
+    contentText,
+    editorRef,
+    effectiveContentLength,
+    fileInputRef,
+    handleEditorInput,
+    handleImageChange,
+    handleImageRemove,
+    handleSubmit,
+    handleTitleChange,
+    handleToolbarAction,
+    imageFile,
+    imagePreviewUrl,
+    isSubmitDisabled,
+    syncEditorState,
+    title,
+  } = useSosoTalkPostEditor({
+    initialTitle,
+    initialContent,
+    initialImageUrl,
+    onSubmit,
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn('mx-auto flex w-full flex-col gap-6 md:gap-8', className)}
+    >
+      <div className="mx-auto flex w-full max-w-[860px] items-end gap-2 md:gap-4">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <label htmlFor="sosotalk-post-title" className="sr-only">
+            게시글 제목
+          </label>
+          <input
+            id="sosotalk-post-title"
+            value={title}
+            onChange={handleTitleChange}
+            placeholder="게시글 제목을 입력해주세요. (최대 30자)"
+            className="border-sosoeat-gray-400 placeholder:text-sosoeat-gray-500 w-full border-b bg-transparent pb-2 text-sm font-semibold outline-none md:text-xl lg:text-3xl"
+          />
+        </div>
+
+        <span className="text-sosoeat-gray-700 pb-3 text-xs font-semibold md:pb-4 md:text-sm">
+          <span className="text-orange-600">{title.length}</span>/
+          {SOSOTALK_POST_EDITOR_TITLE_MAX_LENGTH}
+        </span>
+
+        <Button
+          type="submit"
+          disabled={isSubmitDisabled}
+          className="bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 h-10 w-14 rounded-[14px] px-0 text-sm font-semibold text-white md:h-[48px] md:w-[80px] md:text-lg"
+        >
+          {submitLabel}
+        </Button>
+      </div>
+
+      <div
+        className="mx-auto flex w-full max-w-[860px] flex-col rounded-[24px] bg-white px-4 pt-4 pb-6 shadow-[0_10px_30px_rgba(0,0,0,0.04)] md:rounded-[34px] md:px-9 md:pt-9 md:pb-8"
+        style={{ minHeight: `${SOSOTALK_POST_EDITOR_MIN_HEIGHT}px` }}
+      >
+        <div className="bg-sosoeat-gray-200 rounded-[18px] px-2 py-2 md:rounded-[22px] md:px-4 md:py-2.5">
+          <div className="grid grid-cols-9 items-center gap-0.5 md:gap-1">
+            {TOOLBAR_ACTIONS.map((action) => {
+              const Icon = action.icon;
+              const isActive = action.activeKey ? activeFormats[action.activeKey] : false;
+
+              return (
+                <button
+                  key={action.label}
+                  type="button"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => handleToolbarAction(action.command, action.value, action.isImage)}
+                  className={cn(
+                    'flex h-7 w-full items-center justify-center rounded-full transition-colors md:h-9',
+                    isActive
+                      ? 'bg-white text-orange-600 shadow-[0_2px_10px_rgba(0,0,0,0.06)]'
+                      : 'text-sosoeat-gray-600 hover:bg-white hover:text-orange-600'
+                  )}
+                  aria-label={action.label}
+                  aria-pressed={isActive}
+                >
+                  <Icon className="h-4 w-4 md:h-[18px] md:w-[18px]" />
+                </button>
+              );
+            })}
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={SOSOTALK_POST_EDITOR_ACCEPTED_IMAGE_TYPES}
+            className="hidden"
+            onChange={handleImageChange}
+          />
+        </div>
+
+        <div className="relative mt-4 min-h-[360px] flex-1 md:mt-6">
+          {!contentText ? (
+            <p className="text-sosoeat-gray-600 pointer-events-none absolute top-0 left-0 text-sm font-medium">
+              게시글 내용을 입력해주세요. (최대 {SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH}자)
+            </p>
+          ) : null}
+
+          <div
+            ref={editorRef}
+            contentEditable
+            suppressContentEditableWarning
+            onInput={handleEditorInput}
+            onBlur={syncEditorState}
+            className={cn(
+              'relative min-h-[360px] text-sm font-medium outline-none',
+              '[&_ol]:list-decimal [&_ol]:pl-6 [&_p]:min-h-[1.85em] [&_ul]:list-disc [&_ul]:pl-6'
+            )}
+          />
+        </div>
+
+        <div className="mt-auto pt-6 md:pt-10">
+          <ImageUploadField
+            imageUrl={imagePreviewUrl}
+            imageName={imageFile?.name}
+            onRemove={handleImageRemove}
+          />
+          <p className="text-sosoeat-gray-600 mt-8 text-sm">
+            공백포함 : 총 {effectiveContentLength}자 | 공백제외 : 총 {contentLengthWithoutSpaces}자
+          </p>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.types.ts
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.types.ts
@@ -1,0 +1,16 @@
+export interface SosoTalkPostSubmitPayload {
+  title: string;
+  contentHtml: string;
+  contentText: string;
+  imageFile: File | null;
+  imagePreviewUrl: string;
+}
+
+export interface SosoTalkPostEditorProps {
+  className?: string;
+  initialTitle?: string;
+  initialContent?: string;
+  initialImageUrl?: string;
+  submitLabel?: string;
+  onSubmit?: (payload: SosoTalkPostSubmitPayload) => void;
+}

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.utils.ts
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.utils.ts
@@ -1,0 +1,100 @@
+export const normalizePlainText = (text: string) =>
+  text.replace(/\u00A0/g, ' ').replace(/\n{3,}/g, '\n\n');
+
+export const toInitialHtml = (content: string) => {
+  if (!content.trim()) {
+    return '';
+  }
+
+  return content
+    .split('\n')
+    .map((line) => {
+      if (!line.trim()) {
+        return '<p><br></p>';
+      }
+
+      return `<p>${line}</p>`;
+    })
+    .join('');
+};
+
+export const extractTextFromHtml = (html: string) => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  const container = window.document.createElement('div');
+  container.innerHTML = html;
+
+  return normalizePlainText(container.innerText);
+};
+
+const createTextMeasurer = (element: HTMLElement) => {
+  const computedStyle = window.getComputedStyle(element);
+  const canvas = window.document.createElement('canvas');
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    return null;
+  }
+
+  context.font = [
+    computedStyle.fontStyle,
+    computedStyle.fontVariant,
+    computedStyle.fontWeight,
+    computedStyle.fontSize,
+    computedStyle.fontFamily,
+  ].join(' ');
+
+  const sampleText =
+    '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  const averageCharacterWidth = context.measureText(sampleText).width / sampleText.length;
+
+  return {
+    measureTextWidth: (value: string) => context.measureText(value).width,
+    averageCharacterWidth,
+  };
+};
+
+export const calculateEffectiveContentLength = (text: string, element: HTMLElement | null) => {
+  if (!element || typeof window === 'undefined') {
+    return text.length;
+  }
+
+  const measurer = createTextMeasurer(element);
+
+  if (!measurer) {
+    return text.length;
+  }
+
+  const editorWidth = element.clientWidth;
+
+  if (!editorWidth) {
+    return text.length;
+  }
+
+  let effectiveLength = 0;
+  let currentLineWidth = 0;
+
+  for (const character of text) {
+    if (character === '\n') {
+      const remainingWidth = Math.max(editorWidth - currentLineWidth, 0);
+      const remainingCharacterSlots = Math.round(remainingWidth / measurer.averageCharacterWidth);
+
+      effectiveLength += remainingCharacterSlots;
+      currentLineWidth = 0;
+      continue;
+    }
+
+    const characterWidth = measurer.measureTextWidth(character);
+
+    if (currentLineWidth > 0 && currentLineWidth + characterWidth > editorWidth) {
+      currentLineWidth = 0;
+    }
+
+    currentLineWidth += characterWidth;
+    effectiveLength += 1;
+  }
+
+  return effectiveLength;
+};

--- a/src/app/sosotalk/write/page.tsx
+++ b/src/app/sosotalk/write/page.tsx
@@ -1,0 +1,11 @@
+import { SosoTalkPostEditor } from './_components/sosotalk-post-editor';
+
+export default function SosoTalkWritePage() {
+  return (
+    <main className="min-h-screen bg-[#F6F7FB] px-4 py-16">
+      <div className="mx-auto w-full max-w-[860px]">
+        <SosoTalkPostEditor />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## PR 제목
`[Feat]: 소소톡 글쓰기 에디터 UI 및 상호작용 구현`

### 📌 유형 (Type)
- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)
- 소소톡 글쓰기 페이지 전용 컴포넌트를 `src/app/sosotalk/write/_components` 구조로 구성했습니다.
- 제목 입력, 본문 에디터, 이미지 1장 업로드/삭제, 등록 버튼이 포함된 게시글 작성 UI를 구현했습니다.
- 본문 툴바에 굵게, 기울임, 밑줄, 본문, 좌측 정렬, 가운데 정렬, 목록, 번호 목록, 이미지 추가 기능을 연결했습니다.
- 제목 글자 수 제한(30자)과 본문 글자 수 제한(공백 포함 680자)을 반영했습니다.
- 태블릿/모바일 반응형 스타일을 적용해 제목 크기, 버튼 크기, 툴바 아이콘 크기를 조정했습니다.
- 컨벤션에 맞게 `constants`, `types`, `utils`, `hooks`, `stories`, `test` 파일로 분리했습니다.

### 🧪 테스트 방법 (How to Test)
1. 로컬 환경에서 `npm run dev` 또는 `npm run storybook`을 실행합니다.
2. `/sosotalk/write` 페이지 또는 Storybook의 `SosoTalk/Write/SosoTalkPostEditor` 스토리로 이동합니다.
3. 제목 입력이 30자를 초과하지 않는지 확인합니다.
4. 본문 에디터에서 텍스트 입력, 굵게/기울임/밑줄/정렬/목록 기능이 동작하는지 확인합니다.
5. 이미지 업로드 버튼으로 이미지를 1장 추가하고, 삭제 버튼으로 제거되는지 확인합니다.
6. 모바일/태블릿 너비에서 제목 크기, 등록 버튼 크기, 툴바 아이콘 크기가 반응형으로 변경되는지 확인합니다.
7. 아래 명령이 통과하는지 확인합니다.
   - `npm run type-check`
   - `npx jest src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.test.tsx --runInBand`

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                  |

### 🚨 기타 참고 사항 (Notes)
- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
  - 본문 글자 수 계산은 렌더 폭을 기준으로 추정하는 로직이 포함되어 있어, 실제 브라우저 QA에서 한 번 더 확인이 필요합니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**