### PR TITLE
[Feat]: 소소토크 게시글 상세 컴포넌트 구현

### DIFF
--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/index.ts
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/index.ts
@@ -1,0 +1,2 @@
+export { SosoTalkPostDetail } from './sosotalk-post-detail';
+export type { SosoTalkPostDetailProps } from './sosotalk-post-detail.types';

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail-actions.tsx
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail-actions.tsx
@@ -1,0 +1,87 @@
+import type { ComponentType, ReactNode } from 'react';
+
+import { Heart, MessageCircle, Share2 } from 'lucide-react';
+
+import type { SosoTalkPostActionsProps } from './sosotalk-post-detail.types';
+
+export function SosoTalkPostDetailActions({
+  contentCharacterCount,
+  likeCount = 0,
+  commentCount = 0,
+  onShareClick,
+}: SosoTalkPostActionsProps) {
+  return (
+    <div
+      className={`border-sosoeat-gray-300 flex items-center gap-4 border-t pt-4 ${
+        typeof contentCharacterCount === 'number' ? 'justify-between' : 'justify-end'
+      }`}
+    >
+      {typeof contentCharacterCount === 'number' ? (
+        <div className="text-sosoeat-gray-500 text-sm font-medium md:text-base">
+          {contentCharacterCount}자
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-4 md:gap-6">
+        <PostMetaItem icon={Heart} label="좋아요" value={likeCount} />
+        <PostMetaItem icon={MessageCircle} label="댓글" value={commentCount} />
+        <ActionIcon
+          className="text-sosoeat-gray-900 hover:text-sosoeat-orange-600 inline-flex"
+          label="공유"
+          onClick={onShareClick}
+        >
+          <Share2 className="h-6 w-6" />
+        </ActionIcon>
+      </div>
+    </div>
+  );
+}
+
+interface PostMetaItemProps {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  value: number;
+}
+
+function PostMetaItem({ icon: Icon, label, value }: PostMetaItemProps) {
+  return (
+    <span
+      className="text-sosoeat-gray-900 inline-flex items-center gap-2"
+      aria-label={`${label} ${value}개`}
+    >
+      <Icon className="h-6 w-6 shrink-0" />
+      <span>{value}</span>
+    </span>
+  );
+}
+
+interface ActionIconProps {
+  children: ReactNode;
+  className: string;
+  label: string;
+  onClick?: () => void;
+}
+
+function ActionIcon({ children, className, label, onClick }: ActionIconProps) {
+  const baseClassName =
+    'h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors';
+
+  if (!onClick) {
+    return (
+      <span className={`${baseClassName} ${className}`} aria-hidden="true">
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={`${baseClassName} ${className}`}
+      aria-label={label}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail-body.tsx
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail-body.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+
+import Image from 'next/image';
+
+import type { SosoTalkPostBodyProps } from './sosotalk-post-detail.types';
+
+interface SosoTalkPostDetailBodyProps extends SosoTalkPostBodyProps {
+  children?: ReactNode;
+}
+
+export function SosoTalkPostDetailBody({
+  title,
+  content,
+  imageUrl,
+  children,
+}: SosoTalkPostDetailBodyProps) {
+  const normalizedContent = content.trim();
+
+  return (
+    <section className="border-sosoeat-gray-300 mt-6 flex flex-col gap-5 border-t pt-5 md:mt-8 md:gap-6 md:pt-6">
+      <p className="text-sosoeat-gray-800 text-lg font-normal whitespace-pre-wrap">
+        {normalizedContent}
+      </p>
+
+      {imageUrl ? (
+        <div className="border-sosoeat-gray-300 bg-sosoeat-gray-100 relative aspect-[303/246] w-full max-w-[303px] overflow-hidden rounded-[18px] border md:max-w-[360px] lg:max-w-[420px] xl:max-w-[506px] xl:rounded-[24px]">
+          <Image
+            src={imageUrl}
+            alt={title}
+            fill
+            className="object-cover"
+            sizes="(max-width: 767px) 303px, (max-width: 1023px) 360px, (max-width: 1279px) 420px, 506px"
+            priority
+          />
+        </div>
+      ) : null}
+
+      {children}
+    </section>
+  );
+}

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail-header.tsx
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail-header.tsx
@@ -1,0 +1,90 @@
+import { CalendarDays, MoreHorizontal } from 'lucide-react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar/avatar';
+import { Badge } from '@/components/ui/badge/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown';
+
+import type { SosoTalkPostHeaderProps } from './sosotalk-post-detail.types';
+
+export function SosoTalkPostDetailHeader({
+  title,
+  authorName,
+  authorImageUrl,
+  categoryLabel,
+  statusLabel,
+  createdAt,
+  createdAtDateTime,
+  isAuthor = false,
+  onMoreClick,
+  onEditClick,
+  onDeleteClick,
+}: SosoTalkPostHeaderProps) {
+  return (
+    <header className="flex flex-col gap-4 md:gap-5">
+      <div className="flex items-start justify-between gap-6">
+        <div className="flex flex-1 flex-col gap-4 md:gap-5">
+          {(categoryLabel || statusLabel) && (
+            <div className="flex flex-wrap items-center gap-3">
+              {categoryLabel && (
+                <Badge
+                  variant="outline"
+                  className="border-sosoeat-orange-600 text-sosoeat-orange-600 h-7 rounded-full px-3 text-sm font-semibold"
+                >
+                  {categoryLabel}
+                </Badge>
+              )}
+              {statusLabel && (
+                <Badge className="bg-sosoeat-orange-600 hover:bg-sosoeat-orange-600 h-7 rounded-full px-3 text-sm font-semibold text-white">
+                  {statusLabel}
+                </Badge>
+              )}
+            </div>
+          )}
+
+          <h1 className="text-sosoeat-gray-900 text-2xl font-semibold md:text-3xl">{title}</h1>
+        </div>
+
+        {isAuthor ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="text-sosoeat-gray-500 hover:text-sosoeat-gray-700 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors"
+                aria-label="게시글 메뉴"
+                onClick={onMoreClick}
+              >
+                <MoreHorizontal className="h-7 w-7" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-[120px]">
+              <DropdownMenuItem onClick={onEditClick}>수정하기</DropdownMenuItem>
+              <DropdownMenuItem variant="destructive" onClick={onDeleteClick}>
+                삭제하기
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </div>
+
+      <div className="flex items-center justify-between gap-6">
+        <div className="flex items-center gap-3">
+          <Avatar size="lg" className="border-sosoeat-gray-300 h-8 w-8 border md:h-9 md:w-9">
+            <AvatarImage src={authorImageUrl} alt={authorName} />
+            <AvatarFallback>{authorName.slice(0, 1)}</AvatarFallback>
+          </Avatar>
+          <span className="text-sosoeat-gray-900 text-base font-semibold">{authorName}</span>
+        </div>
+
+        <div className="text-sosoeat-gray-700 flex shrink-0 items-center gap-2 text-sm font-medium md:text-base">
+          <CalendarDays className="h-4 w-4 shrink-0" />
+          <time dateTime={createdAtDateTime ?? undefined}>{createdAt}</time>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     layout: 'fullscreen',
   },
   decorators: [
-    Story => (
+    (Story) => (
       <div className="bg-sosoeat-gray-100 min-h-screen px-4 py-6 md:px-6 md:py-8">
         <div className="mx-auto w-full max-w-[1280px] md:max-w-[685px] lg:max-w-[1280px]">
           <Story />

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { SosoTalkPostDetail } from './sosotalk-post-detail';
+
+const meta = {
+  title: 'SosoTalk/SosoTalkPostDetail',
+  component: SosoTalkPostDetail,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="bg-sosoeat-gray-100 min-h-screen px-4 py-6 md:px-6 md:py-8">
+        <div className="mx-auto w-full max-w-[1280px] md:max-w-[685px] lg:max-w-[1280px]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SosoTalkPostDetail>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    categoryLabel: '함께 먹기',
+    statusLabel: '모집중',
+    title: '마포 고기집 같이 가실 분!',
+    content:
+      '저녁 7시에 마포 고기집에서 삼겹살 먹을 분 구합니다. 1인당 2만원 예상됩니다.\n\n편하게 식사하고 이야기 나누실 분이면 좋겠어요. 시간 맞는 분은 댓글로 남겨주세요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1552566626-52f8b828add9?auto=format&fit=crop&q=80&w=1200',
+    authorName: '김민수',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?auto=format&fit=crop&q=80&w=400',
+    likeCount: 24,
+    commentCount: 6,
+    createdAt: '6일 전',
+    createdAtDateTime: '2026-03-18',
+    contentCharacterCount: 75,
+    isAuthor: true,
+  },
+};
+
+export const WithoutImage: Story = {
+  args: {
+    categoryLabel: '소소토크',
+    title: '모임 추천 부탁드립니다 :D',
+    content:
+      '안녕하세요! 요즘 모임을 찾아보고 있는데, 어떤 모임이 좋을지 모르겠어요.\n\n저는 자연, 풍경 보는 걸 좋아하고 강아지에도 관심이 많습니다!\n혹시 해보신 모임 중에서 괜찮았던 모임이나 주의할 점 있으면 자유롭게 댓글 달아주세요.',
+    authorName: '럽윈즈',
+    likeCount: 8,
+    commentCount: 3,
+    createdAt: '2024.01.25',
+    createdAtDateTime: '2024-01-25',
+    contentCharacterCount: 111,
+  },
+};

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.tsx
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.tsx
@@ -1,25 +1,9 @@
 'use client';
 
-import Image from 'next/image';
-
-import {
-  CalendarDays,
-  Heart,
-  MessageCircle,
-  MoreHorizontal,
-  Share2,
-} from 'lucide-react';
-
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar/avatar';
-import { Badge } from '@/components/ui/badge/badge';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown';
-
 import type { SosoTalkPostDetailProps } from './sosotalk-post-detail.types';
+import { SosoTalkPostDetailActions } from './sosotalk-post-detail-actions';
+import { SosoTalkPostDetailBody } from './sosotalk-post-detail-body';
+import { SosoTalkPostDetailHeader } from './sosotalk-post-detail-header';
 
 export function SosoTalkPostDetail({
   title,
@@ -40,157 +24,31 @@ export function SosoTalkPostDetail({
   onDeleteClick,
   onShareClick,
 }: SosoTalkPostDetailProps) {
-  const normalizedContent = content.trim();
-
   return (
     <article className="border-sosoeat-gray-300 bg-card w-full overflow-hidden rounded-[32px] border shadow-[0_2px_14px_rgba(30,30,30,0.04)]">
       <div className="flex flex-col px-5 py-6 md:px-10 md:py-8 lg:px-12 lg:py-11">
-        <header className="flex flex-col gap-4 md:gap-5">
-          <div className="flex items-start justify-between gap-6">
-            <div className="flex flex-1 flex-col gap-4 md:gap-5">
-              {(categoryLabel || statusLabel) && (
-                <div className="flex flex-wrap items-center gap-3">
-                  {categoryLabel && (
-                    <Badge
-                      variant="outline"
-                      className="border-sosoeat-orange-600 text-sosoeat-orange-600 h-7 rounded-full px-3 text-sm font-semibold"
-                    >
-                      {categoryLabel}
-                    </Badge>
-                  )}
-                  {statusLabel && (
-                    <Badge className="bg-sosoeat-orange-600 text-white h-7 rounded-full px-3 text-sm font-semibold hover:bg-sosoeat-orange-600">
-                      {statusLabel}
-                    </Badge>
-                  )}
-                </div>
-              )}
-
-              <h1 className="text-sosoeat-gray-900 text-2xl font-semibold md:text-3xl">{title}</h1>
-            </div>
-
-            {isAuthor ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    className="text-sosoeat-gray-500 hover:text-sosoeat-gray-700 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors"
-                    aria-label="게시글 메뉴"
-                    onClick={onMoreClick}
-                  >
-                    <MoreHorizontal className="h-7 w-7" />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="min-w-[120px]">
-                  <DropdownMenuItem onClick={onEditClick}>수정하기</DropdownMenuItem>
-                  <DropdownMenuItem variant="destructive" onClick={onDeleteClick}>
-                    삭제하기
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : null}
-          </div>
-
-          <div className="flex items-center justify-between gap-6">
-            <div className="flex items-center gap-3">
-              <Avatar size="lg" className="border-sosoeat-gray-300 h-8 w-8 border md:h-9 md:w-9">
-                <AvatarImage src={authorImageUrl} alt={authorName} />
-                <AvatarFallback>{authorName.slice(0, 1)}</AvatarFallback>
-              </Avatar>
-              <span className="text-sosoeat-gray-900 text-base font-semibold">{authorName}</span>
-            </div>
-
-            <div className="text-sosoeat-gray-700 flex shrink-0 items-center gap-2 text-sm font-medium md:text-base">
-              <CalendarDays className="h-4 w-4 shrink-0" />
-              <time dateTime={createdAtDateTime ?? undefined}>{createdAt}</time>
-            </div>
-          </div>
-        </header>
-
-        <section className="border-sosoeat-gray-300 mt-6 flex flex-col gap-5 border-t pt-5 md:mt-8 md:gap-6 md:pt-6">
-          <p className="text-sosoeat-gray-800 text-lg font-normal whitespace-pre-wrap">
-            {normalizedContent}
-          </p>
-
-          {imageUrl ? (
-            <div className="border-sosoeat-gray-300 bg-sosoeat-gray-100 relative aspect-[303/246] w-full max-w-[303px] overflow-hidden rounded-[18px] border md:max-w-[360px] lg:max-w-[420px] xl:max-w-[506px] xl:rounded-[24px]">
-              <Image
-                src={imageUrl}
-                alt={title}
-                fill
-                className="object-cover"
-                sizes="(max-width: 767px) 303px, (max-width: 1023px) 360px, (max-width: 1279px) 420px, 506px"
-                priority
-              />
-            </div>
-          ) : null}
-
-          <div
-            className={`flex items-center gap-4 border-t border-sosoeat-gray-300 pt-4 ${
-              typeof contentCharacterCount === 'number' ? 'justify-between' : 'justify-end'
-            }`}
-          >
-            {typeof contentCharacterCount === 'number' ? (
-              <div className="text-sosoeat-gray-500 text-sm font-medium md:text-base">
-                {contentCharacterCount}자
-              </div>
-            ) : null}
-
-            <div className="flex items-center gap-4 md:gap-6">
-              <PostMetaItem icon={Heart} label="좋아요" value={likeCount} />
-              <PostMetaItem icon={MessageCircle} label="댓글" value={commentCount} />
-              <ActionIcon
-                className="text-sosoeat-gray-900 hover:text-sosoeat-orange-600 inline-flex"
-                label="공유"
-                onClick={onShareClick}
-              >
-                <Share2 className="h-6 w-6" />
-              </ActionIcon>
-            </div>
-          </div>
-        </section>
+        <SosoTalkPostDetailHeader
+          title={title}
+          authorName={authorName}
+          authorImageUrl={authorImageUrl}
+          categoryLabel={categoryLabel}
+          statusLabel={statusLabel}
+          createdAt={createdAt}
+          createdAtDateTime={createdAtDateTime}
+          isAuthor={isAuthor}
+          onMoreClick={onMoreClick}
+          onEditClick={onEditClick}
+          onDeleteClick={onDeleteClick}
+        />
+        <SosoTalkPostDetailBody title={title} content={content} imageUrl={imageUrl}>
+          <SosoTalkPostDetailActions
+            contentCharacterCount={contentCharacterCount}
+            likeCount={likeCount}
+            commentCount={commentCount}
+            onShareClick={onShareClick}
+          />
+        </SosoTalkPostDetailBody>
       </div>
     </article>
-  );
-}
-
-interface PostMetaItemProps {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  value: number;
-}
-
-function PostMetaItem({ icon: Icon, label, value }: PostMetaItemProps) {
-  return (
-    <span className="text-sosoeat-gray-900 inline-flex items-center gap-2" aria-label={`${label} ${value}개`}>
-      <Icon className="h-6 w-6 shrink-0" />
-      <span>{value}</span>
-    </span>
-  );
-}
-
-interface ActionIconProps {
-  children: React.ReactNode;
-  className: string;
-  label: string;
-  onClick?: () => void;
-}
-
-function ActionIcon({ children, className, label, onClick }: ActionIconProps) {
-  const baseClassName =
-    'h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors';
-
-  if (!onClick) {
-    return (
-      <span className={`${baseClassName} ${className}`} aria-hidden="true">
-        {children}
-      </span>
-    );
-  }
-
-  return (
-    <button type="button" className={`${baseClassName} ${className}`} aria-label={label} onClick={onClick}>
-      {children}
-    </button>
   );
 }

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.tsx
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import Image from 'next/image';
+
+import {
+  CalendarDays,
+  Heart,
+  MessageCircle,
+  MoreHorizontal,
+  Share2,
+} from 'lucide-react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar/avatar';
+import { Badge } from '@/components/ui/badge/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown';
+
+import type { SosoTalkPostDetailProps } from './sosotalk-post-detail.types';
+
+export function SosoTalkPostDetail({
+  title,
+  content,
+  contentCharacterCount,
+  imageUrl,
+  authorName,
+  authorImageUrl,
+  categoryLabel,
+  statusLabel,
+  likeCount = 0,
+  commentCount = 0,
+  createdAt,
+  createdAtDateTime,
+  isAuthor = false,
+  onMoreClick,
+  onEditClick,
+  onDeleteClick,
+  onShareClick,
+}: SosoTalkPostDetailProps) {
+  const normalizedContent = content.trim();
+
+  return (
+    <article className="border-sosoeat-gray-300 bg-card w-full overflow-hidden rounded-[32px] border shadow-[0_2px_14px_rgba(30,30,30,0.04)]">
+      <div className="flex flex-col px-5 py-6 md:px-10 md:py-8 lg:px-12 lg:py-11">
+        <header className="flex flex-col gap-4 md:gap-5">
+          <div className="flex items-start justify-between gap-6">
+            <div className="flex flex-1 flex-col gap-4 md:gap-5">
+              {(categoryLabel || statusLabel) && (
+                <div className="flex flex-wrap items-center gap-3">
+                  {categoryLabel && (
+                    <Badge
+                      variant="outline"
+                      className="border-sosoeat-orange-600 text-sosoeat-orange-600 h-7 rounded-full px-3 text-sm font-semibold"
+                    >
+                      {categoryLabel}
+                    </Badge>
+                  )}
+                  {statusLabel && (
+                    <Badge className="bg-sosoeat-orange-600 text-white h-7 rounded-full px-3 text-sm font-semibold hover:bg-sosoeat-orange-600">
+                      {statusLabel}
+                    </Badge>
+                  )}
+                </div>
+              )}
+
+              <h1 className="text-sosoeat-gray-900 text-2xl font-semibold md:text-3xl">{title}</h1>
+            </div>
+
+            {isAuthor ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-sosoeat-gray-500 hover:text-sosoeat-gray-700 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors"
+                    aria-label="게시글 메뉴"
+                    onClick={onMoreClick}
+                  >
+                    <MoreHorizontal className="h-7 w-7" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[120px]">
+                  <DropdownMenuItem onClick={onEditClick}>수정하기</DropdownMenuItem>
+                  <DropdownMenuItem variant="destructive" onClick={onDeleteClick}>
+                    삭제하기
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
+          </div>
+
+          <div className="flex items-center justify-between gap-6">
+            <div className="flex items-center gap-3">
+              <Avatar size="lg" className="border-sosoeat-gray-300 h-8 w-8 border md:h-9 md:w-9">
+                <AvatarImage src={authorImageUrl} alt={authorName} />
+                <AvatarFallback>{authorName.slice(0, 1)}</AvatarFallback>
+              </Avatar>
+              <span className="text-sosoeat-gray-900 text-base font-semibold">{authorName}</span>
+            </div>
+
+            <div className="text-sosoeat-gray-700 flex shrink-0 items-center gap-2 text-sm font-medium md:text-base">
+              <CalendarDays className="h-4 w-4 shrink-0" />
+              <time dateTime={createdAtDateTime ?? undefined}>{createdAt}</time>
+            </div>
+          </div>
+        </header>
+
+        <section className="border-sosoeat-gray-300 mt-6 flex flex-col gap-5 border-t pt-5 md:mt-8 md:gap-6 md:pt-6">
+          <p className="text-sosoeat-gray-800 text-lg font-normal whitespace-pre-wrap">
+            {normalizedContent}
+          </p>
+
+          {imageUrl ? (
+            <div className="border-sosoeat-gray-300 bg-sosoeat-gray-100 relative aspect-[303/246] w-full max-w-[303px] overflow-hidden rounded-[18px] border md:max-w-[360px] lg:max-w-[420px] xl:max-w-[506px] xl:rounded-[24px]">
+              <Image
+                src={imageUrl}
+                alt={title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 767px) 303px, (max-width: 1023px) 360px, (max-width: 1279px) 420px, 506px"
+                priority
+              />
+            </div>
+          ) : null}
+
+          <div
+            className={`flex items-center gap-4 border-t border-sosoeat-gray-300 pt-4 ${
+              typeof contentCharacterCount === 'number' ? 'justify-between' : 'justify-end'
+            }`}
+          >
+            {typeof contentCharacterCount === 'number' ? (
+              <div className="text-sosoeat-gray-500 text-sm font-medium md:text-base">
+                {contentCharacterCount}자
+              </div>
+            ) : null}
+
+            <div className="flex items-center gap-4 md:gap-6">
+              <PostMetaItem icon={Heart} label="좋아요" value={likeCount} />
+              <PostMetaItem icon={MessageCircle} label="댓글" value={commentCount} />
+              <ActionIcon
+                className="text-sosoeat-gray-900 hover:text-sosoeat-orange-600 inline-flex"
+                label="공유"
+                onClick={onShareClick}
+              >
+                <Share2 className="h-6 w-6" />
+              </ActionIcon>
+            </div>
+          </div>
+        </section>
+      </div>
+    </article>
+  );
+}
+
+interface PostMetaItemProps {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: number;
+}
+
+function PostMetaItem({ icon: Icon, label, value }: PostMetaItemProps) {
+  return (
+    <span className="text-sosoeat-gray-900 inline-flex items-center gap-2" aria-label={`${label} ${value}개`}>
+      <Icon className="h-6 w-6 shrink-0" />
+      <span>{value}</span>
+    </span>
+  );
+}
+
+interface ActionIconProps {
+  children: React.ReactNode;
+  className: string;
+  label: string;
+  onClick?: () => void;
+}
+
+function ActionIcon({ children, className, label, onClick }: ActionIconProps) {
+  const baseClassName =
+    'h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors';
+
+  if (!onClick) {
+    return (
+      <span className={`${baseClassName} ${className}`} aria-hidden="true">
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <button type="button" className={`${baseClassName} ${className}`} aria-label={label} onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.types.ts
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.types.ts
@@ -17,3 +17,30 @@ export interface SosoTalkPostDetailProps {
   onDeleteClick?: () => void;
   onShareClick?: () => void;
 }
+
+export interface SosoTalkPostHeaderProps {
+  title: string;
+  authorName: string;
+  authorImageUrl?: string;
+  categoryLabel?: string;
+  statusLabel?: string;
+  createdAt: string;
+  createdAtDateTime?: string;
+  isAuthor?: boolean;
+  onMoreClick?: () => void;
+  onEditClick?: () => void;
+  onDeleteClick?: () => void;
+}
+
+export interface SosoTalkPostBodyProps {
+  title: string;
+  content: string;
+  imageUrl?: string;
+}
+
+export interface SosoTalkPostActionsProps {
+  contentCharacterCount?: number;
+  likeCount?: number;
+  commentCount?: number;
+  onShareClick?: () => void;
+}

--- a/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.types.ts
+++ b/src/app/sosotalk/[postId]/_components/sosotalk-post-detail/sosotalk-post-detail.types.ts
@@ -1,0 +1,19 @@
+export interface SosoTalkPostDetailProps {
+  title: string;
+  content: string;
+  contentCharacterCount?: number;
+  imageUrl?: string;
+  authorName: string;
+  authorImageUrl?: string;
+  categoryLabel?: string;
+  statusLabel?: string;
+  likeCount?: number;
+  commentCount?: number;
+  createdAt: string;
+  createdAtDateTime?: string;
+  isAuthor?: boolean;
+  onMoreClick?: () => void;
+  onEditClick?: () => void;
+  onDeleteClick?: () => void;
+  onShareClick?: () => void;
+}

--- a/src/app/sosotalk/[postId]/page.tsx
+++ b/src/app/sosotalk/[postId]/page.tsx
@@ -1,0 +1,29 @@
+import { SosoTalkPostDetail } from './_components/sosotalk-post-detail';
+
+const mockPost = {
+  categoryLabel: '함께 먹기',
+  statusLabel: '모집중',
+  title: '마포 고기집 같이 가실 분!',
+  content:
+    '저녁 7시에 마포 고기집에서 삼겹살 먹을 분 구합니다. 1인당 2만원 예상됩니다.\n\n편하게 식사하고 이야기 나누실 분이면 좋겠어요. 시간 맞는 분은 댓글로 남겨주세요.',
+  imageUrl:
+    'https://images.unsplash.com/photo-1552566626-52f8b828add9?auto=format&fit=crop&q=80&w=1200',
+  authorName: '김민수',
+  authorImageUrl:
+    'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?auto=format&fit=crop&q=80&w=400',
+  likeCount: 24,
+  commentCount: 6,
+  createdAt: '6일 전',
+  createdAtDateTime: '2026-03-18',
+  contentCharacterCount: 75,
+};
+
+export default function SosoTalkPostDetailPage() {
+  return (
+    <main className="bg-sosoeat-gray-100 min-h-screen px-4 py-6 md:px-6 md:py-8">
+      <div className="mx-auto w-full max-w-[1280px] md:max-w-[685px] lg:max-w-[1280px]">
+        <SosoTalkPostDetail {...mockPost} />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## PR 제목: [Feat]: 소소토크 게시글 상세 컴포넌트 구현

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- `#55` 소소토크 게시글 상세 페이지 전용 컴포넌트 `SosoTalkPostDetail`를 구현했습니다.
- 게시글 제목, 본문, 작성자 정보, 작성일, 좋아요/댓글 수, 대표 이미지가 표시되도록 상세 UI를 구성했습니다.
- 작성자 여부에 따라 우측 상단 `...` 버튼이 노출되며, 드롭다운으로 `수정하기 / 삭제하기` 메뉴가 보이도록 처리했습니다.
- 글자 수는 공백 포함 기준으로 외부에서 `contentCharacterCount`를 주입받는 구조로 분리했습니다.
- `createdAt` 표시값과 `createdAtDateTime` 값을 분리해 날짜 데이터를 좀 더 안전하게 사용할 수 있도록 했습니다.
- Storybook 스토리와 상세 페이지 샘플 라우트를 추가해 독립적으로 확인할 수 있도록 구성했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 `npm run storybook` 또는 `npm run dev`를 실행합니다.
2. Storybook에서 `SosoTalk/SosoTalkPostDetail` 스토리를 확인하거나 `/sosotalk/[postId]` 상세 페이지 화면을 확인합니다.
3. 게시글 제목, 작성자 정보, 작성일, 본문, 대표 이미지, 하단 메타 영역이 정상적으로 표시되는지 확인합니다.
4. `isAuthor`가 `true`인 경우 우측 상단 `...` 버튼이 보이고, 클릭 시 `수정하기 / 삭제하기` 메뉴가 나타나는지 확인합니다.
5. 모바일 / 태블릿 / PC 화면에서 레이아웃이 어색하지 않은지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

- 반응형과 게시글의 특성상 사진을 하단으로 내리는게 유리할 것 같아서 사진을 하단으로 내렸습니다.
- 공유하기와 댓글 좋아요 버튼의 경우 반응형에서 좌우 공간이 모자를 수 있기에 하단으로 내렸습니다.


| 변경 전 (Before) | 변경 후 (After) |
| <img width="909" height="401" alt="image" src="https://github.com/user-attachments/assets/30b5dbb4-e6fd-43ff-a806-612006f32db6" /> |<img width="1293" height="894" alt="image" src="https://github.com/user-attachments/assets/273bb323-a655-4bd8-a471-e52acb54f0b6" /> |
|                  |                 |



### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- 작성자 전용 드롭다운 노출 조건(`isAuthor`)과 상세 페이지 반응형 레이아웃을 중점적으로 확인 부탁드립니다.
- [x] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
- 수정 / 삭제 / 공유 기능은 UI와 handler props까지만 준비되어 있으며, 실제 API 연동은 추후 진행 예정입니다.
