### PR TITLE
[Feat] comment-textarea 컴포넌트 추가

### DIFF
--- a/src/components/common/comment-textarea/comment-textarea.stories.tsx
+++ b/src/components/common/comment-textarea/comment-textarea.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { CommentTextarea } from './comment-textarea';
+
+const meta: Meta<typeof CommentTextarea> = {
+  title: 'COMPONENTS/common/comment-textarea',
+  component: CommentTextarea,
+  tags: ['autodocs'],
+  argTypes: {
+    onSubmit: { action: 'submitted' },
+    placeholder: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CommentTextarea>;
+
+// 기본 상태
+export const Default: Story = {
+  args: {
+    placeholder: '댓글을 입력하세요.',
+  },
+};
+
+// 비활성화 상태
+export const Disabled: Story = {
+  args: {
+    placeholder: '댓글을 남길 수 없습니다.',
+    disabled: true,
+  },
+};

--- a/src/components/common/comment-textarea/comment-textarea.tsx
+++ b/src/components/common/comment-textarea/comment-textarea.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { SendHorizontal } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface AutoResizeInputProps extends Omit<React.ComponentProps<'textarea'>, 'onSubmit'> {
+  onSubmit?: (value: string) => void;
+}
+
+// 높이 조절
+function useAutoResize(value: string) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [value]);
+
+  return textareaRef;
+}
+
+export function CommentTextarea({ onSubmit, ...props }: AutoResizeInputProps) {
+  const [value, setValue] = useState('');
+  const textareaRef = useAutoResize(value);
+
+  const handleSubmit = () => {
+    if (!value.trim()) return;
+    onSubmit?.(value);
+    setValue('');
+  };
+
+  // Shift + Enter는 줄바꿈, 그냥 Enter는 전송
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'bg-sosoeat-gray-300 focus-within:border-sosoeat-orange-500 flex items-end rounded-4xl p-2 ring-0',
+        'lg:w-293',
+        'max-lg:w-148.25',
+        'max-md:w-69'
+      )}
+    >
+      <textarea
+        ref={textareaRef}
+        rows={1}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className="flex-1 resize-none overflow-hidden bg-transparent px-2 py-1 outline-none"
+        {...props}
+      />
+      <button
+        onClick={handleSubmit}
+        className={cn(
+          'border-sosoeat-orange-500 flex rotate-320 items-center justify-center rounded-full bg-white p-1 text-orange-500 ring-0',
+          'max-lg:h-8 max-lg:w-8 lg:h-9 lg:w-9'
+        )}
+      >
+        <SendHorizontal className="max-lg:size-5 lg:size-7" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/common/comment-textarea/index.ts
+++ b/src/components/common/comment-textarea/index.ts
@@ -1,0 +1,1 @@
+export { CommentTextarea } from './comment-textarea';


### PR DESCRIPTION
## [Feat] comment-textarea 컴포넌트 추가

### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 댓글 작성 시 텍스트 양에 따라 높이가 자동으로 조절되는 컴포넌트인 CommentTextarea를 구현했습니다.
- 현재는 실제 서버 통신 없이 클라이언트 동작을 검증하기 위한 목업(Mock-up) 버전으로 구현되었습니다.

**자동 높이 조절 로직 적용** 
- useAutoResize 커스텀 훅을 구현하여 textarea의 scrollHeight에 따라 높이가 유연하게 변하도록 처리했습니다.

**키보드 UX 개선**
- Enter: 메시지 전송 (onSubmit 호출)
- Shift + Enter: 줄바꿈 허용
- 한글 입력 시 중복 전송 방지를 위해 isComposing 상태를 체크하도록 구현했습니다.

**반응형 디자인 적용** 
- 화면 크기(lg, max-lg, max-md)에 따른 가변 너비와 버튼/아이콘 크기를 대응했습니다.

### 📸 스크린샷 또는 영상 (Optional)

<img width="612" height="68" alt="image" src="https://github.com/user-attachments/assets/1a3a37b4-accc-40e0-918d-4344843d7ba9" />

### 🚨 기타 참고 사항 (Notes)

- [ ] **백엔드 연동 관련**  : 현재는 UI 및 클라이언트 로직만 구현된 상태이며, 실제 API 연동 및 서버 전송 기능은 포함되어 있지 않습니다. (전송 시 입력창 초기화 로직까지만 구현됨)
