### PR TITLE
[Feat]: 소소토크 댓글 섹션 및 공통 댓글 컴포넌트 추가

### DIFF
--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.stories.tsx
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { SosoTalkBanner } from './sosotalk-banner';
 
 const meta = {
-  title: 'SosoTalk/SosoTalkBanner',
+  title: 'pages/sosotalk/sosotalk-banner',
   component: SosoTalkBanner,
   tags: ['autodocs'],
   parameters: {

--- a/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
+++ b/src/app/sosotalk/_components/sosotalk-banner/sosotalk-banner.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image';
+
 import { cn } from '@/lib/utils';
+
 import { SosoTalkBannerProps } from './sosotalk-banner.types';
 
 export const SosoTalkBanner = ({
@@ -15,7 +17,13 @@ export const SosoTalkBanner = ({
           className
         )}
       >
-        <Image src={imageUrl} alt={alt} className="h-full w-full object-cover" />
+        <Image
+          src={imageUrl}
+          alt={alt}
+          fill
+          className="object-cover"
+          sizes="(max-width: 767px) 100vw, (max-width: 1279px) 100vw, 1280px"
+        />
         <div className="absolute inset-0 bg-black/50" />
       </div>
     </section>

--- a/src/app/sosotalk/_components/sosotalk-card/sosotalk-card.stories.tsx
+++ b/src/app/sosotalk/_components/sosotalk-card/sosotalk-card.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { SosoTalkCard } from './sosotalk-card';
 
 const meta = {
-  title: 'SosoTalk/SosoTalkCard',
+  title: 'pages/sosotalk/sosotalk-card',
   component: SosoTalkCard,
   tags: ['autodocs'],
 } satisfies Meta<typeof SosoTalkCard>;

--- a/src/app/sosotalk/_components/sosotalk-comment-section/index.ts
+++ b/src/app/sosotalk/_components/sosotalk-comment-section/index.ts
@@ -1,0 +1,2 @@
+export { SosoTalkCommentSection } from './sosotalk-comment-section';
+export type { SosoTalkCommentSectionProps } from './sosotalk-comment-section.types';

--- a/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.stories.tsx
+++ b/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.stories.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { type ComponentProps, useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { SosoTalkCommentSection } from './sosotalk-comment-section';
+
+const comments = [
+  {
+    id: '1',
+    authorName: '마민준',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop',
+    createdAt: '03월 12일 14:32',
+    relativeTime: '5분 전',
+    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
+  },
+  {
+    id: '2',
+    authorName: '마민준',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop',
+    createdAt: '03월 12일 14:38',
+    relativeTime: '방금 전',
+    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
+    isAuthorComment: true,
+  },
+  {
+    id: '3',
+    authorName: '마민준',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop',
+    createdAt: '03월 12일 14:40',
+    relativeTime: '1분 전',
+    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
+  },
+];
+
+const meta = {
+  title: 'SosoTalk/SosoTalkCommentSection',
+  component: SosoTalkCommentSection,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="bg-sosoeat-gray-100 min-h-screen w-full px-4 py-8 md:px-8 md:py-10">
+        <div className="mx-auto w-full max-w-[1280px]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  args: {
+    comments,
+    commentCount: 3,
+    inputPlaceholder: '댓글을 입력하세요.',
+    currentUserName: '마민준',
+    currentUserImageUrl:
+      'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop',
+  },
+} satisfies Meta<typeof SosoTalkCommentSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function InteractiveSection(args: ComponentProps<typeof SosoTalkCommentSection>) {
+  const [value, setValue] = useState(
+    '글자가 늘어난다면 아래로 현재 입력 박스와 같이 확장됩니다. 나는 이 이야기를 매우 좋아한다.??'
+  );
+
+  return (
+    <SosoTalkCommentSection
+      {...args}
+      inputValue={value}
+      onChangeInput={setValue}
+      onSubmitComment={() => undefined}
+    />
+  );
+}
+
+export const Default: Story = {
+  render: args => <InteractiveSection {...args} />,
+};

--- a/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.stories.tsx
+++ b/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.stories.tsx
@@ -38,14 +38,14 @@ const comments = [
 ];
 
 const meta = {
-  title: 'SosoTalk/SosoTalkCommentSection',
+  title: 'pages/sosotalk/sosotalk-comment-section',
   component: SosoTalkCommentSection,
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',
   },
   decorators: [
-    Story => (
+    (Story) => (
       <div className="bg-sosoeat-gray-100 min-h-screen w-full px-4 py-8 md:px-8 md:py-10">
         <div className="mx-auto w-full max-w-[1280px]">
           <Story />
@@ -83,5 +83,5 @@ function InteractiveSection(args: ComponentProps<typeof SosoTalkCommentSection>)
 }
 
 export const Default: Story = {
-  render: args => <InteractiveSection {...args} />,
+  render: (args) => <InteractiveSection {...args} />,
 };

--- a/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.tsx
+++ b/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { MessageSquareText } from 'lucide-react';
+
+import { CommentInput } from '@/components/common/comment-input';
+import { CommentItem } from '@/components/common/comment-item';
+import { CountingBadge } from '@/components/common/counting-badge';
+import { cn } from '@/lib/utils';
+
+import { SosoTalkCommentSectionProps } from './sosotalk-comment-section.types';
+
+export function SosoTalkCommentSection({
+  comments,
+  commentCount,
+  inputValue,
+  inputPlaceholder,
+  onChangeInput,
+  onSubmitComment,
+  currentUserName,
+  currentUserImageUrl,
+  className,
+}: SosoTalkCommentSectionProps) {
+  const totalCommentCount = commentCount ?? comments.length;
+
+  return (
+    <section
+      className={cn(
+        'border-sosoeat-gray-400 mx-auto w-full max-w-[1280px] rounded-[24px] border bg-white px-4 pt-5 sm:px-6 sm:pt-6 md:px-8 md:pt-8',
+        className
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <MessageSquareText className="size-5 text-sosoeat-orange-600" />
+        <h2 className="text-lg font-semibold text-sosoeat-gray-900">댓글</h2>
+        <CountingBadge count={totalCommentCount} />
+      </div>
+
+      <div className="mt-6 space-y-2">
+        {comments.map(comment => (
+          <CommentItem
+            key={comment.id}
+            authorName={comment.authorName}
+            authorImageUrl={comment.authorImageUrl}
+            createdAt={comment.createdAt}
+            relativeTime={comment.relativeTime}
+            content={comment.content}
+            isAuthorComment={comment.isAuthorComment}
+          />
+        ))}
+      </div>
+
+      <div className="-mx-4 mt-4 rounded-b-[24px] bg-sosoeat-gray-100 px-4 py-6 sm:-mx-6 sm:px-6 sm:py-7 md:-mx-8 md:px-8 md:py-8">
+        <div className="mx-auto w-full">
+          <CommentInput
+            value={inputValue}
+            placeholder={inputPlaceholder}
+            onChange={onChangeInput}
+            onSubmit={onSubmitComment}
+            currentUserName={currentUserName}
+            currentUserImageUrl={currentUserImageUrl}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.types.ts
+++ b/src/app/sosotalk/_components/sosotalk-comment-section/sosotalk-comment-section.types.ts
@@ -1,0 +1,13 @@
+import type { CommentItemData } from '@/components/common/comment-item';
+
+export interface SosoTalkCommentSectionProps {
+  comments: CommentItemData[];
+  commentCount?: number;
+  inputValue?: string;
+  inputPlaceholder?: string;
+  onChangeInput?: (value: string) => void;
+  onSubmitComment?: () => void;
+  currentUserName?: string;
+  currentUserImageUrl?: string;
+  className?: string;
+}

--- a/src/components/common/comment-input/comment-input.stories.tsx
+++ b/src/components/common/comment-input/comment-input.stories.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { type ComponentProps, useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { CommentInput } from './comment-input';
+
+const meta = {
+  title: 'components/common/comment-input',
+  component: CommentInput,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className="w-full max-w-[760px] bg-white p-3 sm:p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    placeholder: '댓글을 입력하세요.',
+    currentUserName: '마민준',
+    currentUserImageUrl:
+      'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop',
+  },
+} satisfies Meta<typeof CommentInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function InteractiveCommentInput(args: ComponentProps<typeof CommentInput>) {
+  const [value, setValue] = useState(
+    '글자가 늘어난다면 아래로 현재 입력 박스와 같이 확장됩니다.'
+  );
+
+  return <CommentInput {...args} value={value} onChange={setValue} onSubmit={() => undefined} />;
+}
+
+export const Default: Story = {
+  render: args => <InteractiveCommentInput {...args} />,
+};

--- a/src/components/common/comment-input/comment-input.tsx
+++ b/src/components/common/comment-input/comment-input.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { Send } from 'lucide-react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+import { CommentInputProps } from './comment-input.types';
+
+export function CommentInput({
+  value = '',
+  placeholder = '댓글을 입력하세요.',
+  onChange,
+  onSubmit,
+  disabled = false,
+  submitLabel = '댓글 전송',
+  currentUserName = '사용자',
+  currentUserImageUrl,
+  submitOnEnter = true,
+  className,
+}: CommentInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+
+    if (!textarea) {
+      return;
+    }
+
+    textarea.style.height = '0px';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [value]);
+
+  const isSubmitDisabled = disabled || value.trim().length === 0;
+
+  const handleSubmit = () => {
+    if (isSubmitDisabled) {
+      return;
+    }
+
+    onSubmit?.();
+  };
+
+  return (
+    <div className={cn('flex items-center gap-3 sm:gap-4', className)}>
+      <Avatar size="default" className="h-[54px] w-[54px] shrink-0">
+        <AvatarImage src={currentUserImageUrl} alt={currentUserName} />
+        <AvatarFallback className="text-sm font-semibold">
+          {currentUserName.slice(0, 1)}
+        </AvatarFallback>
+      </Avatar>
+
+      <div className="bg-sosoeat-gray-300 flex min-h-[46px] min-w-0 flex-1 items-end gap-3 rounded-[24px] py-2 pr-[14px] pl-5 sm:pr-[14px] sm:pl-6">
+        <Textarea
+          ref={textareaRef}
+          value={value}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+          onChange={event => onChange?.(event.target.value)}
+          onKeyDown={event => {
+            if (!submitOnEnter || event.key !== 'Enter' || event.shiftKey) {
+              return;
+            }
+
+            event.preventDefault();
+            handleSubmit();
+          }}
+          className="text-sosoeat-gray-900 placeholder:text-sosoeat-gray-700 max-h-40 min-h-[23px] flex-1 resize-none border-0 bg-transparent px-0 pt-0 pb-1.5 text-base font-normal shadow-none focus-visible:ring-0 md:text-base"
+        />
+
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label={submitLabel}
+          disabled={isSubmitDisabled}
+          onClick={handleSubmit}
+          className="text-sosoeat-gray-700 hover:text-sosoeat-gray-800 disabled:text-sosoeat-gray-500 mb-0.5 size-9 shrink-0 self-end rounded-none bg-transparent p-0 shadow-none hover:bg-transparent disabled:bg-transparent"
+        >
+          <Send className="mt-0.5 size-6 fill-current" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/comment-input/comment-input.tsx
+++ b/src/components/common/comment-input/comment-input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 import { Send } from 'lucide-react';
 
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
-import { CommentInputProps } from './comment-input.types';
+import type { CommentInputProps } from './comment-input.types';
 
 export function CommentInput({
   value = '',
@@ -25,7 +25,7 @@ export function CommentInput({
 }: CommentInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const textarea = textareaRef.current;
 
     if (!textarea) {
@@ -62,9 +62,14 @@ export function CommentInput({
           placeholder={placeholder}
           disabled={disabled}
           rows={1}
-          onChange={event => onChange?.(event.target.value)}
-          onKeyDown={event => {
-            if (!submitOnEnter || event.key !== 'Enter' || event.shiftKey) {
+          onChange={(event) => onChange?.(event.target.value)}
+          onKeyDown={(event) => {
+            if (
+              !submitOnEnter ||
+              event.key !== 'Enter' ||
+              event.shiftKey ||
+              event.nativeEvent.isComposing
+            ) {
               return;
             }
 

--- a/src/components/common/comment-input/comment-input.types.ts
+++ b/src/components/common/comment-input/comment-input.types.ts
@@ -1,0 +1,12 @@
+export interface CommentInputProps {
+  value?: string;
+  placeholder?: string;
+  onChange?: (value: string) => void;
+  onSubmit?: () => void;
+  disabled?: boolean;
+  submitLabel?: string;
+  currentUserName?: string;
+  currentUserImageUrl?: string;
+  submitOnEnter?: boolean;
+  className?: string;
+}

--- a/src/components/common/comment-input/index.ts
+++ b/src/components/common/comment-input/index.ts
@@ -1,0 +1,2 @@
+export { CommentInput } from './comment-input';
+export type { CommentInputProps } from './comment-input.types';

--- a/src/components/common/comment-item/comment-item.stories.tsx
+++ b/src/components/common/comment-item/comment-item.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { CommentItem } from './comment-item';
+
+const meta = {
+  title: 'components/common/comment-item',
+  component: CommentItem,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className="w-full max-w-[1280px] bg-white p-3 sm:p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    authorName: '마민준',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop',
+    createdAt: '03월 12일 14:32',
+    relativeTime: '5분 전',
+    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
+  },
+} satisfies Meta<typeof CommentItem>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AuthorComment: Story = {
+  args: {
+    isAuthorComment: true,
+  },
+};

--- a/src/components/common/comment-item/comment-item.tsx
+++ b/src/components/common/comment-item/comment-item.tsx
@@ -1,0 +1,48 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+
+import { CommentItemProps } from './comment-item.types';
+
+export function CommentItem({
+  authorName,
+  authorImageUrl,
+  createdAt,
+  relativeTime,
+  content,
+  isAuthorComment = false,
+  className,
+}: CommentItemProps) {
+  return (
+    <article
+      className={cn(
+        'flex items-start gap-3 rounded-[20px] px-4 py-4 sm:gap-4 sm:px-5 sm:py-5',
+        isAuthorComment && 'bg-sosoeat-orange-100/70',
+        className
+      )}
+    >
+      <Avatar size="default" className="h-[54px] w-[54px] shrink-0">
+        <AvatarImage src={authorImageUrl} alt={authorName} />
+        <AvatarFallback className="text-sm font-semibold">{authorName.slice(0, 1)}</AvatarFallback>
+      </Avatar>
+
+      <div className="min-w-0 flex-1 pt-1">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="text-base leading-5 font-bold text-sosoeat-gray-900">{authorName}</span>
+          <div className="flex items-center gap-1 text-xs leading-4 font-semibold text-sosoeat-gray-500">
+            <time>{createdAt}</time>
+            {relativeTime ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>{relativeTime}</span>
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        <p className="whitespace-pre-wrap break-words text-base leading-6 font-normal text-sosoeat-gray-900">
+          {content}
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/src/components/common/comment-item/comment-item.types.ts
+++ b/src/components/common/comment-item/comment-item.types.ts
@@ -1,0 +1,13 @@
+export interface CommentItemData {
+  id: string;
+  authorName: string;
+  authorImageUrl?: string;
+  createdAt: string;
+  relativeTime?: string;
+  content: string;
+  isAuthorComment?: boolean;
+}
+
+export interface CommentItemProps extends Omit<CommentItemData, 'id'> {
+  className?: string;
+}

--- a/src/components/common/comment-item/index.ts
+++ b/src/components/common/comment-item/index.ts
@@ -1,0 +1,2 @@
+export { CommentItem } from './comment-item';
+export type { CommentItemData, CommentItemProps } from './comment-item.types';

--- a/src/components/ui/textarea/textarea.tsx
+++ b/src/components/ui/textarea/textarea.tsx
@@ -2,17 +2,22 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
-  return (
-    <textarea
-      data-slot="textarea"
-      className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm',
-        className
-      )}
-      {...props}
-    />
-  );
-}
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        data-slot="textarea"
+        className={cn(
+          'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Textarea.displayName = 'Textarea';
 
 export { Textarea };


### PR DESCRIPTION
## PR 제목
[Feat]: 소소토크 댓글 섹션 및 공통 댓글 컴포넌트 추가

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 이슈 `#64` 기준으로 소소토크 상세 페이지에서 사용할 댓글 섹션 UI를 구현했습니다.
- 재사용 가능한 공통 컴포넌트 `CommentItem`, `CommentInput`을 추가했습니다.
- 소소토크 전용 `SosoTalkCommentSection`을 추가해 댓글 목록, 댓글 수, 입력창 레이아웃을 구성했습니다.
- 댓글 작성자 프로필, 작성자명, 작성 시각, 댓글 내용이 표시되도록 구현했습니다.
- 게시물 작성자가 남긴 댓글은 `isAuthorComment` 상태로 구분해 강조 배경이 적용되도록 했습니다.
- 댓글 입력창은 자동 높이 확장, `Enter` 전송, `Shift + Enter` 줄바꿈이 가능하도록 구현했습니다.
- Storybook에서 `CommentItem`, `CommentInput`, `SosoTalkCommentSection`을 각각 확인할 수 있도록 스토리를 추가했습니다.
- 자동 높이 조절을 위해 공통 `Textarea`가 `ref`를 받을 수 있도록 수정했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬에서 `npm run storybook`을 실행합니다.
2. `components/common/comment-item`, `components/common/comment-input`, `SosoTalk/SosoTalkCommentSection` 스토리로 이동합니다.
3. 댓글 아이템에 작성자명, 시간, 본문이 정상적으로 표시되는지 확인합니다.
4. `SosoTalkCommentSection` 스토리에서 게시물 작성자 댓글만 연한 오렌지 배경으로 표시되는지 확인합니다.
5. 입력창에 텍스트를 입력했을 때 한 줄에서는 고정 높이처럼 보이고, 내용이 길어지면 아래로 자연스럽게 확장되는지 확인합니다.
6. 입력창에서 `Enter` 입력 시 전송 동작이 실행되고, `Shift + Enter` 입력 시 줄바꿈이 되는지 확인합니다.
7. 브라우저 너비를 줄이거나 늘려서 모바일/PC 환경 모두에서 레이아웃이 자연스럽게 반응하는지 확인합니다.
8. `npm run type-check`가 통과하는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| <img width="1083" height="844" alt="image" src="https://github.com/user-attachments/assets/2a322e79-6a74-4333-a417-b17dcb984259" /> |<img width="1298" height="543" alt="image" src="https://github.com/user-attachments/assets/dd5796d4-eaeb-482a-a759-f737cabf145d" />|
|                  | 댓글 섹션 / 댓글 입력창 / 반응형 스토리북 화면 첨부 |

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
