### PR TITLE
[Feat]: meetings 고정 `MeetingMakeButton` UI 구현 및 컴포넌트 구조 정리

### DIFF
--- a/src/app/meetings/_components/meeting-make-button.tsx/index.ts
+++ b/src/app/meetings/_components/meeting-make-button.tsx/index.ts
@@ -1,0 +1,2 @@
+export { MeetingMakeButton } from './meeting-make-button';
+export type { MeetingMakeButtonProps } from './meeting-make-button.types';

--- a/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.stories.tsx
+++ b/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { MeetingMakeButton } from './meeting-make-button';
+
+const meta = {
+  title: 'app/meetings/meeting-make-button',
+  component: MeetingMakeButton,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof MeetingMakeButton>;
+
+export default meta;
+
+export const Default: StoryObj<typeof MeetingMakeButton> = {
+  render: function MeetingMakeButtonStory() {
+    return <MeetingMakeButton />;
+  },
+};

--- a/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.tsx
+++ b/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Plus } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+/** 피그마 Create button — #FF6600 = sosoeat-orange-600 */
+const focusRingClass =
+  'shadow-none focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-0';
+
+const fixedMobile = 'fixed right-[28px] bottom-[23px] z-50';
+const fixedDesktop = 'fixed right-[22px] bottom-[22px] z-50 lg:right-[86px] lg:bottom-[56px]';
+
+export const MeetingMakeButton = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  if (isMobile) {
+    return (
+      <Button
+        type="button"
+        variant="default"
+        className={cn(
+          'bg-sosoeat-orange-600 size-16 shrink-0 rounded-[24px] border-0 p-0',
+          'hover:bg-sosoeat-orange-600/90 active:bg-sosoeat-orange-700',
+          'flex items-center justify-center [&_svg]:text-white',
+          focusRingClass,
+          fixedMobile
+        )}
+        aria-label="모임 만들기"
+      >
+        <Plus className="size-4 text-white" strokeWidth={2} aria-hidden />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="default"
+      className={cn(
+        'box-border h-16 w-[188px] shrink-0 rounded-[24px] border-0',
+        'bg-sosoeat-orange-600 hover:bg-sosoeat-orange-600/90 active:bg-sosoeat-orange-700 px-7 py-4',
+        'flex flex-row items-center justify-center gap-0',
+        'text-white [&_svg]:text-white',
+        focusRingClass,
+        fixedDesktop
+      )}
+    >
+      <span className="flex h-8 w-[132px] flex-row items-center gap-1.5 pr-1">
+        <span className="flex size-8 shrink-0 items-center justify-center" aria-hidden>
+          <Plus className="size-4 text-white" strokeWidth={2} />
+        </span>
+        <span className="w-[90px] shrink-0 text-center text-xl leading-[30px] font-bold tracking-[-0.02em] text-white">
+          모임 만들기
+          {/* 차후 모임 만들기 모달 뜨도록 */}
+        </span>
+      </span>
+    </Button>
+  );
+};

--- a/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.tsx
+++ b/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.tsx
@@ -7,6 +7,8 @@ import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
+import type { MeetingMakeButtonProps } from './meeting-make-button.types';
+
 /** 피그마 Create button — #FF6600 = sosoeat-orange-600 */
 const focusRingClass =
   'shadow-none focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-0';
@@ -14,7 +16,12 @@ const focusRingClass =
 const fixedMobile = 'fixed right-[28px] bottom-[23px] z-50';
 const fixedDesktop = 'fixed right-[22px] bottom-[22px] z-50 lg:right-[86px] lg:bottom-[56px]';
 
-export const MeetingMakeButton = () => {
+export const MeetingMakeButton = ({
+  className,
+  onClick,
+  label = '모임 만들기',
+  mobileAriaLabel = '모임 만들기',
+}: MeetingMakeButtonProps) => {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -34,9 +41,11 @@ export const MeetingMakeButton = () => {
           'hover:bg-sosoeat-orange-600/90 active:bg-sosoeat-orange-700',
           'flex items-center justify-center [&_svg]:text-white',
           focusRingClass,
-          fixedMobile
+          fixedMobile,
+          className
         )}
-        aria-label="모임 만들기"
+        aria-label={mobileAriaLabel}
+        onClick={onClick}
       >
         <Plus className="size-4 text-white" strokeWidth={2} aria-hidden />
       </Button>
@@ -53,15 +62,17 @@ export const MeetingMakeButton = () => {
         'flex flex-row items-center justify-center gap-0',
         'text-white [&_svg]:text-white',
         focusRingClass,
-        fixedDesktop
+        fixedDesktop,
+        className
       )}
+      onClick={onClick}
     >
       <span className="flex h-8 w-[132px] flex-row items-center gap-1.5 pr-1">
         <span className="flex size-8 shrink-0 items-center justify-center" aria-hidden>
           <Plus className="size-4 text-white" strokeWidth={2} />
         </span>
         <span className="w-[90px] shrink-0 text-center text-xl leading-[30px] font-bold tracking-[-0.02em] text-white">
-          모임 만들기
+          {label}
           {/* 차후 모임 만들기 모달 뜨도록 */}
         </span>
       </span>

--- a/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.types.ts
+++ b/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.types.ts
@@ -1,0 +1,6 @@
+export interface MeetingMakeButtonProps {
+  className?: string;
+  onClick?: () => void;
+  label?: string;
+  mobileAriaLabel?: string;
+}


### PR DESCRIPTION
## PR 제목: [Feat]: meetings 고정 `MeetingMakeButton` UI 구현 및 컴포넌트 구조 정리

### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- meetings 영역의 `MeetingMakeButton`을 피그마 스펙에 맞는 고정 CTA UI로 구현했습니다.  
  - 데스크톱: 188x64, 오렌지 배경, 아이콘 + `모임 만들기` 라벨
  - 모바일: 아이콘 중심의 64x64 고정 버튼
- 반응형 분기를 위해 뷰포트 기준(`window.innerWidth < 768`) 상태를 구독하도록 정리했습니다.
- 컴포넌트 구조를 정리했습니다.
  - `meeting-make-button.types.ts` 추가 (`MeetingMakeButtonProps`)
  - `index.ts` 추가 (barrel export)
  - `onClick`, `label`, `mobileAriaLabel`, `className` props를 컴포넌트에 연결
- Storybook 파일 import도 타입 import 형태로 정리했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬에서 `npm run storybook` 또는 앱을 실행합니다.
2. `MeetingMakeButton`이 렌더되는 화면으로 이동합니다.
3. 브라우저 폭을 768px 이상/미만으로 변경합니다.
4. 아래를 확인합니다.
   - 768px 이상: 텍스트 포함(모임 만들기) 고정 버튼 노출
   - 768px 미만: 아이콘-only 고정 버튼 노출
   - 버튼 클릭 시 전달한 `onClick` 핸들러가 실행됨
   - 모바일 버튼에 `aria-label="모임 만들기"`가 적용됨
5. 정적 검증:
   - `npm run type-check` 통과 확인

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
| (텍스트/레이아웃 미완성 상태) | (피그마 스펙 반영된 고정 CTA 버튼) |

### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**  
  - 고정 위치 오프셋(`right/bottom`) 값이 실제 페이지 레이아웃(네비/패딩)과 충돌 없는지 확인 부탁드립니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**