### PR TITLE
Feat/#90 소소토크 메인 페이지 레이아웃 구현

### DIFF
--- a/src/app/sosotalk/_components/sosotalk-main-page/index.ts
+++ b/src/app/sosotalk/_components/sosotalk-main-page/index.ts
@@ -1,0 +1,1 @@
+export { SosoTalkMainPage } from './sosotalk-main-page';

--- a/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.stories.tsx
+++ b/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.stories.tsx
@@ -1,0 +1,39 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { useAuthStore } from '@/store/auth-store';
+
+import { SosoTalkMainPage } from './sosotalk-main-page';
+
+const meta = {
+  title: 'pages/sosotalk/sosotalk-main-page',
+  component: SosoTalkMainPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof SosoTalkMainPage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+type AuthSnapshot = Pick<ReturnType<typeof useAuthStore.getState>, 'user'>;
+
+const withAuthState =
+  (state: AuthSnapshot): Decorator =>
+  (Story) => {
+    useAuthStore.setState(state);
+    return <Story />;
+  };
+
+export const Default: Story = {
+  decorators: [
+    withAuthState({
+      user: {
+        id: '1',
+        name: '김민준',
+        profileImage: 'https://i.pravatar.cc/80?img=12',
+      },
+    }),
+  ],
+};

--- a/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useState } from 'react';
+
+import Link from 'next/link';
+
+import { Plus } from 'lucide-react';
+
+import { NavigationBar } from '@/components/common/navigation-bar';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+import { SosoTalkBanner } from '../sosotalk-banner';
+import { SosoTalkCard, type SosoTalkCardProps } from '../sosotalk-card';
+import {
+  SosoTalkFilterBar,
+  type SosoTalkSortValue,
+  type SosoTalkTabValue,
+} from '../sosotalk-filter-bar';
+
+interface SosoTalkMainPageProps {
+  className?: string;
+}
+
+interface SosoTalkMainPost extends SosoTalkCardProps {
+  id: number;
+  isPopular: boolean;
+}
+
+const SOSOTALK_BANNER_IMAGE =
+  'https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=1600&auto=format&fit=crop';
+
+const SOSOTALK_POSTS: SosoTalkMainPost[] = [
+  {
+    id: 1,
+    title: '혼밥하기 좋은 성수 식당 추천해요',
+    content:
+      '조용하게 한 끼 하기 좋은 곳 찾고 있었는데, 웨이팅 적고 음식도 깔끔했던 곳들 공유해요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?q=80&w=1200&auto=format&fit=crop',
+    authorName: '민지',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1494790108377-be9c29b29330?q=80&w=300&auto=format&fit=crop',
+    likeCount: 24,
+    commentCount: 8,
+    createdAt: '2026.03.24',
+    isPopular: true,
+  },
+  {
+    id: 2,
+    title: '직장인 점심 도시락 메뉴 같이 고민해요',
+    content:
+      '매일 비슷한 메뉴라 지겨워서요. 간단하게 준비하기 좋았던 도시락 메뉴 있으면 알려주세요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1547592180-85f173990554?q=80&w=1200&auto=format&fit=crop',
+    authorName: '도윤',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?q=80&w=300&auto=format&fit=crop',
+    likeCount: 11,
+    commentCount: 14,
+    createdAt: '2026.03.23',
+    isPopular: false,
+  },
+  {
+    id: 3,
+    title: '비 오는 날 생각나는 국물 요리 TALK',
+    content: '칼국수, 순두부, 쌀국수 중에서 오늘 같은 날 제일 당기는 메뉴가 뭔지 궁금해요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1544025162-d76694265947?q=80&w=1200&auto=format&fit=crop',
+    authorName: '서현',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?q=80&w=300&auto=format&fit=crop',
+    likeCount: 31,
+    commentCount: 19,
+    createdAt: '2026.03.22',
+    isPopular: true,
+  },
+  {
+    id: 4,
+    title: '야식으로 먹기 좋은 배달 메뉴 추천',
+    content: '너무 헤비하지 않으면서 만족감 있는 메뉴 찾고 있어요. 최근에 괜찮았던 조합 있나요?',
+    imageUrl:
+      'https://images.unsplash.com/photo-1513104890138-7c749659a591?q=80&w=1200&auto=format&fit=crop',
+    authorName: '지훈',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?q=80&w=300&auto=format&fit=crop',
+    likeCount: 17,
+    commentCount: 6,
+    createdAt: '2026.03.21',
+    isPopular: false,
+  },
+  {
+    id: 5,
+    title: '다이어트 중인데 맛있었던 샐러드집 있어요?',
+    content: '포만감 있고 재료 신선한 샐러드집 찾고 있어요. 배달 말고 매장 방문 기준도 좋아요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1512621776951-a57141f2eefd?q=80&w=1200&auto=format&fit=crop',
+    authorName: '하린',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1488426862026-3ee34a7d66df?q=80&w=300&auto=format&fit=crop',
+    likeCount: 28,
+    commentCount: 10,
+    createdAt: '2026.03.20',
+    isPopular: true,
+  },
+  {
+    id: 6,
+    title: '집들이 음식 메뉴 구성 같이 봐주세요',
+    content:
+      '파스타, 샐러드, 핑거푸드 정도 생각 중인데 너무 많거나 부족하지 않을지 의견 듣고 싶어요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1528605248644-14dd04022da1?q=80&w=1200&auto=format&fit=crop',
+    authorName: '예준',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1504593811423-6dd665756598?q=80&w=300&auto=format&fit=crop',
+    likeCount: 13,
+    commentCount: 12,
+    createdAt: '2026.03.19',
+    isPopular: false,
+  },
+  {
+    id: 7,
+    title: '퇴근 후 가볍게 먹기 좋은 메뉴 추천',
+    content:
+      '늦은 저녁이라 부담 없는 메뉴를 찾고 있어요. 간단하지만 만족감 있었던 메뉴 있으면 알려주세요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1515003197210-e0cd71810b5f?q=80&w=1200&auto=format&fit=crop',
+    authorName: '수아',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1544005313-94ddf0286df2?q=80&w=300&auto=format&fit=crop',
+    likeCount: 22,
+    commentCount: 9,
+    createdAt: '2026.03.18',
+    isPopular: true,
+  },
+  {
+    id: 8,
+    title: '우리 동네 브런치 맛집 추천받아요',
+    content:
+      '주말 오전에 가기 좋은 브런치 집 찾고 있어요. 분위기 좋고 오래 앉아 있기 좋은 곳이면 더 좋아요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1484723091739-30a097e8f929?q=80&w=1200&auto=format&fit=crop',
+    authorName: '태윤',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1504257432389-52343af06ae3?q=80&w=300&auto=format&fit=crop',
+    likeCount: 15,
+    commentCount: 7,
+    createdAt: '2026.03.17',
+    isPopular: false,
+  },
+  {
+    id: 9,
+    title: '봄 제철 음식 뭐부터 먹을지 고민 중',
+    content:
+      '냉이, 달래, 주꾸미처럼 봄 느낌 나는 메뉴 중에 제일 먼저 먹고 싶은 음식이 뭔지 궁금해요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1467003909585-2f8a72700288?q=80&w=1200&auto=format&fit=crop',
+    authorName: '유진',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1517841905240-472988babdf9?q=80&w=300&auto=format&fit=crop',
+    likeCount: 27,
+    commentCount: 13,
+    createdAt: '2026.03.16',
+    isPopular: true,
+  },
+  {
+    id: 10,
+    title: '간단한 집밥 반찬 추천해주세요',
+    content:
+      '평일 저녁에 빠르게 만들 수 있는 반찬이 필요해요. 자주 해 먹는 메뉴 있으면 참고하고 싶어요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1543332164-6e82f355badc?q=80&w=1200&auto=format&fit=crop',
+    authorName: '은호',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1504593811423-6dd665756598?q=80&w=300&auto=format&fit=crop',
+    likeCount: 18,
+    commentCount: 5,
+    createdAt: '2026.03.15',
+    isPopular: false,
+  },
+  {
+    id: 11,
+    title: '매운 음식 당길 때 어디까지 가능해요?',
+    content:
+      '엽떡, 마라탕, 불닭처럼 매운 음식 좋아하는데 다들 어느 정도 맵기까지 즐기는지 궁금해요.',
+    imageUrl:
+      'https://images.unsplash.com/photo-1512058564366-18510be2db19?q=80&w=1200&auto=format&fit=crop',
+    authorName: '현우',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?q=80&w=300&auto=format&fit=crop',
+    likeCount: 34,
+    commentCount: 18,
+    createdAt: '2026.03.14',
+    isPopular: true,
+  },
+  {
+    id: 12,
+    title: '재료 남았을 때 활용하기 좋은 요리',
+    content:
+      '냉장고에 조금씩 남은 재료를 정리하고 싶은데, 볶음밥 말고도 자주 해 먹는 메뉴가 있나요?',
+    imageUrl:
+      'https://images.unsplash.com/photo-1473093295043-cdd812d0e601?q=80&w=1200&auto=format&fit=crop',
+    authorName: '채원',
+    authorImageUrl:
+      'https://images.unsplash.com/photo-1502685104226-ee32379fefbe?q=80&w=300&auto=format&fit=crop',
+    likeCount: 12,
+    commentCount: 11,
+    createdAt: '2026.03.13',
+    isPopular: false,
+  },
+];
+
+const sortPosts = (posts: SosoTalkMainPost[], activeSort: SosoTalkSortValue) => {
+  const sortedPosts = [...posts];
+
+  if (activeSort === 'comments') {
+    return sortedPosts.sort((a, b) => b.commentCount - a.commentCount);
+  }
+
+  if (activeSort === 'likes') {
+    return sortedPosts.sort((a, b) => b.likeCount - a.likeCount);
+  }
+
+  return sortedPosts.sort((a, b) => b.id - a.id);
+};
+
+export const SosoTalkMainPage = ({ className }: SosoTalkMainPageProps) => {
+  const [activeTab, setActiveTab] = useState<SosoTalkTabValue>('all');
+  const [activeSort, setActiveSort] = useState<SosoTalkSortValue>('latest');
+
+  const posts =
+    activeTab === 'popular' ? SOSOTALK_POSTS.filter((post) => post.isPopular) : SOSOTALK_POSTS;
+  const filteredPosts = sortPosts(posts, activeSort);
+
+  return (
+    <div className={cn('bg-background min-h-screen w-full bg-[#f9f9f9] pb-24 md:pb-28', className)}>
+      <NavigationBar />
+
+      <main className="mx-auto flex w-full max-w-[1280px] flex-col px-4 pt-4 md:px-6 md:pt-6 xl:px-0">
+        <SosoTalkBanner imageUrl={SOSOTALK_BANNER_IMAGE} alt="소소토크 배너 이미지" />
+
+        <SosoTalkFilterBar
+          activeTab={activeTab}
+          activeSort={activeSort}
+          onTabChange={setActiveTab}
+          onSortChange={setActiveSort}
+        />
+
+        <section className="pt-2">
+          <div className="grid grid-cols-1 justify-items-center gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:justify-items-stretch">
+            {filteredPosts.map(({ id, isPopular: _isPopular, ...post }) => (
+              <SosoTalkCard key={id} {...post} />
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <Button
+        asChild
+        className={cn(
+          'bg-sosoeat-orange-600 fixed right-5 bottom-5 z-50 h-14 rounded-full px-5 text-base font-bold text-white shadow-lg',
+          'hover:bg-sosoeat-orange-700 md:right-8 md:bottom-8 md:h-16 md:px-7 md:text-lg'
+        )}
+      >
+        <Link href="/sosotalk/write">
+          <Plus className="size-5" aria-hidden />
+          게시글 작성
+        </Link>
+      </Button>
+    </div>
+  );
+};

--- a/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.tsx
@@ -33,6 +33,8 @@ const SOSOTALK_BANNER_IMAGE =
 const INITIAL_POST_COUNT = 8;
 const LOAD_MORE_COUNT = 4;
 
+// 실제 API 연동 전까지는 더미 데이터를 사용하여 구현합니다. 게시글 ID는 정수형으로 가정하고, 최신 게시글이 ID가 더 큰 형태로 정렬되어 있다고 가정합니다.
+
 const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
     id: 1,
@@ -67,8 +69,7 @@ const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
     id: 3,
     title: '비 오는 날 생각나는 국물 요리 TALK',
-    content:
-      '칼국수, 순두부, 쌀국수 중에서 오늘 같은 날 제일 당기는 메뉴가 뭔지 궁금해요.',
+    content: '칼국수, 순두부, 쌀국수 중에서 오늘 같은 날 제일 당기는 메뉴가 뭔지 궁금해요.',
     imageUrl:
       'https://images.unsplash.com/photo-1544025162-d76694265947?q=80&w=1200&auto=format&fit=crop',
     authorName: '서현',
@@ -82,8 +83,7 @@ const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
     id: 4,
     title: '야식으로 먹기 좋은 배달 메뉴 추천',
-    content:
-      '너무 헤비하지 않으면서 만족감 있는 메뉴 찾고 있어요. 최근에 괜찮았던 조합 있나요?',
+    content: '너무 헤비하지 않으면서 만족감 있는 메뉴 찾고 있어요. 최근에 괜찮았던 조합 있나요?',
     imageUrl:
       'https://images.unsplash.com/photo-1513104890138-7c749659a591?q=80&w=1200&auto=format&fit=crop',
     authorName: '지훈',
@@ -97,8 +97,7 @@ const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
     id: 5,
     title: '다이어트 중인데 맛있었던 샐러드집 있어요?',
-    content:
-      '포만감 있고 재료 신선한 샐러드집 찾고 있어요. 배달 말고 매장 방문 기준도 좋아요.',
+    content: '포만감 있고 재료 신선한 샐러드집 찾고 있어요. 배달 말고 매장 방문 기준도 좋아요.',
     imageUrl:
       'https://images.unsplash.com/photo-1512621776951-a57141f2eefd?q=80&w=1200&auto=format&fit=crop',
     authorName: '하린',
@@ -328,7 +327,9 @@ export const SosoTalkMainPage = ({ className }: SosoTalkMainPageProps) => {
               <>
                 <div ref={observerTargetRef} className="h-4 w-full" aria-hidden />
                 <p className="text-sosoeat-gray-500 text-sm">
-                  {isLoadingMore ? '게시글을 더 불러오는 중이에요.' : '아래로 스크롤하면 게시글이 더 보여요.'}
+                  {isLoadingMore
+                    ? '게시글을 더 불러오는 중이에요.'
+                    : '아래로 스크롤하면 게시글이 더 보여요.'}
                 </p>
               </>
             ) : (

--- a/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/app/sosotalk/_components/sosotalk-main-page/sosotalk-main-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import Link from 'next/link';
 
@@ -29,6 +29,9 @@ interface SosoTalkMainPost extends SosoTalkCardProps {
 
 const SOSOTALK_BANNER_IMAGE =
   'https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=1600&auto=format&fit=crop';
+
+const INITIAL_POST_COUNT = 8;
+const LOAD_MORE_COUNT = 4;
 
 const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
@@ -64,7 +67,8 @@ const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
     id: 3,
     title: '비 오는 날 생각나는 국물 요리 TALK',
-    content: '칼국수, 순두부, 쌀국수 중에서 오늘 같은 날 제일 당기는 메뉴가 뭔지 궁금해요.',
+    content:
+      '칼국수, 순두부, 쌀국수 중에서 오늘 같은 날 제일 당기는 메뉴가 뭔지 궁금해요.',
     imageUrl:
       'https://images.unsplash.com/photo-1544025162-d76694265947?q=80&w=1200&auto=format&fit=crop',
     authorName: '서현',
@@ -78,7 +82,8 @@ const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
     id: 4,
     title: '야식으로 먹기 좋은 배달 메뉴 추천',
-    content: '너무 헤비하지 않으면서 만족감 있는 메뉴 찾고 있어요. 최근에 괜찮았던 조합 있나요?',
+    content:
+      '너무 헤비하지 않으면서 만족감 있는 메뉴 찾고 있어요. 최근에 괜찮았던 조합 있나요?',
     imageUrl:
       'https://images.unsplash.com/photo-1513104890138-7c749659a591?q=80&w=1200&auto=format&fit=crop',
     authorName: '지훈',
@@ -92,7 +97,8 @@ const SOSOTALK_POSTS: SosoTalkMainPost[] = [
   {
     id: 5,
     title: '다이어트 중인데 맛있었던 샐러드집 있어요?',
-    content: '포만감 있고 재료 신선한 샐러드집 찾고 있어요. 배달 말고 매장 방문 기준도 좋아요.',
+    content:
+      '포만감 있고 재료 신선한 샐러드집 찾고 있어요. 배달 말고 매장 방문 기준도 좋아요.',
     imageUrl:
       'https://images.unsplash.com/photo-1512621776951-a57141f2eefd?q=80&w=1200&auto=format&fit=crop',
     authorName: '하린',
@@ -227,10 +233,74 @@ const sortPosts = (posts: SosoTalkMainPost[], activeSort: SosoTalkSortValue) => 
 export const SosoTalkMainPage = ({ className }: SosoTalkMainPageProps) => {
   const [activeTab, setActiveTab] = useState<SosoTalkTabValue>('all');
   const [activeSort, setActiveSort] = useState<SosoTalkSortValue>('latest');
+  const [visiblePostCount, setVisiblePostCount] = useState(INITIAL_POST_COUNT);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
-  const posts =
-    activeTab === 'popular' ? SOSOTALK_POSTS.filter((post) => post.isPopular) : SOSOTALK_POSTS;
-  const filteredPosts = sortPosts(posts, activeSort);
+  const observerTargetRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredPosts = useMemo(() => {
+    const posts =
+      activeTab === 'popular' ? SOSOTALK_POSTS.filter((post) => post.isPopular) : SOSOTALK_POSTS;
+
+    return sortPosts(posts, activeSort);
+  }, [activeSort, activeTab]);
+
+  const visiblePosts = filteredPosts.slice(0, visiblePostCount);
+  const hasMorePosts = visiblePostCount < filteredPosts.length;
+
+  const handleTabChange = (value: SosoTalkTabValue) => {
+    setActiveTab(value);
+    setVisiblePostCount(INITIAL_POST_COUNT);
+    setIsLoadingMore(false);
+  };
+
+  const handleSortChange = (value: SosoTalkSortValue) => {
+    setActiveSort(value);
+    setVisiblePostCount(INITIAL_POST_COUNT);
+    setIsLoadingMore(false);
+  };
+
+  useEffect(() => {
+    const target = observerTargetRef.current;
+
+    if (!target || !hasMorePosts || isLoadingMore) {
+      return;
+    }
+
+    // 목록 하단 sentinel이 보이면 다음 카드 묶음을 로드합니다.
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+
+        setIsLoadingMore(true);
+      },
+      {
+        rootMargin: '160px',
+      }
+    );
+
+    observer.observe(target);
+
+    return () => observer.disconnect();
+  }, [hasMorePosts, isLoadingMore]);
+
+  useEffect(() => {
+    if (!isLoadingMore) {
+      return;
+    }
+
+    // API 연동 전까지는 지연 시간을 두고 추가 로딩 동작만 시뮬레이션합니다.
+    const timeout = window.setTimeout(() => {
+      setVisiblePostCount((previousCount) =>
+        Math.min(previousCount + LOAD_MORE_COUNT, filteredPosts.length)
+      );
+      setIsLoadingMore(false);
+    }, 500);
+
+    return () => window.clearTimeout(timeout);
+  }, [filteredPosts.length, isLoadingMore]);
 
   return (
     <div className={cn('bg-background min-h-screen w-full bg-[#f9f9f9] pb-24 md:pb-28', className)}>
@@ -242,15 +312,28 @@ export const SosoTalkMainPage = ({ className }: SosoTalkMainPageProps) => {
         <SosoTalkFilterBar
           activeTab={activeTab}
           activeSort={activeSort}
-          onTabChange={setActiveTab}
-          onSortChange={setActiveSort}
+          onTabChange={handleTabChange}
+          onSortChange={handleSortChange}
         />
 
         <section className="pt-2">
           <div className="grid grid-cols-1 justify-items-center gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:justify-items-stretch">
-            {filteredPosts.map(({ id, isPopular: _isPopular, ...post }) => (
+            {visiblePosts.map(({ id, isPopular: _isPopular, ...post }) => (
               <SosoTalkCard key={id} {...post} />
             ))}
+          </div>
+
+          <div className="flex flex-col items-center justify-center py-8">
+            {hasMorePosts ? (
+              <>
+                <div ref={observerTargetRef} className="h-4 w-full" aria-hidden />
+                <p className="text-sosoeat-gray-500 text-sm">
+                  {isLoadingMore ? '게시글을 더 불러오는 중이에요.' : '아래로 스크롤하면 게시글이 더 보여요.'}
+                </p>
+              </>
+            ) : (
+              <p className="text-sosoeat-gray-400 text-sm">마지막 게시글까지 모두 확인했어요.</p>
+            )}
           </div>
         </section>
       </main>

--- a/src/app/sosotalk/page.tsx
+++ b/src/app/sosotalk/page.tsx
@@ -1,0 +1,5 @@
+import { SosoTalkMainPage } from './_components/sosotalk-main-page';
+
+export default function SosoTalkPage() {
+  return <SosoTalkMainPage />;
+}


### PR DESCRIPTION
## PR 제목: [Feat]: 소소토크 메인 페이지 레이아웃 구현

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- #90 소소토크 메인 페이지 레이아웃을 구현했습니다.
- 기존에 작업된 `SosoTalkBanner`, `SosoTalkFilterBar`, `SosoTalkCard` 컴포넌트를 조합해 메인 페이지를 구성했습니다.
- `app/sosotalk/page.tsx`에서 메인 페이지 조립 컴포넌트를 렌더링하도록 연결했습니다.
- 더미 게시글 데이터를 기반으로 카드 목록이 보이도록 구성했습니다.
- PC 환경에서 더 많은 카드가 보이도록 반응형 grid 레이아웃을 적용했습니다.
- 상단 `NavigationBar`와 우측 하단 게시글 작성 버튼을 추가했습니다.
- API 연동 전 단계로, 더미 데이터 기반 무한 스크롤 동작을 확인할 수 있도록 구성했습니다.
- Storybook에서 확인할 수 있도록 메인 페이지 스토리도 추가했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 `npm run dev` 또는 `npm run storybook`을 실행합니다.
2. `/sosotalk` 페이지 또는 Storybook의 `pages/sosotalk/sosotalk-main-page`로 이동합니다.
3. 상단 네비게이션, 배너, 필터 바, 카드 목록, 우측 하단 게시글 작성 버튼이 노출되는지 확인합니다.
4. 화면 크기를 PC / Tablet / Mobile로 변경했을 때 카드 개수와 배치가 반응형으로 변경되는지 확인합니다.
5. 페이지 하단으로 스크롤했을 때 더미 데이터 기반으로 카드가 추가 렌더링되는지 확인합니다.
6. 필터 탭 또는 정렬 옵션을 변경했을 때 목록이 다시 처음 상태부터 렌더링되는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
  현재 무한 스크롤은 API 연동 전 단계라 더미 데이터 기반으로만 동작합니다. 추후 실제 API 응답 구조에 맞춰 교체가 필요합니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**