### PR TITLE
[Feat]: RootLayout에 NavigationBar 추가 및 상단 고정 배치

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { Providers } from '@/app/providers';
+import { NavigationBar } from '@/components/common/navigation-bar/navigation-bar';
 import { Toaster } from '@/components/ui/sonner/index';
 
 import '@/app/globals.css';
@@ -18,7 +19,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="min-w-[375px]">
-        <Providers>{children}</Providers>
+        <Providers>
+          <NavigationBar />
+          <main>{children}</main>
+        </Providers>
         <Toaster />
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 
 import { Providers } from '@/app/providers';
-import { NavigationBar } from '@/components/common/navigation-bar/navigation-bar';
+import { NavigationBarClient } from '@/components/common/navigation-bar/navigation-bar-client';
 import { Toaster } from '@/components/ui/sonner/index';
 
 import '@/app/globals.css';
@@ -20,7 +20,7 @@ export default function RootLayout({
     <html lang="ko">
       <body className="min-w-[375px]">
         <Providers>
-          <NavigationBar />
+          <NavigationBarClient />
           <main>{children}</main>
         </Providers>
         <Toaster />

--- a/src/components/common/navigation-bar/navigation-bar-client.tsx
+++ b/src/components/common/navigation-bar/navigation-bar-client.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const NavigationBarDynamic = dynamic(
+  () => import('./navigation-bar').then((m) => ({ default: m.NavigationBar })),
+  { ssr: false }
+);
+
+export function NavigationBarClient() {
+  return <NavigationBarDynamic />;
+}


### PR DESCRIPTION
### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

**구현 배경** (#98)

모든 페이지에 공통으로 표시되는 NavigationBar를 RootLayout에 추가했습니다.
Nav가 없는 페이지가 없으므로 Route Group 없이 RootLayout에서 통합 관리합니다.

**변경 내용**

- `layout.tsx` — `<NavigationBarClient />` 추가, `<main>`에 `pt-16` 적용
- `navigation-bar-client.tsx` 추가 — `dynamic + ssr: false`로 감싸 CSR에서만 렌더되도록 처리
- `navigation-bar-auth.tsx` — hydration 에러 해결을 위해 mounted 패턴 제거

**hydration 에러 해결 과정**

`layout.tsx`(서버 컴포넌트)에서 shadcn/ui 기반 컴포넌트(DropdownMenu, Sheet)를 직접 렌더링하면 Radix UI가 서버/클라이언트에서 각각 다른 랜덤 ID를 생성해 hydration 불일치가 발생했습니다.

```
+ aria-controls="radix-R_1d1b_"  ← 클라이언트
- aria-controls="radix-R_51lb_"  ← 서버
```

처음에는 mounted 패턴으로 해결을 시도했으나 프로젝트 ESLint 룰(`useEffect 내 setState 금지`)에 걸려 사용할 수 없었습니다. 최종적으로 클라이언트 래퍼 컴포넌트(`navigation-bar-client.tsx`)를 추가해 `dynamic + ssr: false`로 감싸는 방식으로 해결했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 앱을 실행합니다.
2. 브라우저 콘솔에서 hydration 관련 에러가 없는지 확인합니다.
3. 로그인/비로그인 상태에서 NavigationBar가 정상적으로 렌더되는지 확인합니다.
4. 햄버거 메뉴(모바일), 드롭다운 메뉴(PC)가 정상 동작하는지 확인합니다.
5. 콘텐츠가 NavigationBar에 가려지지 않는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)
<img width="1895" height="464" alt="image" src="https://github.com/user-attachments/assets/a808bb8e-5142-4f75-bb99-647c7fbde74e" />


### 🚨 기타 참고 사항 (Notes)

- [x] **shadcn/ui 컴포넌트(Radix UI 기반)를 `layout.tsx` 등 서버 컴포넌트에서 직접 사용할 경우 동일한 hydration 에러가 발생할 수 있습니다. 클라이언트 래퍼로 감싸는 동일한 패턴으로 해결 가능합니다.**
- [x] **현재 NavigationBar는 `ssr: false`로 전체 CSR 처리되어 있습니다. 추후 로고, 메뉴 링크 등 정적인 영역은 SSR로, 로그인 상태에 따라 달라지는 영역만 CSR로 분리하는 방향으로 리팩토링할 예정입니다.**
- [ ] 배포 시 특이사항 없음