### PR TITLE
feat: 소소토크 게시글 작성 페이지 조립 및 포스트 에디터 테스트 추가

### DIFF
--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/image-upload-field.tsx
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/_components/image-upload-field/image-upload-field.tsx
@@ -33,7 +33,7 @@ export function ImageUploadField({
           type="button"
           onClick={onRemove}
           disabled={disabled}
-          className="absolute top-8 right-8 flex h-5 w-5 items-center justify-center rounded-full bg-black/70 text-white transition-opacity hover:opacity-85 disabled:pointer-events-none disabled:opacity-50"
+          className="absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full bg-black/70 text-white transition-opacity hover:opacity-85 disabled:pointer-events-none disabled:opacity-50"
           aria-label="업로드한 이미지 삭제"
         >
           <X className="h-3.5 w-3.5" />

--- a/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.test.tsx
+++ b/src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { SosoTalkPostEditor } from './sosotalk-post-editor';
@@ -10,6 +10,8 @@ import {
 beforeEach(() => {
   document.execCommand = jest.fn();
   document.queryCommandState = jest.fn().mockReturnValue(false);
+  URL.createObjectURL = jest.fn().mockReturnValue('blob:preview-image');
+  URL.revokeObjectURL = jest.fn();
 });
 
 describe('SosoTalkPostEditor', () => {
@@ -59,5 +61,96 @@ describe('SosoTalkPostEditor', () => {
     expect(
       screen.getByText(new RegExp(`공백포함 : 총 ${SOSOTALK_POST_EDITOR_CONTENT_MAX_LENGTH}자`))
     ).toBeInTheDocument();
+  });
+
+  it('제목이나 본문이 비어 있으면 등록되지 않는다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+
+    render(<SosoTalkPostEditor onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('button', { name: '등록' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('등록 시 작성한 내용이 onSubmit payload로 전달된다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+
+    render(
+      <SosoTalkPostEditor
+        initialTitle="모임 추천 부탁드립니다"
+        initialContent={'안녕하세요.\n\n같이 식사하실 분 계실까요?'}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '등록' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: '모임 추천 부탁드립니다',
+      contentHtml: '<p>안녕하세요.</p><p><br></p><p>같이 식사하실 분 계실까요?</p>',
+      contentText: '안녕하세요.\n\n같이 식사하실 분 계실까요?',
+      imageFile: null,
+      imagePreviewUrl: '',
+    });
+  });
+
+  it('이미지 파일을 선택하면 미리보기가 표시된다', async () => {
+    const file = new File(['image'], 'dog.png', { type: 'image/png' });
+    const { container } = render(<SosoTalkPostEditor />);
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByAltText('dog.png')).toBeInTheDocument();
+    });
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+  });
+
+  it('이미지 추가 버튼을 누르면 파일 선택창이 열린다', async () => {
+    const user = userEvent.setup();
+    const clickSpy = jest.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+
+    render(<SosoTalkPostEditor />);
+
+    await user.click(screen.getByRole('button', { name: '이미지 추가' }));
+
+    expect(clickSpy).toHaveBeenCalled();
+
+    clickSpy.mockRestore();
+  });
+
+  it('초기값이 바뀌면 에디터 상태가 함께 동기화된다', () => {
+    const { container, rerender } = render(
+      <SosoTalkPostEditor
+        initialTitle="첫 번째 제목"
+        initialContent="첫 번째 본문"
+        initialImageUrl="https://example.com/first.jpg"
+      />
+    );
+
+    rerender(
+      <SosoTalkPostEditor
+        initialTitle="두 번째 제목"
+        initialContent="두 번째 본문"
+        initialImageUrl="https://example.com/second.jpg"
+      />
+    );
+
+    const editor = container.querySelector('[contenteditable="true"]');
+
+    return waitFor(() => {
+      expect(screen.getByLabelText('게시글 제목')).toHaveValue('두 번째 제목');
+      expect(editor).toHaveTextContent('두 번째 본문');
+      expect(screen.getByAltText('업로드한 이미지')).toHaveAttribute(
+        'src',
+        expect.stringContaining('https://example.com/second.jpg')
+      );
+    });
   });
 });

--- a/src/app/sosotalk/write/page.stories.tsx
+++ b/src/app/sosotalk/write/page.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import SosoTalkWritePage from './page';
+
+const meta = {
+  title: 'pages/sosotalk/write/page',
+  component: SosoTalkWritePage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: {
+      default: 'lightGray',
+      values: [{ name: 'lightGray', value: '#F6F7FB' }],
+    },
+  },
+} satisfies Meta<typeof SosoTalkWritePage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/app/sosotalk/write/page.tsx
+++ b/src/app/sosotalk/write/page.tsx
@@ -1,11 +1,18 @@
+import { NavigationBar } from '@/components/common/navigation-bar';
+
 import { SosoTalkPostEditor } from './_components/sosotalk-post-editor';
 
 export default function SosoTalkWritePage() {
   return (
-    <main className="min-h-screen bg-[#F6F7FB] px-4 py-16">
-      <div className="mx-auto w-full max-w-[860px]">
-        <SosoTalkPostEditor />
-      </div>
-    </main>
+    <>
+      <NavigationBar />
+      <main className="min-h-screen bg-[#f9f9f9] px-4 py-8 md:px-6 md:py-10">
+        <div className="mx-auto w-full max-w-[1280px]">
+          <div className="mx-auto w-full max-w-[860px]">
+            <SosoTalkPostEditor />
+          </div>
+        </div>
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## PR 제목: [Feat]: 소소토크 게시글 작성 페이지 조립 및 포스트 에디터 테스트 추가

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 소소토크 게시글 작성 페이지에서 기존 `SosoTalkPostEditor`를 활용해 페이지 조립을 완료했습니다.
- `/sosotalk/write` 페이지에 상단 네비게이션과 레이아웃 컨테이너를 적용했습니다.
- 작성 페이지 전체 조립 상태를 확인할 수 있도록 `write/page` Storybook 스토리를 추가했습니다.
- `SosoTalkPostEditor`의 필수 테스트와 추가 시나리오 테스트를 작성했습니다.
- 이미지 미리보기 썸네일의 삭제 버튼 위치를 우측 상단으로 조정했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 `npm run dev` 또는 `npm run storybook`을 실행합니다.
2. 브라우저에서 `/sosotalk/write` 페이지와 Storybook의 `pages/sosotalk/write/page`, `pages/sosotalk/write/sosotalk-post-editor`를 확인합니다.
3. 제목/본문 입력, 등록 버튼 활성화, 이미지 업로드 및 삭제가 정상 동작하는지 확인합니다.
4. 아래 명령어로 단위 테스트와 타입 체크를 실행합니다.

```bash
npx jest --runInBand src/app/sosotalk/write/_components/sosotalk-post-editor/sosotalk-post-editor.test.tsx
npm run type-check
```

5. 테스트 9개가 모두 통과하고 타입 에러가 없는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
X 버튼의 위치가 다소 어색하여 해당 이미지의 위치로 바꿨습니다.
<img width="290" height="288" alt="image" src="https://github.com/user-attachments/assets/901e5862-6274-42c1-a46f-e15418f63aea" />

### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
  `SosoTalkPostEditor`는 기존 `contentEditable` 구조를 유지한 상태로 테스트를 보강했습니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**