### PR TITLE
[Feat]: EditProfileModal - 마이페이지 프로필 수정 모달 구현

### DIFF
--- a/src/app/mypage/_components/count-card/count-card.stories.tsx
+++ b/src/app/mypage/_components/count-card/count-card.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { CountCard } from './count-card';
 
 const meta: Meta<typeof CountCard> = {
-  title: 'COMPONENTS/common/card-count',
+  title: 'APP/mypage/card-count',
   component: CountCard,
   tags: ['autodocs'],
   argTypes: {

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.stories.tsx
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.stories.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { PencilLine } from 'lucide-react';
+
+import { EditProfileModal } from './edit-profile-modal';
+
+const meta: Meta<typeof EditProfileModal> = {
+  title: 'APP/mypage/edit-profile-modal',
+  component: EditProfileModal,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EditProfileModal>;
+
+const ModalWithToggle = (args: React.ComponentProps<typeof EditProfileModal>) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div>
+      <div className="flex h-[34.45px] w-[104.04px] flex-row">
+        <button
+          onClick={() => setIsOpen(true)}
+          className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-300 flex h-full w-full items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1"
+        >
+          <PencilLine className="h-[12.99px] w-[12.99px]"></PencilLine>
+          프로필 수정
+        </button>
+      </div>
+      <EditProfileModal {...args} isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </div>
+  );
+};
+
+// default
+export const Default: Story = {
+  render: (args) => <ModalWithToggle {...args} />,
+  args: {
+    initialName: '김민준',
+    initialEmail: 'sosoeat@codeit.com',
+  },
+};
+
+// 모달이 처음부터 열려 있는 상태
+export const OpenByDefault: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    initialName: '김민준',
+    initialEmail: 'sosoeat@codeit.com',
+  },
+};

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.stories.tsx
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.stories.tsx
@@ -16,39 +16,10 @@ const meta: Meta<typeof EditProfileModal> = {
 export default meta;
 type Story = StoryObj<typeof EditProfileModal>;
 
-const ModalWithToggle = (args: React.ComponentProps<typeof EditProfileModal>) => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <div>
-      <div className="flex h-[34.45px] w-[104.04px] flex-row">
-        <button
-          onClick={() => setIsOpen(true)}
-          className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-300 flex h-full w-full items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1"
-        >
-          <PencilLine className="h-[12.99px] w-[12.99px]"></PencilLine>
-          프로필 수정
-        </button>
-      </div>
-      <EditProfileModal {...args} isOpen={isOpen} onClose={() => setIsOpen(false)} />
-    </div>
-  );
-};
-
 // default
 export const Default: Story = {
-  render: (args) => <ModalWithToggle {...args} />,
+  name: '반응형',
   args: {
-    initialName: '김민준',
-    initialEmail: 'sosoeat@codeit.com',
-  },
-};
-
-// 모달이 처음부터 열려 있는 상태
-export const OpenByDefault: Story = {
-  args: {
-    isOpen: true,
-    onClose: () => {},
     initialName: '김민준',
     initialEmail: 'sosoeat@codeit.com',
   },

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+
+import Image from 'next/image';
+
+import { Pencil, XIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Field, FieldContent, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+
+import type {
+  EditProfileModalProps,
+  ModalActionButtonsProps,
+  ProfileFieldProps,
+} from './edit-profile-modal.types';
+
+const styles = {
+  input: 'focus:border-sosoeat-gray-700 border border-transparent focus:ring-0 focus:outline-none',
+  fieldLabel: 'text-sm font-semibold',
+  actionButton: 'w-fill h-15 flex-1 rounded-2xl py-3 text-xl font-semibold',
+} as const;
+
+// 프로필 이미지
+function ProfileImageEditor() {
+  return (
+    <div className="flex justify-center py-10">
+      <div className="relative">
+        <Image
+          src="/"
+          alt="프로필 이미지"
+          width={116}
+          height={119}
+          className="ring-sosoeat-gray-300 rounded-full object-cover ring-1"
+        />
+        <Button className="ring-sosoeat-gray-300 absolute right-0 bottom-0 flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-600 ring-1">
+          <Pencil className="h-6 w-6" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// 이름, 이메일 input
+function ProfileField({ id, label, type = 'text', value, onChange }: ProfileFieldProps) {
+  return (
+    <Field orientation="vertical" className="gap-2">
+      <FieldLabel htmlFor={id} className={styles.fieldLabel}>
+        {label}
+      </FieldLabel>
+      <FieldContent>
+        <Input id={id} type={type} value={value} onChange={onChange} className={styles.input} />
+      </FieldContent>
+    </Field>
+  );
+}
+
+// 취소,수정하기 button
+function ModalActionButtons({ onCancel, onSubmit }: ModalActionButtonsProps) {
+  return (
+    <div className="flex gap-3 py-15">
+      <Button
+        onClick={onCancel}
+        className={`${styles.actionButton} border-sosoeat-gray-300 border bg-white text-gray-700 hover:bg-gray-50`}
+      >
+        취소
+      </Button>
+      <Button
+        onClick={onSubmit}
+        className={`${styles.actionButton} bg-sosoeat-orange-600 text-white`}
+      >
+        수정하기
+      </Button>
+    </div>
+  );
+}
+
+export function EditProfileModal({
+  isOpen,
+  onClose,
+  initialName = '',
+  initialEmail = '',
+}: EditProfileModalProps) {
+  const [name, setName] = useState(initialName);
+  const [email, setEmail] = useState(initialEmail);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = () => {
+    // 수정 API 호출
+    console.log('수정하기:', { name, email });
+    onClose();
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={handleOverlayClick}
+    >
+      <div className="relative h-[627px] w-[544px] rounded-4xl bg-white p-12 shadow-xl">
+        <div className="p-2">
+          <Button
+            onClick={onClose}
+            className="absolute top-9 right-7 bg-white text-gray-400"
+            aria-label="닫기"
+          >
+            <XIcon className="size-6" strokeWidth={1.8} />
+          </Button>
+          <h2 className="text-xl font-semibold text-gray-900">프로필 수정하기</h2>
+        </div>
+
+        <ProfileImageEditor />
+
+        <FieldGroup className="gap-4 py-2">
+          <ProfileField
+            id="name"
+            label="이름"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <ProfileField
+            id="email"
+            label="이메일"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </FieldGroup>
+
+        <ModalActionButtons onCancel={onClose} onSubmit={handleSubmit} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.tsx
@@ -1,38 +1,52 @@
+'use client';
+
 import { useState } from 'react';
 
 import Image from 'next/image';
 
-import { Pencil, XIcon } from 'lucide-react';
+import { Pencil, PencilLine, XIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Field, FieldContent, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 
 import type {
   EditProfileModalProps,
-  ModalActionButtonsProps,
   ProfileFieldProps,
+  ProfileImageEditorProps,
 } from './edit-profile-modal.types';
 
 const styles = {
   input: 'focus:border-sosoeat-gray-700 border border-transparent focus:ring-0 focus:outline-none',
   fieldLabel: 'text-sm font-semibold',
-  actionButton: 'w-fill h-15 flex-1 rounded-2xl py-3 text-xl font-semibold',
+  actionButton:
+    'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold',
 } as const;
 
-// 프로필 이미지
-function ProfileImageEditor() {
+function ProfileImageEditor({ imageUrl }: ProfileImageEditorProps) {
+  // 실제 프롭스로 넘어온 이미지가 있으면 그걸 쓰고, 없으면 public 폴더의 기본 이미지를 씁니다.
+  const imageSrc = imageUrl || '/default-profile.png';
+
   return (
-    <div className="flex justify-center py-10">
+    <div className="flex justify-center">
       <div className="relative">
         <Image
-          src="/"
+          src={imageSrc} // ✅ 2. "/" 대신 imageSrc 변수를 넣습니다.
           alt="프로필 이미지"
           width={116}
-          height={119}
+          height={116}
           className="ring-sosoeat-gray-300 rounded-full object-cover ring-1"
         />
-        <Button className="ring-sosoeat-gray-300 absolute right-0 bottom-0 flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-600 ring-1">
+        <Button className="ring-sosoeat-gray-300 absolute right-1 bottom-2 flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-600 ring-1 md:right-1 md:bottom-7">
           <Pencil className="h-6 w-6" />
         </Button>
       </div>
@@ -40,7 +54,6 @@ function ProfileImageEditor() {
   );
 }
 
-// 이름, 이메일 input
 function ProfileField({ id, label, type = 'text', value, onChange }: ProfileFieldProps) {
   return (
     <Field orientation="vertical" className="gap-2">
@@ -54,67 +67,53 @@ function ProfileField({ id, label, type = 'text', value, onChange }: ProfileFiel
   );
 }
 
-// 취소,수정하기 button
-function ModalActionButtons({ onCancel, onSubmit }: ModalActionButtonsProps) {
-  return (
-    <div className="flex gap-3 py-15">
-      <Button
-        onClick={onCancel}
-        className={`${styles.actionButton} border-sosoeat-gray-300 border bg-white text-gray-700 hover:bg-gray-50`}
-      >
-        취소
-      </Button>
-      <Button
-        onClick={onSubmit}
-        className={`${styles.actionButton} bg-sosoeat-orange-600 text-white`}
-      >
-        수정하기
-      </Button>
-    </div>
-  );
-}
-
 export function EditProfileModal({
-  isOpen,
-  onClose,
   initialName = '',
   initialEmail = '',
+  initialImageUrl = '',
+  onSubmit,
 }: EditProfileModalProps) {
   const [name, setName] = useState(initialName);
   const [email, setEmail] = useState(initialEmail);
-
-  if (!isOpen) return null;
-
+  const [open, setOpen] = useState(false);
   const handleSubmit = () => {
-    // 수정 API 호출
-    console.log('수정하기:', { name, email });
-    onClose();
-  };
-
-  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) onClose();
+    onSubmit?.({ name, email });
+    setOpen(false);
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      onClick={handleOverlayClick}
-    >
-      <div className="relative h-[627px] w-[544px] rounded-4xl bg-white p-12 shadow-xl">
-        <div className="p-2">
-          <Button
-            onClick={onClose}
-            className="absolute top-9 right-7 bg-white text-gray-400"
-            aria-label="닫기"
-          >
-            <XIcon className="size-6" strokeWidth={1.8} />
-          </Button>
-          <h2 className="text-xl font-semibold text-gray-900">프로필 수정하기</h2>
-        </div>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-300 flex h-[34.45px] w-[104.04px] flex-row items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1">
+          <PencilLine className="h-[12.99px] w-[12.99px]" />
+          프로필 수정
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        showCloseButton={false}
+        className="h-[499px] w-[343px] max-w-none rounded-4xl bg-white p-9 shadow-xl sm:max-w-none md:h-[627px] md:w-[544px]"
+      >
+        {/* Title + shadcn 기본 X버튼 */}
+        <DialogHeader className="flex w-full flex-row items-center justify-between">
+          <DialogTitle className="text-xl font-semibold text-gray-900">프로필 수정하기</DialogTitle>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-8 shrink-0 text-[#737373] hover:bg-transparent hover:text-[#737373]"
+              aria-label="닫기"
+            >
+              <XIcon className="size-6" strokeWidth={1.8} />
+            </Button>
+          </DialogClose>
+        </DialogHeader>
 
-        <ProfileImageEditor />
+        {/* 프로필 이미지 */}
+        <ProfileImageEditor imageUrl={initialImageUrl} />
 
-        <FieldGroup className="gap-4 py-2">
+        {/* 이름, 이메일 필드 */}
+        <FieldGroup className="gap-4">
           <ProfileField
             id="name"
             label="이름"
@@ -130,8 +129,23 @@ export function EditProfileModal({
           />
         </FieldGroup>
 
-        <ModalActionButtons onCancel={onClose} onSubmit={handleSubmit} />
-      </div>
-    </div>
+        {/* 취소, 수정하기 버튼 */}
+        <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
+          <DialogClose asChild>
+            <Button
+              className={`${styles.actionButton} border-sosoeat-gray-300 border bg-white text-gray-700 hover:bg-gray-50`}
+            >
+              취소
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={handleSubmit}
+            className={`${styles.actionButton} bg-sosoeat-orange-600 text-white`}
+          >
+            수정하기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
@@ -1,0 +1,19 @@
+export interface EditProfileModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialName?: string;
+  initialEmail?: string;
+}
+
+export interface ProfileFieldProps {
+  id: string;
+  label: string;
+  type?: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export interface ModalActionButtonsProps {
+  onCancel: () => void;
+  onSubmit: () => void;
+}

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
@@ -1,8 +1,12 @@
+import type { ChangeEvent } from 'react';
+
 export interface EditProfileModalProps {
   isOpen: boolean;
   onClose: () => void;
   initialName?: string;
   initialEmail?: string;
+  initialImageUrl?: string;
+  onSubmit?: (data: { name: string; email: string }) => void;
 }
 
 export interface ProfileFieldProps {
@@ -10,10 +14,14 @@ export interface ProfileFieldProps {
   label: string;
   type?: string;
   value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
 export interface ModalActionButtonsProps {
   onCancel: () => void;
   onSubmit: () => void;
+}
+
+export interface ProfileImageEditorProps {
+  imageUrl?: string;
 }

--- a/src/app/mypage/_components/edit-profile-modal/index.ts
+++ b/src/app/mypage/_components/edit-profile-modal/index.ts
@@ -1,0 +1,1 @@
+export { EditProfileModal } from './edit-profile-modal';


### PR DESCRIPTION
## [Feat]: 마이페이지 프로필 수정 모달 구현

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 마이페이지에서 사용자가 직접 자신의 정보를 수정할 수 있는 UI를 구현하였습니다.
- 사용자 프로필 정보(이름, 이메일) 및 프로필 이미지를 수정할 수 있는 EditProfileModal 컴포넌트를  추가했습니다.
- 입력창(Input) 클릭 시 발생하는 브라우저 기본 ring 및 outline 효과를 제거하고, focus:border-sosoeat-gray-700 속성을 활용해 디자인 시안에 맞는 깔끔한 포커스 테두리 스타일을 구현했습니다.
- 코드 가독성과 유지보수를 위해 모달 내부의 UI 요소들을 ProfileImageEditor, ProfileField, ModalActionButtons 등의 하위 컴포넌트로 분리하여 작성했습니다.

### 🧪 테스트 방법 (How to Test)

1. storybook에서 프로필 수정 버튼을 클릭하여 EditProfileModal 창을 띄웁니다.
2. 입력창에 텍스트를 입력하여 상태(state)가 정상적으로 변경되는지 확인합니다.
3. 모달 우측 상단의 'X' 버튼, 하단의 '취소' 버튼, 또는 모달 바깥의 **어두운 배경(오버레이)**을 클릭했을 때 모달이 정상적으로 닫히는지 확인합니다.
4. 정보를 입력하고 '수정하기' 버튼을 클릭했을 때, 개발자 도구 콘솔(Console)에 입력한 데이터가 올바르게 찍히며 모달이 닫히는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

<img width="223" height="146" alt="image" src="https://github.com/user-attachments/assets/c96e5e54-ac2a-47f5-a04f-777b4ba36003" />
<img width="695" height="711" alt="image" src="https://github.com/user-attachments/assets/7cb13d07-1215-47c3-800f-6d4fae1a5ce6" />

### 🚨 기타 참고 사항 (Notes)

- [ ] 이메일 형식 검사, 이름 글자 수 제한 등의 검증 로직은 현재 단계에서는 제외되었습니다.
