### PR TITLE
 [Style]: MeetingMakeButton 데스크톱 UI 시안에 맞게 조정

### DIFF
--- a/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.tsx
+++ b/src/app/meetings/_components/meeting-make-button.tsx/meeting-make-button.tsx
@@ -69,7 +69,7 @@ export const MeetingMakeButton = ({
     >
       <span className="flex h-8 flex-row items-center gap-1.5 self-stretch pr-1">
         <span className="flex size-8 shrink-0 items-center justify-center" aria-hidden>
-          <Plus className="size-7 text-white" strokeWidth={2} />
+          <Plus className="size-7 text-white" strokeWidth={2.5} />
         </span>
         <span className="w-22.5 shrink-0 text-center text-xl leading-7.5 font-bold tracking-[-0.02em] text-white">
           {label}


### PR DESCRIPTION
## PR 제목: [Style]: MeetingMakeButton 데스크톱 UI 시안에 맞게 조정

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

이 PR에서 변경된 내용을 **간결하고 명확하게** 설명해주세요.

- meetings 페이지의 `MeetingMakeButton` 데스크톱 UI를 피그마 시안에 맞게 조정했습니다.
- 버튼 너비를 조정하고, 내부 레이아웃을 가로 정렬에서 시안 기준 배치로 수정했습니다.
- 플러스 아이콘 크기를 키우고, 텍스트 영역 너비 및 `line-height`를 함께 보정했습니다.
- 모바일 버튼의 위치, 크기, 접근성 라벨 및 클릭 동작은 기존 동작을 유지했습니다.

### 🧪 테스트 방법 (How to Test)

변경 사항을 확인하기 위해 **테스트해야 할 단계나 시나리오**를 상세히 설명해주세요.

1. 로컬 환경에서 앱을 실행합니다.
2. `/meetings` 페이지로 이동합니다.
3. 데스크톱 해상도에서 우측 하단 플로팅 버튼의 너비, 내부 정렬, 아이콘 크기, 텍스트 배치가 시안과 맞는지 확인합니다.
4. 브라우저 너비를 모바일로 줄여 원형 플로팅 버튼으로 정상 전환되는지 확인합니다.
5. 버튼 클릭 시 기존 `onClick` 동작에 영향이 없는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

| 변경 후 (After) |
| :--------------: | :-------------: |
|        첨부 예정        |      첨부 예정       |

<img width="266" height="177" alt="image" src="https://github.com/user-attachments/assets/28b9dd7c-2add-41d8-a230-beed5994f656" />

### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
  - 데스크톱 버튼의 `w-47`, `gap-2.5`, `size-7`, `w-22.5`, `leading-7.5` 값이 실제 피그마 기준과 일치하는지 확인 부탁드립니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**