### PR TITLE
[Feat] 마이페이지 API 연동 및 UI 개선 

### DIFF
--- a/src/app/mypage/_components/count-card/count-card.variants.ts
+++ b/src/app/mypage/_components/count-card/count-card.variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const cardVariants = cva(
-  'hidden md:flex flex flex-col gap-1 rounded-2xl text-center ring-0 lg:h-20 lg:w-90 max-lg:h-17.5 max-lg:w-52.5',
+  'hidden md:flex flex-col gap-1 rounded-2xl text-center ring-0 h-20 w-90',
   {
     variants: {
       variant: {

--- a/src/app/mypage/_components/count-card/count-card.variants.ts
+++ b/src/app/mypage/_components/count-card/count-card.variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const cardVariants = cva(
-  'hidden md:flex flex-col gap-1 rounded-2xl text-center ring-0 h-20 w-90',
+  'hidden md:flex flex-col gap-1 rounded-2xl text-center ring-0 h-20 w-85',
   {
     variants: {
       variant: {

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import Image from 'next/image';
 
-import { Pencil, PencilLine, XIcon } from 'lucide-react';
+import { Loader2, Pencil, PencilLine, XIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -18,6 +18,8 @@ import {
 } from '@/components/ui/dialog';
 import { Field, FieldContent, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
+import { useUploadImage } from '@/services/images';
+import { PresignedUrlRequestFolderEnum } from '@/types/generated-client';
 
 import type {
   EditProfileModalProps,
@@ -32,22 +34,45 @@ const styles = {
     'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold',
 } as const;
 
-function ProfileImageEditor({ imageUrl }: ProfileImageEditorProps) {
-  // 실제 프롭스로 넘어온 이미지가 있으면 그걸 쓰고, 없으면 public 폴더의 기본 이미지를 씁니다.
-  const imageSrc = imageUrl || '/default-profile.png';
+function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { mutateAsync, isPending } = useUploadImage(PresignedUrlRequestFolderEnum.Users);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const publicUrl = await mutateAsync(file);
+    if (publicUrl) onChange(publicUrl);
+  };
 
   return (
     <div className="flex justify-center">
       <div className="relative">
         <Image
-          src={imageSrc} // ✅ 2. "/" 대신 imageSrc 변수를 넣습니다.
+          src={imageUrl || '/default-profile.png'}
           alt="프로필 이미지"
           width={116}
           height={116}
           className="ring-sosoeat-gray-300 rounded-full object-cover ring-1"
         />
-        <Button className="ring-sosoeat-gray-300 absolute right-1 bottom-2 flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-600 ring-1 md:right-1 md:bottom-7">
-          <Pencil className="h-6 w-6" />
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        <Button
+          type="button"
+          disabled={isPending}
+          onClick={() => inputRef.current?.click()}
+          className="ring-sosoeat-gray-300 absolute right-1 bottom-2 flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-600 ring-1 md:right-1 md:bottom-7"
+        >
+          {isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Pencil className="h-6 w-6" />
+          )}
         </Button>
       </div>
     </div>
@@ -72,28 +97,34 @@ export function EditProfileModal({
   initialEmail = '',
   initialImageUrl = '',
   onSubmit,
+  open: externalOpen,
+  onOpenChange: externalOnOpenChange,
 }: EditProfileModalProps) {
   const [name, setName] = useState(initialName);
   const [email, setEmail] = useState(initialEmail);
-  const [open, setOpen] = useState(false);
+  const [imageUrl, setImageUrl] = useState(initialImageUrl);
+  const [internalOpen, setInternalOpen] = useState(false);
+
+  const open = externalOpen ?? internalOpen;
+  const setOpen = externalOnOpenChange ?? setInternalOpen;
+
   const handleSubmit = () => {
-    onSubmit?.({ name, email });
+    onSubmit?.({ name, email, imageUrl });
     setOpen(false);
   };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-300 flex h-[34.45px] w-[104.04px] flex-row items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1">
+        <button className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-300 hidden h-[34.45px] w-[104.04px] flex-row items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1 md:flex">
           <PencilLine className="h-[12.99px] w-[12.99px]" />
           프로필 수정
         </button>
       </DialogTrigger>
       <DialogContent
         showCloseButton={false}
-        className="h-[499px] w-[343px] max-w-none rounded-4xl bg-white p-9 shadow-xl sm:max-w-none md:h-[627px] md:w-[544px]"
+        className="h-124.75 w-85.75 max-w-none rounded-4xl bg-white p-9 shadow-xl sm:max-w-none md:h-156.75 md:w-136"
       >
-        {/* Title + shadcn 기본 X버튼 */}
         <DialogHeader className="flex w-full flex-row items-center justify-between">
           <DialogTitle className="text-xl font-semibold text-gray-900">프로필 수정하기</DialogTitle>
           <DialogClose asChild>
@@ -109,10 +140,8 @@ export function EditProfileModal({
           </DialogClose>
         </DialogHeader>
 
-        {/* 프로필 이미지 */}
-        <ProfileImageEditor imageUrl={initialImageUrl} />
+        <ProfileImageEditor imageUrl={imageUrl} onChange={setImageUrl} />
 
-        {/* 이름, 이메일 필드 */}
         <FieldGroup className="gap-4">
           <ProfileField
             id="name"
@@ -129,7 +158,6 @@ export function EditProfileModal({
           />
         </FieldGroup>
 
-        {/* 취소, 수정하기 버튼 */}
         <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
           <DialogClose asChild>
             <Button

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
@@ -1,8 +1,6 @@
 import type { ChangeEvent } from 'react';
 
 export interface EditProfileModalProps {
-  isOpen?: boolean;
-  onClose?: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   initialName?: string;

--- a/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
+++ b/src/app/mypage/_components/edit-profile-modal/edit-profile-modal.types.ts
@@ -1,12 +1,14 @@
 import type { ChangeEvent } from 'react';
 
 export interface EditProfileModalProps {
-  isOpen: boolean;
-  onClose: () => void;
+  isOpen?: boolean;
+  onClose?: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   initialName?: string;
   initialEmail?: string;
   initialImageUrl?: string;
-  onSubmit?: (data: { name: string; email: string }) => void;
+  onSubmit?: (data: { name: string; email: string; imageUrl?: string }) => void;
 }
 
 export interface ProfileFieldProps {
@@ -24,4 +26,5 @@ export interface ModalActionButtonsProps {
 
 export interface ProfileImageEditorProps {
   imageUrl?: string;
+  onChange: (url: string) => void;
 }

--- a/src/app/mypage/_components/meeting-tabs/meeting-tabs-list.tsx
+++ b/src/app/mypage/_components/meeting-tabs/meeting-tabs-list.tsx
@@ -3,7 +3,7 @@ import { MYPAGE_TABS, TabValue } from './meeting-tabs.types';
 
 export function MeetingTabsList() {
   return (
-    <TabsList className="border-sosoeat-gray-200 relative flex h-auto w-full justify-start rounded-none border-b-2 bg-transparent p-0 max-sm:items-center max-sm:justify-center max-sm:border-b">
+    <TabsList className="border-sosoeat-gray-200 relative flex h-auto w-full justify-start rounded-none border-b-2 bg-transparent p-0 max-md:justify-center max-md:border-b">
       {MYPAGE_TABS.map((tab) => (
         <TabsTrigger key={tab.value} value={tab.value}>
           {tab.label}

--- a/src/app/mypage/_components/meeting-tabs/meeting-tabs.tsx
+++ b/src/app/mypage/_components/meeting-tabs/meeting-tabs.tsx
@@ -1,20 +1,75 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { useMeetingTabs } from '../../hooks/use-meeting-tabs';
+import { MyPageCard } from '../mypage-card/mypage-card';
 
 import { Tabs, TabsContent } from './tabs/tabs';
 import { MYPAGE_TABS, TabValue } from './meeting-tabs.types';
 import { MeetingTabsEmpty } from './meeting-tabs-empty';
 import { MeetingTabsList } from './meeting-tabs-list';
 
+const TAB_PARAM_MAP: Record<string, TabValue> = {
+  liked: 'favorite',
+  favorite: 'favorite',
+  created: 'created',
+  all: 'all',
+};
+
 export function MeetingTabs() {
-  const [activeTab, setActiveTab] = useState<TabValue>('all');
-  // 추후 실제 데이터로 교체
-  const isEmpty = true;
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const tabParam = searchParams.get('tab') ?? 'all';
+  const activeTab: TabValue = TAB_PARAM_MAP[tabParam] ?? 'all';
+
+  const setActiveTab = useCallback(
+    (value: TabValue) => {
+      router.push(`/mypage?tab=${value}`);
+    },
+    [router]
+  );
+
+  const { cards: fetchedCards, isLoading } = useMeetingTabs(activeTab);
+
+  const MOCK_CARDS = [
+    {
+      meetingId: 1,
+      title: '힐링 오피스 스트레칭',
+      currentCount: 5,
+      maxCount: 10,
+      location: '강남구',
+      month: 4,
+      day: 30,
+      hour: 18,
+      minute: 0,
+      variant: 'groupEat' as const,
+      confirmedAt: new Date(),
+      isCompleted: false,
+    },
+    {
+      meetingId: 2,
+      title: '점심 같이 먹어요',
+      currentCount: 3,
+      maxCount: 5,
+      location: '마포구',
+      month: 3,
+      day: 15,
+      hour: 12,
+      minute: 30,
+      variant: 'groupBuy' as const,
+      confirmedAt: null,
+      isCompleted: true,
+    },
+  ];
+
+  const cards = fetchedCards.length > 0 ? fetchedCards : MOCK_CARDS;
 
   return (
     <Tabs
-      className="max-w-[1108px] p-6 px-2 max-sm:flex max-sm:w-full max-sm:flex-col"
+      className="mx-auto w-full max-w-[1140px] p-6 px-2"
       value={activeTab}
       onValueChange={(v) => setActiveTab(v as TabValue)}
     >
@@ -26,11 +81,16 @@ export function MeetingTabs() {
           value={tab.value}
           className="w-full items-center justify-center"
         >
-          {isEmpty ? (
+          {isLoading ? (
+            <div className="py-40 text-center text-sm text-gray-400">불러오는 중...</div>
+          ) : cards.length === 0 ? (
             <MeetingTabsEmpty />
           ) : (
-            // 추후 MeetingTabsListContent으로 교체
-            <div>모임 목록</div>
+            <div className="flex flex-col items-center gap-4 py-4 lg:flex-row">
+              {cards.map((card) => (
+                <MyPageCard key={card.meetingId} {...card} />
+              ))}
+            </div>
           )}
         </TabsContent>
       ))}

--- a/src/app/mypage/_components/meeting-tabs/meeting-tabs.tsx
+++ b/src/app/mypage/_components/meeting-tabs/meeting-tabs.tsx
@@ -69,7 +69,7 @@ export function MeetingTabs() {
 
   return (
     <Tabs
-      className="mx-auto w-full max-w-[1140px] p-6 px-2"
+      className="mx-auto w-full max-w-285 p-6"
       value={activeTab}
       onValueChange={(v) => setActiveTab(v as TabValue)}
     >
@@ -86,7 +86,7 @@ export function MeetingTabs() {
           ) : cards.length === 0 ? (
             <MeetingTabsEmpty />
           ) : (
-            <div className="flex flex-col items-center gap-4 py-4 lg:flex-row">
+            <div className="flex flex-col items-center gap-4 py-4 lg:flex-row lg:flex-wrap lg:justify-center">
               {cards.map((card) => (
                 <MyPageCard key={card.meetingId} {...card} />
               ))}

--- a/src/app/mypage/_components/meeting-tabs/tabs/tabs.tsx
+++ b/src/app/mypage/_components/meeting-tabs/tabs/tabs.tsx
@@ -59,7 +59,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
       className={cn(
         'relative rounded-none border-transparent bg-transparent px-8 pb-5 text-xl font-semibold text-gray-400',
         'shadow-none transition-colors after:absolute after:bottom-2 after:left-0 after:h-0.5 after:w-full after:bg-transparent data-[state=active]:text-orange-600 data-[state=active]:after:bg-orange-500',
-        'max-sm:w-full max-sm:items-center max-sm:px-0 max-sm:text-sm max-sm:after:bottom-1',
+        'max-md:w-full max-md:items-center max-md:px-0 max-md:text-sm max-md:after:bottom-1',
 
         className
       )}

--- a/src/app/mypage/_components/mypage-card/mypage-card.stories.tsx
+++ b/src/app/mypage/_components/mypage-card/mypage-card.stories.tsx
@@ -26,17 +26,35 @@ export default meta;
 type Story = StoryObj<typeof MyPageCard>;
 
 export const GroupEat: Story = {
+  name: '함께먹기',
   args: {},
 };
 
 export const GroupBuy: Story = {
+  name: '공동구매',
   args: {
     variant: 'groupBuy',
   },
 };
 
 export const Unconfirmed: Story = {
+  name: '개설대기',
   args: {
     confirmedAt: null,
+  },
+};
+
+export const Completed1: Story = {
+  name: '이용예정',
+  args: {
+    isCompleted: false,
+  },
+};
+
+export const Completed2: Story = {
+  name: '이용완료',
+  args: {
+    variant: 'groupBuy',
+    isCompleted: true,
   },
 };

--- a/src/app/mypage/_components/mypage-card/mypage-card.tsx
+++ b/src/app/mypage/_components/mypage-card/mypage-card.tsx
@@ -60,18 +60,34 @@ function InfoItem({ Icon, text }: { Icon: LucideIcon; text: string }) {
 // 상태 뱃지
 function StatusBadgeGroup({
   confirmedAt,
+  isCompleted,
+  isFavorited,
   variant,
   meetingId,
 }: {
   confirmedAt: Date | null;
+  isCompleted: boolean;
+  isFavorited: boolean;
   variant: Variant;
   meetingId: number;
 }) {
   return (
     <div className="flex items-center gap-2">
-      <UseStateBadge variant={variant}></UseStateBadge>
-      <EstablishmentStatusBadge confirmedAt={confirmedAt} variant={variant} />
-      <HeartButton className="relative -top-2 left-1 ml-16 max-md:hidden" meetingId={meetingId} />
+      {isCompleted ? (
+        <UseStateBadge variant={variant} status="completed" />
+      ) : confirmedAt ? (
+        <>
+          <UseStateBadge variant={variant} status="upcoming" />
+          <EstablishmentStatusBadge confirmedAt={confirmedAt} variant={variant} />
+        </>
+      ) : (
+        <EstablishmentStatusBadge confirmedAt={null} variant={variant} />
+      )}
+      <HeartButton
+        className="relative -top-3 left-0 ml-auto max-md:hidden"
+        meetingId={meetingId}
+        isFavorited={isFavorited}
+      />
     </div>
   );
 }
@@ -87,6 +103,8 @@ export function MyPageCard({
   hour,
   minute,
   confirmedAt = null,
+  isCompleted = false,
+  isFavorited = false,
   imageUrl = DEFAULT_IMAGE_URL,
   imageAlt,
   variant,
@@ -96,18 +114,22 @@ export function MyPageCard({
     <Card
       className={cn(
         'flex overflow-hidden rounded-4xl border-none p-0 shadow-none',
-        'gap-0 max-md:w-[343px] max-md:flex-col md:h-60 md:w-[530px] md:flex-row md:items-center md:gap-4 md:px-4',
+        'gap-0 max-md:w-85.75 max-md:flex-col md:h-60 md:w-132.5 md:flex-row md:items-center md:gap-4 md:px-4',
         className
       )}
     >
       {/* 이미지 */}
-      <div className="relative shrink-0 overflow-hidden max-md:h-[156px] max-md:w-full max-md:rounded-t-4xl md:size-47 md:rounded-2xl">
+      <div className="relative shrink-0 overflow-hidden max-md:h-39 max-md:w-full max-md:rounded-t-4xl md:size-47 md:rounded-2xl">
         <Image src={imageUrl} alt={imageAlt ?? title} fill className="object-cover" />
 
         {/* 이미지 위 오버레이 (모바일 전용) */}
         <div className="absolute top-1 right-4 left-4 flex items-center justify-between md:hidden">
           <VariantBadge variant={variant} />
-          <HeartButton className="relative top-3 left-1" meetingId={meetingId} />
+          <HeartButton
+            className="relative top-3 left-1"
+            meetingId={meetingId}
+            isFavorited={isFavorited}
+          />
         </div>
       </div>
 
@@ -120,7 +142,13 @@ export function MyPageCard({
 
         {/* 상태 뱃지 (모바일) */}
         <div className="py-2 md:hidden">
-          <StatusBadgeGroup confirmedAt={confirmedAt} variant={variant} meetingId={meetingId} />
+          <StatusBadgeGroup
+            confirmedAt={confirmedAt}
+            isCompleted={isCompleted}
+            isFavorited={isFavorited}
+            variant={variant}
+            meetingId={meetingId}
+          />
         </div>
 
         {/* 제목 / 인원 */}
@@ -143,7 +171,13 @@ export function MyPageCard({
 
         {/* 상태 뱃지 (웹) */}
         <div className="mt-4 hidden md:block">
-          <StatusBadgeGroup confirmedAt={confirmedAt} variant={variant} meetingId={meetingId} />
+          <StatusBadgeGroup
+            confirmedAt={confirmedAt}
+            isCompleted={isCompleted}
+            isFavorited={isFavorited}
+            variant={variant}
+            meetingId={meetingId}
+          />
         </div>
       </div>
     </Card>

--- a/src/app/mypage/_components/mypage-card/mypage-card.types.ts
+++ b/src/app/mypage/_components/mypage-card/mypage-card.types.ts
@@ -12,5 +12,8 @@ export interface MyPageCardProps {
   imageAlt?: string;
   variant: 'groupBuy' | 'groupEat';
   confirmedAt?: Date | null;
+  isCompleted?: boolean;
+  isHost?: boolean;
+  isFavorited?: boolean;
   className?: string;
 }

--- a/src/app/mypage/_components/user-card/user-card.stories.tsx
+++ b/src/app/mypage/_components/user-card/user-card.stories.tsx
@@ -20,7 +20,7 @@ export const Default: Story = {
   args: {
     name: '김민준',
     joinedAt: '2024-01-15',
-    email: '1인 가구 3년차입니다. 식재료 낭비 없이 알뜰하게 살고 싶어요!',
+    email: 'minjun.kim@example.com',
     className: 'bg-sosoeat-gray-100',
   },
 };

--- a/src/app/mypage/_components/user-card/user-card.stories.tsx
+++ b/src/app/mypage/_components/user-card/user-card.stories.tsx
@@ -8,9 +8,8 @@ const meta: Meta<typeof UserCard> = {
   tags: ['autodocs'],
   argTypes: {
     name: { control: 'text' },
-    location: { control: 'text' },
     joinedAt: { control: 'text' },
-    bio: { control: 'text' },
+    email: { control: 'text' },
   },
 };
 
@@ -20,9 +19,8 @@ type Story = StoryObj<typeof UserCard>;
 export const Default: Story = {
   args: {
     name: '김민준',
-    location: '서울 강남구',
     joinedAt: '2024-01-15',
-    bio: '1인 가구 3년차입니다. 식재료 낭비 없이 알뜰하게 살고 싶어요!',
+    email: '1인 가구 3년차입니다. 식재료 낭비 없이 알뜰하게 살고 싶어요!',
     className: 'bg-sosoeat-gray-100',
   },
 };

--- a/src/app/mypage/_components/user-card/user-card.tsx
+++ b/src/app/mypage/_components/user-card/user-card.tsx
@@ -43,7 +43,7 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
       >
         <CardHeader>
           <div className="flex items-center gap-6 md:hidden">
-            <Avatar className="r h-[83px] w-[83px] shrink-0 border-2 border-white">
+            <Avatar className="h-[83px] w-[83px] shrink-0 border-2 border-white">
               <AvatarImage src={localImageUrl} />
               <AvatarFallback></AvatarFallback>
             </Avatar>

--- a/src/app/mypage/_components/user-card/user-card.tsx
+++ b/src/app/mypage/_components/user-card/user-card.tsx
@@ -1,63 +1,101 @@
-import { Calendar, MapPin, Pencil } from 'lucide-react';
+'use client';
+
+import { useState } from 'react';
+
+import { Calendar, Mail, Pencil } from 'lucide-react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
+
+import { mypageRepository } from '../../repositories/mypage.repository';
+import { EditProfileModal } from '../edit-profile-modal';
 
 import { UserCardProps } from './user-card.types';
 
-export function UserCard({ name, location, joinedAt, bio, className }: UserCardProps) {
-  return (
-    <Card
-      className={cn(
-        'bg-sosoeat-orange-100 gap-2 ring-0',
-        'md:bg-sosoeat-gray-100',
-        'h-28.75 w-120 md:h-full md:w-full'
-      )}
-    >
-      <CardHeader>
-        <div className="flex items-center gap-2 md:hidden">
-          <Avatar className="size-20 shrink-0">
-            <AvatarImage />
-            <AvatarFallback></AvatarFallback>
-          </Avatar>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <CardTitle className={cn('text-base font-bold')}>{name}</CardTitle>
-              <Pencil className="text-sosoeat-gray-600 size-3 shrink-0" />
-            </div>
-            {joinedAt && (
-              <span className="bg-sosoeat-orange-200 text-sosoeat-gray-600 flex items-center gap-1 rounded-2xl px-4 py-1.5 text-xs ring-0">
-                <Calendar className={cn('size-3')} /> {joinedAt} 가입
-              </span>
-            )}
-          </div>
-        </div>
+export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCardProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [localName, setLocalName] = useState(name);
+  const [localEmail, setLocalEmail] = useState(email);
+  const [localImageUrl, setLocalImageUrl] = useState(imageUrl);
 
-        <div className="hidden md:block">
-          <CardTitle className="w-full text-base font-bold">{name}</CardTitle>
-          <CardDescription>
-            <span className="text-sosoeat-gray-600 flex gap-x-3 gap-y-1 text-xs">
-              {location && (
-                <span className="flex items-center gap-1">
-                  <MapPin className={cn('size-3')} /> {location}
-                </span>
-              )}
+  const handleProfileUpdate = async (data: { name: string; email: string; imageUrl?: string }) => {
+    const updated = await mypageRepository.patchMe({
+      name: data.name,
+      email: data.email,
+      image: data.imageUrl,
+    });
+    if (updated) {
+      setLocalName(updated.name);
+      setLocalEmail(updated.email);
+      setLocalImageUrl(updated.image);
+    }
+  };
+
+  return (
+    <div className={cn('relative w-full p-4', className)}>
+      <Card
+        className={cn(
+          'bg-sosoeat-orange-100 ring-0',
+          'md:bg-sosoeat-gray-100',
+          'h-28.75 w-full md:h-full md:w-full'
+        )}
+      >
+        <CardHeader>
+          <div className="flex items-center gap-6 md:hidden">
+            <Avatar className="r h-[83px] w-[83px] shrink-0 border-2 border-white">
+              <AvatarImage src={localImageUrl} />
+              <AvatarFallback></AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center py-1">
+                <CardTitle className={cn('px-2 text-base font-bold')}>{localName}</CardTitle>
+                <button onClick={() => setModalOpen(true)}>
+                  <Pencil className="text-sosoeat-gray-600 size-3 shrink-0" />
+                </button>
+              </div>
               {joinedAt && (
-                <span className="bg-sosoeat-gray-100 flex items-center gap-1 rounded-2xl px-1 py-1.5 ring-0">
+                <span className="bg-sosoeat-orange-200 text-sosoeat-gray-600 flex items-center gap-1 rounded-2xl px-4 py-2 text-xs ring-0">
                   <Calendar className={cn('size-3')} /> {joinedAt} 가입
                 </span>
               )}
-            </span>
-          </CardDescription>
-        </div>
-      </CardHeader>
+            </div>
+          </div>
 
-      {bio && (
-        <CardContent className="hidden md:block">
-          <p className="text-sosoeat-gray-700 text-xs">{bio}</p>
-        </CardContent>
-      )}
-    </Card>
+          <div className="hidden items-center gap-6 md:flex">
+            <Avatar className="h-42.25 w-42.25 shrink-0">
+              <AvatarImage src={localImageUrl} />
+              <AvatarFallback></AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col gap-1">
+              <CardTitle className="w-full text-[28px] font-bold">{localName}</CardTitle>
+              <CardDescription className="text-sosoeat-gray-600 flex flex-col text-sm">
+                {joinedAt && (
+                  <span className="flex items-center gap-1 py-3">
+                    <Calendar className={cn('size-3')} /> {joinedAt} 가입
+                  </span>
+                )}
+                {localEmail && (
+                  <span className="flex items-center gap-1">
+                    <Mail className={cn('size-3')} /> {localEmail}
+                  </span>
+                )}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <div className="absolute top-4 right-0 p-5">
+        <EditProfileModal
+          open={modalOpen}
+          onOpenChange={setModalOpen}
+          initialEmail={localEmail}
+          initialName={localName}
+          initialImageUrl={localImageUrl}
+          onSubmit={handleProfileUpdate}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/app/mypage/_components/user-card/user-card.types.ts
+++ b/src/app/mypage/_components/user-card/user-card.types.ts
@@ -1,7 +1,7 @@
 export interface UserCardProps {
   name: string;
-  location: string;
-  joinedAt: string;
-  bio: string;
+  joinedAt?: string;
+  email?: string;
+  imageUrl?: string;
   className?: string;
 }

--- a/src/app/mypage/_services/mypage.queries.ts
+++ b/src/app/mypage/_services/mypage.queries.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+import { UpdateUserRequest } from '@/types/generated-client';
+
+import { mypageRepository } from '../repositories/mypage.repository';
+
+export const mypageQueryKeys = {
+  joinedMeetings: ['mypage-joined-meetings'] as const,
+  createdMeetings: ['mypage-created-meetings'] as const,
+  favoriteMeetings: ['mypage-favorite-meetings'] as const,
+};
+
+export const useJoinedMeetings = (enabled = true) =>
+  useQuery({
+    queryKey: mypageQueryKeys.joinedMeetings,
+    queryFn: mypageRepository.fetchJoinedMeetings,
+    enabled,
+  });
+
+export const useCreatedMeetings = (enabled = true) =>
+  useQuery({
+    queryKey: mypageQueryKeys.createdMeetings,
+    queryFn: mypageRepository.fetchCreatedMeetings,
+    enabled,
+  });
+
+export const useFavoriteMeetings = (enabled = true) =>
+  useQuery({
+    queryKey: mypageQueryKeys.favoriteMeetings,
+    queryFn: mypageRepository.fetchFavoriteMeetings,
+    enabled,
+    refetchOnMount: 'always',
+  });
+
+export const usePatchMe = () =>
+  useMutation({
+    mutationFn: (body: UpdateUserRequest) => mypageRepository.patchMe(body),
+  });

--- a/src/app/mypage/_services/mypage.service.ts
+++ b/src/app/mypage/_services/mypage.service.ts
@@ -1,0 +1,60 @@
+import {
+  FavoriteList,
+  UserMeeting,
+  UserMeetingRoleEnum,
+  UserMeetingsResponse,
+} from '@/types/generated-client';
+
+import { MyPageCardProps } from '../_components/mypage-card/mypage-card.types';
+
+const parseDateTime = (dateTime: Date | string) => {
+  const date = new Date(dateTime);
+  return {
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+    hour: date.getHours(),
+    minute: date.getMinutes(),
+  };
+};
+
+const isCompleted = (dateTime: Date | string) => new Date(dateTime) < new Date();
+
+const toVariant = (type?: string): 'groupBuy' | 'groupEat' =>
+  type === 'groupBuy' ? 'groupBuy' : 'groupEat';
+
+const toImageUrl = (image?: string) => (image?.startsWith('https://') ? image : undefined);
+
+const toMeetingCard = (m: UserMeeting): MyPageCardProps => ({
+  meetingId: m.id,
+  title: m.name,
+  currentCount: m.participantCount,
+  maxCount: m.capacity,
+  location: m.region,
+  ...parseDateTime(m.dateTime),
+  variant: 'groupEat',
+  isCompleted: isCompleted(m.dateTime),
+  isHost: m.role === UserMeetingRoleEnum.Host,
+  isFavorited: false,
+});
+
+export const toJoinedMeetingCards = (data: UserMeetingsResponse): MyPageCardProps[] =>
+  data.data.map(toMeetingCard);
+
+export const toCreatedMeetingCards = (data: UserMeetingsResponse): MyPageCardProps[] =>
+  data.data.map(toMeetingCard);
+
+export const toFavoriteMeetingCards = (data: FavoriteList): MyPageCardProps[] =>
+  data.data.map((f) => ({
+    meetingId: f.meeting.id,
+    title: f.meeting.name,
+    currentCount: f.meeting.participantCount,
+    maxCount: f.meeting.capacity,
+    location: f.meeting.region,
+    ...parseDateTime(f.meeting.dateTime),
+    variant: toVariant(f.meeting.type),
+    imageUrl: toImageUrl(f.meeting.image),
+    confirmedAt: f.meeting.confirmedAt ?? null,
+    isCompleted: isCompleted(f.meeting.dateTime),
+    isHost: false,
+    isFavorited: true,
+  }));

--- a/src/app/mypage/hooks/use-meeting-tabs.ts
+++ b/src/app/mypage/hooks/use-meeting-tabs.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { TabValue } from '../_components/meeting-tabs/meeting-tabs.types';
+import {
+  useCreatedMeetings,
+  useFavoriteMeetings,
+  useJoinedMeetings,
+} from '../_services/mypage.queries';
+import {
+  toCreatedMeetingCards,
+  toFavoriteMeetingCards,
+  toJoinedMeetingCards,
+} from '../_services/mypage.service';
+
+export function useMeetingTabs(activeTab: TabValue) {
+  const joinedQuery = useJoinedMeetings(activeTab === 'all');
+  const createdQuery = useCreatedMeetings(activeTab === 'created');
+  const favoriteQuery = useFavoriteMeetings(activeTab === 'favorite');
+
+  const cards = useMemo(() => {
+    if (activeTab === 'all' && joinedQuery.data) {
+      return toJoinedMeetingCards(joinedQuery.data);
+    }
+    if (activeTab === 'created' && createdQuery.data) {
+      return toCreatedMeetingCards(createdQuery.data);
+    }
+    if (activeTab === 'favorite' && favoriteQuery.data) {
+      return toFavoriteMeetingCards(favoriteQuery.data);
+    }
+    return [];
+  }, [activeTab, joinedQuery.data, createdQuery.data, favoriteQuery.data]);
+
+  const isLoading =
+    (activeTab === 'all' && joinedQuery.isLoading) ||
+    (activeTab === 'created' && createdQuery.isLoading) ||
+    (activeTab === 'favorite' && favoriteQuery.isLoading);
+
+  return { cards, isLoading };
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -28,7 +28,6 @@ export default async function MyPage() {
           imageUrl={user?.image}
           className="lg:max-w-276"
         />
-        <div className="absolute top-15 right-25"></div>
       </div>
 
       <div className="flex flex-row justify-center gap-5 md:p-5">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -9,13 +9,15 @@ import {
   fetchFavoriteCountServer,
   fetchMeetingCountServer,
   fetchMeServer,
+  fetchPostCountServer,
 } from './repositories/mypage.repository.server';
 
 export default async function MyPage() {
-  const [user, meetingCount, favoriteCount] = await Promise.all([
-    fetchMeServer(),
+  const user = await fetchMeServer();
+  const [meetingCount, favoriteCount, postCount] = await Promise.all([
     fetchMeetingCountServer(),
     fetchFavoriteCountServer(),
+    user ? fetchPostCountServer(user.id) : Promise.resolve(0),
   ]);
 
   return (
@@ -33,7 +35,7 @@ export default async function MyPage() {
       <div className="flex flex-row justify-center gap-5 md:p-5">
         <CountCard variant="meeting" count={meetingCount} />
         <CountCard variant="favorite" count={favoriteCount} />
-        <CountCard variant="post" count={5} />
+        <CountCard variant="post" count={postCount} />
       </div>
 
       <Suspense>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,45 @@
+import { Suspense } from 'react';
+
+import { format } from 'date-fns';
+
+import { CountCard } from './_components/count-card';
+import { MeetingTabs } from './_components/meeting-tabs';
+import { UserCard } from './_components/user-card';
+import {
+  fetchFavoriteCountServer,
+  fetchMeetingCountServer,
+  fetchMeServer,
+} from './repositories/mypage.repository.server';
+
+export default async function MyPage() {
+  const [user, meetingCount, favoriteCount] = await Promise.all([
+    fetchMeServer(),
+    fetchMeetingCountServer(),
+    fetchFavoriteCountServer(),
+  ]);
+
+  return (
+    <div className="bg-sosoeat-gray-100 min-h-screen">
+      <div className="relative flex justify-center">
+        <UserCard
+          name={user?.name ?? ''}
+          joinedAt={user ? format(user.createdAt, 'yyyy.MM.dd') : undefined}
+          email={user?.email}
+          imageUrl={user?.image}
+          className="lg:max-w-276"
+        />
+        <div className="absolute top-15 right-25"></div>
+      </div>
+
+      <div className="flex flex-row justify-center gap-5 md:p-5">
+        <CountCard variant="meeting" count={meetingCount} />
+        <CountCard variant="favorite" count={favoriteCount} />
+        <CountCard variant="post" count={5} />
+      </div>
+
+      <Suspense>
+        <MeetingTabs />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/mypage/repositories/mypage.repository.server.ts
+++ b/src/app/mypage/repositories/mypage.repository.server.ts
@@ -20,3 +20,10 @@ export const fetchFavoriteCountServer = async (): Promise<number> => {
   const data: FavoriteCount = await res.json();
   return data.count;
 };
+
+export const fetchPostCountServer = async (userId: number): Promise<number> => {
+  const res = await apiServer.get(`/articles?authorId=${userId}`, { cache: 'no-store' });
+  if (!res.ok) return 0;
+  const data = await res.json();
+  return data.totalCount ?? 0;
+};

--- a/src/app/mypage/repositories/mypage.repository.server.ts
+++ b/src/app/mypage/repositories/mypage.repository.server.ts
@@ -1,0 +1,37 @@
+import { CookieStorage } from '@/lib/auth/cookie-storage';
+import { FavoriteCount, User, UserMeetingsResponse } from '@/types/generated-client';
+
+const BASE_URL = process.env.API_BASE_URL;
+const TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID;
+
+export const fetchMeServer = async (): Promise<User | null> => {
+  const token = await CookieStorage.getAccessToken();
+  const res = await fetch(`${BASE_URL}/${TEAM_ID}/users/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) return null;
+  return res.json();
+};
+
+export const fetchMeetingCountServer = async (): Promise<number> => {
+  const token = await CookieStorage.getAccessToken();
+  const res = await fetch(`${BASE_URL}/${TEAM_ID}/users/me/meetings?size=9999`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) return 0;
+  const data: UserMeetingsResponse = await res.json();
+  return data.data.length;
+};
+
+export const fetchFavoriteCountServer = async (): Promise<number> => {
+  const token = await CookieStorage.getAccessToken();
+  const res = await fetch(`${BASE_URL}/${TEAM_ID}/favorites/count`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) return 0;
+  const data: FavoriteCount = await res.json();
+  return data.count;
+};

--- a/src/app/mypage/repositories/mypage.repository.server.ts
+++ b/src/app/mypage/repositories/mypage.repository.server.ts
@@ -1,36 +1,21 @@
-import { CookieStorage } from '@/lib/auth/cookie-storage';
+import { apiServer } from '@/lib/http/api-server';
 import { FavoriteCount, User, UserMeetingsResponse } from '@/types/generated-client';
 
-const BASE_URL = process.env.API_BASE_URL;
-const TEAM_ID = process.env.NEXT_PUBLIC_TEAM_ID;
-
 export const fetchMeServer = async (): Promise<User | null> => {
-  const token = await CookieStorage.getAccessToken();
-  const res = await fetch(`${BASE_URL}/${TEAM_ID}/users/me`, {
-    headers: { Authorization: `Bearer ${token}` },
-    cache: 'no-store',
-  });
+  const res = await apiServer.get('/users/me', { cache: 'no-store' });
   if (!res.ok) return null;
   return res.json();
 };
 
 export const fetchMeetingCountServer = async (): Promise<number> => {
-  const token = await CookieStorage.getAccessToken();
-  const res = await fetch(`${BASE_URL}/${TEAM_ID}/users/me/meetings?size=9999`, {
-    headers: { Authorization: `Bearer ${token}` },
-    cache: 'no-store',
-  });
+  const res = await apiServer.get('/users/me/meetings?size=9999', { cache: 'no-store' });
   if (!res.ok) return 0;
   const data: UserMeetingsResponse = await res.json();
   return data.data.length;
 };
 
 export const fetchFavoriteCountServer = async (): Promise<number> => {
-  const token = await CookieStorage.getAccessToken();
-  const res = await fetch(`${BASE_URL}/${TEAM_ID}/favorites/count`, {
-    headers: { Authorization: `Bearer ${token}` },
-    cache: 'no-store',
-  });
+  const res = await apiServer.get('/favorites/count', { cache: 'no-store' });
   if (!res.ok) return 0;
   const data: FavoriteCount = await res.json();
   return data.count;

--- a/src/app/mypage/repositories/mypage.repository.ts
+++ b/src/app/mypage/repositories/mypage.repository.ts
@@ -1,0 +1,33 @@
+import { fetchClient } from '@/lib/http/fetch-client';
+import {
+  FavoriteList,
+  UpdateUserRequest,
+  User,
+  UserMeetingsResponse,
+} from '@/types/generated-client';
+
+export const mypageRepository = {
+  patchMe: async (body: UpdateUserRequest): Promise<User | null> => {
+    const res = await fetchClient.patch('/users/me', body);
+    if (!res.ok) return null;
+    return res.json();
+  },
+
+  fetchJoinedMeetings: async (): Promise<UserMeetingsResponse> => {
+    const res = await fetchClient.get('/users/me/meetings?type=joined');
+    if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
+    return res.json();
+  },
+
+  fetchCreatedMeetings: async (): Promise<UserMeetingsResponse> => {
+    const res = await fetchClient.get('/users/me/meetings?type=created');
+    if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
+    return res.json();
+  },
+
+  fetchFavoriteMeetings: async (): Promise<FavoriteList> => {
+    const res = await fetchClient.get('/favorites');
+    if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
+    return res.json();
+  },
+};

--- a/src/components/common/use-state-badge/use-state-badge.tsx
+++ b/src/components/common/use-state-badge/use-state-badge.tsx
@@ -8,7 +8,12 @@ const usageVariantClassName = {
   groupBuy: 'border-0 bg-sosoeat-blue-50 text-sosoeat-blue-700',
 } as const;
 
-export function UseStateBadge({ variant, className }: UseStateBadgeProps) {
+const STATUS_LABEL: Record<UseStateBadgeProps['status'], string> = {
+  upcoming: '이용예정',
+  completed: '이용완료',
+};
+
+export function UseStateBadge({ variant, status, className }: UseStateBadgeProps) {
   return (
     <Badge
       variant="outline"
@@ -18,7 +23,7 @@ export function UseStateBadge({ variant, className }: UseStateBadgeProps) {
         className
       )}
     >
-      이용 예정
+      {STATUS_LABEL[status]}
     </Badge>
   );
 }

--- a/src/components/common/use-state-badge/use-state-badge.types.ts
+++ b/src/components/common/use-state-badge/use-state-badge.types.ts
@@ -1,4 +1,5 @@
 export interface UseStateBadgeProps {
   variant: 'groupEat' | 'groupBuy';
+  status: 'upcoming' | 'completed';
   className?: string;
 }


### PR DESCRIPTION
## [Feat] 마이페이지 API 연동 및 UI 개선 

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 마이페이지 데이터 레이어 구성 — repository / service / query / hook 추가 및 page.tsx API 연동
- UseStateBadge에 status prop 추가 — 이용예정 / 이용완료 상태 동적 처리
- EditProfileModal 이미지 업로드 실제 연동 (presigned URL) 및 외부 open/onOpenChange 제어 지원
- UserCard props 변경 (location/bio → email/imageUrl), 프로필 수정 모달 연동 및 데스크톱 UI 개선
- MyPageCard에 isCompleted/isFavorited props 추가 및 상태 뱃지 로직 개선
- MeetingTabs URL 파라미터 기반 탭 상태 관리 및 API 데이터 연동
- CountCard, TabsTrigger 반응형 브레이크포인트 스타일 수정

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 앱을 실행합니다.
2. 로그인 후 /mypage로 이동합니다.
3. 유저 카드의 연필 아이콘 클릭 → 프로필 수정 모달이 열리는지 확인합니다.
4. 모달에서 이미지 변경 → 업로드 후 프로필 이미지가 즉시 반영되는지 확인합니다.
5. 탭 전환 (전체 / 생성한 모임 / 찜한 모임) → URL 파라미터(?tab=...)가 변경되고 해당 데이터가 로드되는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

<img width="1611" height="807" alt="image" src="https://github.com/user-attachments/assets/83a0f284-6cc5-47e9-98e8-0b114147d1f0" />

### 🚨 기타 참고 사항 (Notes)

- [ ] 마이페이지 모임 카드는 mock 데이터입니다.
- [ ] 게시글 작성 count-card 부분은 아직 API 미연동 상태입니다.