### PR TITLE
[Fix]: 소소톡 댓글 수정 입력 UI 정리 (#185)

### DIFF
--- a/src/components/common/comment-input/comment-input.tsx
+++ b/src/components/common/comment-input/comment-input.tsx
@@ -20,6 +20,7 @@ export function CommentInput({
   submitLabel = '댓글 전송',
   currentUserName = '사용자',
   currentUserImageUrl,
+  showAvatar = true,
   submitOnEnter = true,
   className,
 }: CommentInputProps) {
@@ -48,12 +49,14 @@ export function CommentInput({
 
   return (
     <div className={cn('flex items-center gap-3 sm:gap-4', className)}>
-      <Avatar size="default" className="h-[54px] w-[54px] shrink-0">
-        <AvatarImage src={currentUserImageUrl} alt={currentUserName} />
-        <AvatarFallback className="text-sm font-semibold">
-          {currentUserName.slice(0, 1)}
-        </AvatarFallback>
-      </Avatar>
+      {showAvatar ? (
+        <Avatar size="default" className="h-[54px] w-[54px] shrink-0">
+          <AvatarImage src={currentUserImageUrl} alt={currentUserName} />
+          <AvatarFallback className="text-sm font-semibold">
+            {currentUserName.slice(0, 1)}
+          </AvatarFallback>
+        </Avatar>
+      ) : null}
 
       <div className="bg-sosoeat-gray-300 flex min-h-[46px] min-w-0 flex-1 items-end gap-3 rounded-[24px] py-2 pr-[14px] pl-5 sm:pr-[14px] sm:pl-6">
         <Textarea
@@ -88,7 +91,7 @@ export function CommentInput({
           onClick={handleSubmit}
           className="text-sosoeat-gray-700 hover:text-sosoeat-gray-800 disabled:text-sosoeat-gray-500 mb-0.5 size-9 shrink-0 self-end rounded-full bg-transparent p-0 shadow-none transition-[transform,color,background-color,box-shadow] duration-150 ease-out hover:-translate-y-0.5 hover:bg-white/70 hover:shadow-[0_4px_12px_rgba(30,30,30,0.08)] active:translate-y-0 active:scale-95 active:bg-white/85 disabled:rounded-none disabled:bg-transparent disabled:shadow-none"
         >
-          <Send className="mt-0.5 size-6 fill-current" />
+          <Send className="mt-0.5 size-5 fill-current" />
         </Button>
       </div>
     </div>

--- a/src/components/common/comment-input/comment-input.types.ts
+++ b/src/components/common/comment-input/comment-input.types.ts
@@ -7,6 +7,7 @@ export interface CommentInputProps {
   submitLabel?: string;
   currentUserName?: string;
   currentUserImageUrl?: string;
+  showAvatar?: boolean;
   submitOnEnter?: boolean;
   className?: string;
 }

--- a/src/components/common/comment-item/comment-item.tsx
+++ b/src/components/common/comment-item/comment-item.tsx
@@ -92,6 +92,7 @@ export function CommentItem({
               submitLabel="댓글 수정"
               currentUserName={authorName}
               currentUserImageUrl={authorImageUrl}
+              showAvatar={false}
             />
             <div className="flex justify-end">
               <button


### PR DESCRIPTION
### 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경
- [ ] **Style (스타일):** 코드 포맷, 주석, 스타일 수정
- [ ] **Chore (기타):** 빌드, 설정, 의존성 변경

### 변경 사항 (Changes)

- #185
- 소소톡 댓글 수정 상태에서 프로필 이미지가 좌측에 중복으로 보이던 문제를 수정했습니다.
- `CommentInput`에 `showAvatar` 옵션을 추가해서, 기본 댓글 입력창에서는 기존처럼 프로필을 유지하고 댓글 수정 모드에서만 아바타를 숨기도록 분리했습니다.
- 전송 버튼 호버 시 흰색 원 안에서 전송 아이콘이 너무 꽉 차 보이던 부분도 함께 조정했습니다.

### 테스트 방법 (How to Test)

1. 소소톡 게시글 상세 페이지로 이동합니다.
2. 본인 댓글에서 `수정하기`를 클릭합니다.
3. 댓글 수정 UI에서 좌측 프로필 이미지가 1개만 보이는지 확인합니다.
4. 수정 입력창의 전송 버튼에 마우스를 올립니다.
5. 호버 시 흰색 원과 전송 아이콘 비율이 자연스럽게 보이는지 확인합니다.

### 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
| 댓글 수정 시 프로필 이미지 중복 노출 | 댓글 수정 시 프로필 이미지 1개만 노출 |

### 기타 참고 사항 (Notes)

- [ ] 코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.
- [ ] 배포 시점에 고려해야 할 사항이 있다면 명시해주세요.