### PR TITLE
PR 제목: [Fix]: 모임 정렬 선택값이 API 요청에 반영되지 않는 문제 수정

### DIFF
--- a/src/app/meetings/usehooks/use-meeting-page.ts
+++ b/src/app/meetings/usehooks/use-meeting-page.ts
@@ -35,8 +35,8 @@ const useMeetingPage = () => {
       dateEnd == null
         ? undefined
         : new Date(dateEnd.getFullYear(), dateEnd.getMonth(), dateEnd.getDate() + 1),
-    sortBy: sortBy ? undefined : sortBy,
-    sortOrder: sortOrder ? undefined : sortOrder,
+    sortBy: sortBy,
+    sortOrder: sortOrder,
   };
 
   const handleTypeFilterChange = (value: 'all' | 'groupEat' | 'groupBuy') => {


### PR DESCRIPTION
## PR 제목: [Fix]: 모임 정렬 선택값이 API 요청에 반영되지 않는 문제 수정

### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 모임찾기 정렬 드롭다운 선택 시, `sortBy`/`sortOrder`가 요청에 반영되지 않던 버그를 수정했습니다.
- 원인:
  - `sortBy: sortBy ? undefined : sortBy`
  - `sortOrder: sortOrder ? undefined : sortOrder`
  - 상태값이 존재할 때 오히려 `undefined`가 들어가도록 조건이 반대로 작성되어 있었음
- 수정:
  - `sortBy: sortBy`
  - `sortOrder: sortOrder`
- 관련 파일:
  - use-meeting-page.ts

### 🧪 테스트 방법 (How to Test)

1. 로컬에서 앱 실행 후 `/meetings` 페이지로 이동합니다.
2. 정렬 드롭다운에서 아래 옵션을 순서대로 선택합니다.
   - 인기순
   - 모임일 임박순
   - 모집 마감 임박 순
   - 모집 마감 먼 순
3. 네트워크 요청 파라미터에 `sortBy`/`sortOrder`가 선택값과 일치하는지 확인합니다.
4. 목록 정렬 순서가 선택값에 따라 변경되는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- 확인 포인트:
  - 정렬 선택 시 `useMeetingPage`의 options 생성 로직
  - `MeetingFilterBar`의 선택 상태와 실제 API 요청 동기화 여부
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**