### PR TITLE
[Feat]: 모임 상세 페이지 코어 API·UI 연동

### DIFF
--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.tsx
@@ -19,8 +19,8 @@ interface MeetingCommentItemProps {
 // ─── MeetingCommentItem ───────────────────────────────────────
 
 export function MeetingCommentItem({ comment, isReply = false }: MeetingCommentItemProps) {
+  // mutation 연동 시 comment.id 사용
   const {
-    id: _id, // TODO: 좋아요/수정/삭제 mutation에서 사용 예정
     author,
     content,
     isDeleted,

--- a/src/app/meetings/[id]/_components/meeting-detail-card/_components/action-button.tsx
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/_components/action-button.tsx
@@ -12,13 +12,15 @@ interface ActionButtonProps {
   config: ActionButtonConfig;
   category: MeetingCategory;
   onClick?: () => void;
+  /** API 진행 중 연타 방지 */
+  pending?: boolean;
 }
 
-export function ActionButton({ config, category, onClick }: ActionButtonProps) {
+export function ActionButton({ config, category, onClick, pending }: ActionButtonProps) {
   if (config.variant === 'disabled') {
     return (
       <Button
-        className="text-sosoeat-gray-700 border-sosoeat-gray-300 bg-sosoeat-gray-200 h-full w-full rounded-2xl border-2 text-sm md:text-base lg:text-xl"
+        className="text-sosoeat-gray-700 border-sosoeat-gray-300 bg-sosoeat-gray-200 h-full w-full cursor-not-allowed rounded-2xl border-2 text-sm md:text-base lg:text-xl"
         disabled
       >
         {config.label}
@@ -32,7 +34,12 @@ export function ActionButton({ config, category, onClick }: ActionButtonProps) {
       : outlineButtonVariants({ category });
 
   return (
-    <Button variant="ghost" className={cn(className)} onClick={onClick}>
+    <Button
+      variant="ghost"
+      className={cn('cursor-pointer disabled:cursor-not-allowed', className)}
+      onClick={onClick}
+      disabled={!!pending}
+    >
       {config.label}
     </Button>
   );

--- a/src/app/meetings/[id]/_components/meeting-detail-card/_components/ellipsis-menu.tsx
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/_components/ellipsis-menu.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
 import { EllipsisVerticalIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -11,19 +15,37 @@ import {
 interface EllipsisMenuProps {
   onEdit?: () => void;
   onDelete?: () => void;
+  isDeletePending?: boolean;
 }
 
-export function EllipsisMenu({ onEdit, onDelete }: EllipsisMenuProps) {
+const subscribe = () => () => {};
+
+export function EllipsisMenu({ onEdit, onDelete, isDeletePending }: EllipsisMenuProps) {
+  const mounted = useSyncExternalStore(
+    subscribe,
+    () => true, // 클라이언트: true
+    () => false // 서버: false
+  );
+
+  if (!mounted) return null;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon-sm" aria-label="더보기">
+        <Button variant="ghost" size="icon-sm" className="cursor-pointer" aria-label="더보기">
           <EllipsisVerticalIcon className="text-sosoeat-gray-500 size-5" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={onEdit}>수정하기</DropdownMenuItem>
-        <DropdownMenuItem variant="destructive" onClick={onDelete}>
+        <DropdownMenuItem className="cursor-pointer" onClick={onEdit}>
+          수정하기
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          variant="destructive"
+          className="cursor-pointer data-disabled:cursor-not-allowed"
+          disabled={isDeletePending}
+          onClick={onDelete}
+        >
           삭제하기
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.constants.ts
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.constants.ts
@@ -80,7 +80,7 @@ export interface ActionButtonConfig {
 export const ACTION_BUTTON_CONFIGS: ActionButtonConfig[] = [
   {
     type: 'closed',
-    match: ({ status }) => status === 'closed',
+    match: ({ status }) => status === 'closed' || status === 'full',
     label: '모집 마감',
     variant: 'disabled',
   },

--- a/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.stories.tsx
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.stories.tsx
@@ -33,7 +33,7 @@ const mockMeeting: Meeting = {
   image: '',
   description: '',
   hostId: 1,
-  createdBy: '1',
+  createdBy: 1,
   updatedAt: '2024/03/01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,

--- a/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.test.tsx
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.test.tsx
@@ -21,7 +21,7 @@ const mockMeeting: Meeting = {
   image: '',
   description: '',
   hostId: 1,
-  createdBy: '1',
+  createdBy: 1,
   updatedAt: '2024/03/01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,
@@ -53,7 +53,7 @@ describe('MeetingDetailCard', () => {
     expect(screen.getByText('김소소')).toBeInTheDocument();
   });
 
-  it('confirmedAt이 있으면 개설확정 뱃지가 노출된다', () => {
+  it('confirmedAt이 있으면 개설완료 뱃지가 노출된다', () => {
     render(
       <MeetingDetailCard
         {...DEFAULT_PROPS}

--- a/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.tsx
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.tsx
@@ -65,8 +65,13 @@ interface ParticipantsRowProps {
 function ParticipantsRow({ meetingId, current, max, category, className }: ParticipantsRowProps) {
   return (
     <div className={cn('flex items-center gap-3', className)}>
-      <div className="bg-sosoeat-orange-100 flex h-9 w-9 shrink-0 items-center justify-center rounded-full">
-        <UsersIcon className="text-sosoeat-orange-400 h-4 w-4" />
+      <div
+        className={cn(
+          'flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+          iconBgVariants({ category })
+        )}
+      >
+        <UsersIcon className={cn('h-4 w-4', iconColorVariants({ category }))} />
       </div>
       <div className="flex-1">
         <p className="text-sosoeat-gray-600 mb-1 text-xs font-semibold">참여 현황</p>
@@ -140,7 +145,7 @@ function InfoSection({ meeting, category, fullDateLabel, className }: InfoSectio
         category={category}
       />
 
-      <HostRow name={meeting.host.name} profileImage={meeting.host.profileImage} />
+      <HostRow name={meeting.host.name} profileImage={meeting.host.image} />
     </div>
   );
 }
@@ -151,21 +156,24 @@ function InfoSection({ meeting, category, fullDateLabel, className }: InfoSectio
 
 interface ActionRowProps {
   actionButton: React.ReactNode;
+  meetingId: number;
   isFavorited: boolean;
 }
 
-function ActionRow({ actionButton, isFavorited }: ActionRowProps) {
+function ActionRow({ actionButton, meetingId, isFavorited }: ActionRowProps) {
   return (
     <div className="flex items-center gap-2">
       <div className="h-10 w-full lg:h-[62px]">{actionButton}</div>
       {/* sm·md: 40×40 */}
       <HeartButton
+        meetingId={meetingId}
         isFavorited={isFavorited}
         size="sm"
         className="border-sosoeat-gray-500 relative inset-auto m-0 lg:hidden"
       />
       {/* lg: 60×60 */}
       <HeartButton
+        meetingId={meetingId}
         isFavorited={isFavorited}
         size="lg"
         className="border-sosoeat-gray-500 relative inset-auto m-0 hidden lg:block"
@@ -190,10 +198,21 @@ export function MeetingDetailCard(props: MeetingDetailCardProps) {
   const hasSafetyBadge = isConfirmed; /* || isScheduled */
 
   const ellipsisMenu =
-    props.role === 'host' ? <EllipsisMenu onEdit={props.onEdit} onDelete={props.onDelete} /> : null;
+    props.role === 'host' ? (
+      <EllipsisMenu
+        onEdit={props.onEdit}
+        onDelete={props.onDelete}
+        isDeletePending={props.isDeletePending}
+      />
+    ) : null;
 
   const actionButton = (
-    <ActionButton config={activeConfig} category={category} onClick={actionHandler} />
+    <ActionButton
+      config={activeConfig}
+      category={category}
+      onClick={actionHandler}
+      pending={props.isActionPending}
+    />
   );
 
   return (
@@ -268,7 +287,11 @@ export function MeetingDetailCard(props: MeetingDetailCardProps) {
       {/* ════════════════════════════════════════
           액션 버튼 + 좋아요
           ════════════════════════════════════════ */}
-      <ActionRow actionButton={actionButton} isFavorited={meeting.isFavorited ?? false} />
+      <ActionRow
+        actionButton={actionButton}
+        meetingId={meeting.id}
+        isFavorited={meeting.isFavorited ?? false}
+      />
     </div>
   );
 }

--- a/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.types.ts
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.types.ts
@@ -10,6 +10,10 @@ export type MeetingStatus = 'open' | 'closed' | 'confirmed' | 'full';
 type BaseProps = {
   meeting: Meeting;
   status: MeetingStatus;
+  /** 참여·취소·확정·공유 등 메인 액션 API 진행 중 */
+  isActionPending?: boolean;
+  /** 호스트 모임 삭제 API 진행 중 */
+  isDeletePending?: boolean;
 };
 
 type GuestProps = BaseProps & {

--- a/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.utils.ts
+++ b/src/app/meetings/[id]/_components/meeting-detail-card/meeting-detail-card.utils.ts
@@ -5,10 +5,17 @@ import type { Meeting } from '@/types/meeting';
 
 import type { MeetingRole, MeetingStatus } from './meeting-detail-card.types';
 
+/**
+ * 모임 상태 단일 정의 — 카드 액션 테이블·역할 훅과 동일 규칙을 씁니다.
+ * (마감일 경과 또는 정원 만석은 모두 `closed` → 모집 마감 UI)
+ */
 export const getMeetingStatus = (meeting: Meeting): MeetingStatus => {
-  if (meeting.canceledAt) return 'closed';
-  if (meeting.confirmedAt) return 'confirmed';
-  if (meeting.participantCount >= meeting.capacity) return 'full';
+  if (meeting.canceledAt != null) return 'closed';
+  if (meeting.confirmedAt != null) return 'confirmed';
+  const now = new Date();
+  if (new Date(meeting.registrationEnd) < now || meeting.participantCount >= meeting.capacity) {
+    return 'closed';
+  }
   return 'open';
 };
 

--- a/src/app/meetings/[id]/_components/meeting-hero-section/hooks/use-meeting-role.ts
+++ b/src/app/meetings/[id]/_components/meeting-hero-section/hooks/use-meeting-role.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useAuthStore } from '@/store/auth-store';
+import type { Meeting } from '@/types/meeting';
+
+import type {
+  MeetingRole,
+  MeetingStatus,
+} from '../../meeting-detail-card/meeting-detail-card.types';
+import { getMeetingStatus } from '../../meeting-detail-card/meeting-detail-card.utils';
+
+interface UseMeetingRoleResult {
+  role: MeetingRole;
+  status: MeetingStatus;
+  isJoined: boolean;
+}
+
+export function useMeetingRole(meeting: Meeting): UseMeetingRoleResult {
+  const user = useAuthStore((s) => s.user);
+
+  const isHost = user != null && user.id === meeting.hostId;
+  const isJoined = meeting.isJoined ?? false;
+  const role: MeetingRole = isHost ? 'host' : isJoined ? 'participant' : 'guest';
+  const status: MeetingStatus = getMeetingStatus(meeting);
+
+  return { role, status, isJoined };
+}

--- a/src/app/meetings/[id]/_components/meeting-hero-section/meeting-hero-section.tsx
+++ b/src/app/meetings/[id]/_components/meeting-hero-section/meeting-hero-section.tsx
@@ -1,22 +1,89 @@
-import Image from 'next/image';
+'use client';
 
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+import { MeetingEditModal, toMeetingEditFormData } from '@/components/common/meeting-edit-modal';
+import { useModal } from '@/hooks/use-modal';
 import type { Meeting } from '@/types/meeting';
 
+import {
+  useConfirmMeeting,
+  useDeleteMeeting,
+  useJoinMeeting,
+  useLeaveMeeting,
+} from '../../services/meeting-detail.queries';
 import { MeetingDetailCard } from '../meeting-detail-card';
+
+import { useMeetingRole } from './hooks/use-meeting-role';
 
 interface MeetingHeroSectionProps {
   meeting: Meeting;
 }
 
 export function MeetingHeroSection({ meeting }: MeetingHeroSectionProps) {
+  const router = useRouter();
+  const { role, status } = useMeetingRole(meeting);
+  const { isOpen: isEditOpen, open: openEdit, close: closeEdit } = useModal();
+
+  const refresh = () => router.refresh();
+
+  const joinMutation = useJoinMeeting(meeting.id, refresh);
+  const leaveMutation = useLeaveMeeting(meeting.id, refresh);
+  const confirmMutation = useConfirmMeeting(meeting.id, refresh);
+  const deleteMutation = useDeleteMeeting(meeting.id);
+
+  const isActionPending =
+    joinMutation.isPending || leaveMutation.isPending || confirmMutation.isPending;
+  const isDeletePending = deleteMutation.isPending;
+
+  const cardProps =
+    role === 'host'
+      ? {
+          role: 'host' as const,
+          onConfirm: () => confirmMutation.mutate(),
+          onShare: () => {
+            navigator.clipboard.writeText(window.location.href);
+          },
+          onEdit: openEdit,
+          onDelete: () => deleteMutation.mutate(),
+          isActionPending,
+          isDeletePending,
+        }
+      : role === 'participant'
+        ? {
+            role: 'participant' as const,
+            isJoined: true,
+            onJoin: () => joinMutation.mutate(),
+            onCancel: () => leaveMutation.mutate(),
+            isActionPending,
+          }
+        : {
+            role: 'guest' as const,
+            onJoin: () => joinMutation.mutate(),
+            isActionPending,
+          };
+
   return (
-    <div className="flex flex-col gap-6 md:flex-row">
-      <div className="relative h-[241px] w-full overflow-hidden rounded-[24px] md:h-auto md:min-w-0 md:flex-1">
-        <Image src={meeting.image} alt={meeting.name} fill className="object-cover" />
+    <>
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="relative h-[241px] w-full overflow-hidden rounded-[24px] md:h-auto md:min-w-0 md:flex-1">
+          <Image src={meeting.image} alt={meeting.name} fill className="object-cover" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <MeetingDetailCard meeting={meeting} status={status} {...cardProps} />
+        </div>
       </div>
-      <div className="min-w-0 flex-1">
-        <MeetingDetailCard meeting={meeting} role="guest" status="open" />
-      </div>
-    </div>
+
+      {role === 'host' && (
+        <MeetingEditModal
+          open={isEditOpen}
+          onClose={closeEdit}
+          meetingId={meeting.id}
+          defaultValues={toMeetingEditFormData(meeting)}
+          onSuccess={refresh}
+        />
+      )}
+    </>
   );
 }

--- a/src/app/meetings/[id]/_components/meeting-recommended-card/meeting-recommended-card.stories.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-card/meeting-recommended-card.stories.tsx
@@ -19,7 +19,7 @@ const mockMeeting: Meeting = {
   image: 'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?w=600',
   description: '',
   hostId: 1,
-  createdBy: '1',
+  createdBy: 1,
   updatedAt: '2024-03-01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,

--- a/src/app/meetings/[id]/_components/meeting-recommended-card/meeting-recommended-card.test.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-card/meeting-recommended-card.test.tsx
@@ -5,6 +5,13 @@ import type { Meeting } from '@/types/meeting';
 
 import RecommendedMeetingCard from './meeting-recommended-card';
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
 jest.mock('next/image', () => ({
   __esModule: true,
   default: ({ src, alt }: { src: string; alt: string }) => (
@@ -34,7 +41,7 @@ const mockMeeting: Meeting = {
   image: '/test-image.jpg',
   description: '',
   hostId: 1,
-  createdBy: '1',
+  createdBy: 1,
   updatedAt: '2024-03-01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,

--- a/src/app/meetings/[id]/_components/meeting-recommended-card/meeting-recommended-card.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-card/meeting-recommended-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 import { MapPin } from 'lucide-react';
 
@@ -15,18 +16,31 @@ interface RecommendedMeetingCardProps {
 }
 
 export default function RecommendedMeetingCard({ meeting, onClick }: RecommendedMeetingCardProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick(meeting.id);
+    } else {
+      router.push(`/meetings/${meeting.id}`);
+    }
+  };
+
   return (
     <Card
       className="h-[286px] w-[302px] cursor-pointer border-none bg-transparent pt-0 shadow-none ring-0"
-      onClick={() => onClick?.(meeting.id)}
+      onClick={handleClick}
     >
       <CardContent className="flex flex-col p-0">
         {/* ── 썸네일 ── */}
         <div className="pb-[14px]">
           <div className="relative h-[160px] w-full overflow-hidden rounded-3xl">
             <Image src={meeting.image} alt={meeting.name} fill className="object-cover" />
-            <div className="absolute right-5 bottom-5" onClick={(e) => e.stopPropagation()}>
-              <HeartButton size="sm" isFavorited={meeting.isFavorited} />
+            <div
+              className="absolute right-5 bottom-5 cursor-pointer"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <HeartButton size="sm" meetingId={meeting.id} isFavorited={meeting.isFavorited} />
             </div>
           </div>
         </div>

--- a/src/app/meetings/[id]/page.tsx
+++ b/src/app/meetings/[id]/page.tsx
@@ -1,188 +1,46 @@
+import { getMeetings } from '@/services/meetings/meetings.server';
 import type { Meeting } from '@/types/meeting';
 
-import type { MeetingComment } from './_components/meeting-comment-section';
-import { MeetingCommentSection } from './_components/meeting-comment-section';
 import { MeetingHeroSection } from './_components/meeting-hero-section';
 import { MeetingLocationSection } from './_components/meeting-location-section';
 import { MeetingRecommendedSection } from './_components/meeting-recommended-section';
-
-// ─── Mock Data ───────────────────────────────────────────────
-
-const mockMeeting: Meeting = {
-  id: 1,
-  name: '하루 10분 글쓰기 습관',
-  type: 'groupEat',
-  region: '강남구',
-  address: '서울특별시 중구 청계전로 100 시그니처타워 동관',
-  latitude: 37.5697,
-  longitude: 126.9822,
-  dateTime: '2026-04-10T09:30:00.000Z',
-  registrationEnd: '2026-04-09T23:59:59.000Z',
-  participantCount: 3,
-  capacity: 6,
-  image: 'https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=800',
-  description:
-    '작은 독서 습관을 만들기위해서 같이 열심히 하실 분을 구합니다~\n궁금한 점 있으시면 https://open.kakao.com/o/abcdefg12345 참여에서 질문주세요~',
-  hostId: 1,
-  createdBy: '1',
-  updatedAt: '',
-  host: { id: 1, name: '김민준' },
-  isFavorited: false,
-};
-
-const mockComments: MeetingComment[] = [
-  {
-    id: 1,
-    parentId: null,
-    author: { nickname: '마민준', profileUrl: null },
-    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
-    isDeleted: false,
-    createdAt: '03월 12일',
-    likeCount: 3,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 2,
-    parentId: 1,
-    author: { nickname: '마민준', profileUrl: null },
-    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
-    isDeleted: false,
-    createdAt: '03월 12일',
-    likeCount: 3,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 3,
-    parentId: 1,
-    author: { nickname: '마민준', profileUrl: null },
-    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
-    isDeleted: false,
-    createdAt: '03월 12일',
-    likeCount: 3,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 4,
-    parentId: null,
-    author: { nickname: '마민준', profileUrl: null },
-    content: '안녕하세요! 혼자 참여하는데 괜찮을까요? 음식 알레르기는 없고 적극적으로 참여할게요!!',
-    isDeleted: false,
-    createdAt: '03월 12일',
-    likeCount: 3,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-];
-
-const mockRecommendedMeetings: Meeting[] = [
-  {
-    id: 1,
-    name: '하루 10분 글쓰기 습관',
-    type: 'groupEat',
-    region: '강남구',
-    address: '',
-    latitude: 0,
-    longitude: 0,
-    dateTime: '2025-01-07T17:30:00.000Z',
-    registrationEnd: '2025-01-06T23:59:59.000Z',
-    participantCount: 0,
-    capacity: 6,
-    image: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?w=300',
-    description: '',
-    hostId: 1,
-    createdBy: '1',
-    updatedAt: '',
-    host: { id: 1, name: '김소소' },
-    isFavorited: false,
-  },
-  {
-    id: 2,
-    name: '카페 투어 멤버 모집',
-    type: 'groupEat',
-    region: '강남구 · 하이/아이',
-    address: '',
-    latitude: 0,
-    longitude: 0,
-    dateTime: '2025-01-07T17:30:00.000Z',
-    registrationEnd: '2025-01-06T23:59:59.000Z',
-    participantCount: 0,
-    capacity: 6,
-    image: 'https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=300',
-    description: '',
-    hostId: 1,
-    createdBy: '1',
-    updatedAt: '',
-    host: { id: 1, name: '김소소' },
-    isFavorited: false,
-  },
-  {
-    id: 3,
-    name: '퇴근 후 책으로 여행하기',
-    type: 'groupEat',
-    region: '강남구 · 하이/아이',
-    address: '',
-    latitude: 0,
-    longitude: 0,
-    dateTime: '2025-01-07T17:30:00.000Z',
-    registrationEnd: '2025-01-06T23:59:59.000Z',
-    participantCount: 0,
-    capacity: 6,
-    image: 'https://images.unsplash.com/photo-1512820790803-83ca734da794?w=300',
-    description: '',
-    hostId: 1,
-    createdBy: '1',
-    updatedAt: '',
-    host: { id: 1, name: '김소소' },
-    isFavorited: false,
-  },
-  {
-    id: 4,
-    name: '영화로 만나는 짧은 대화',
-    type: 'groupEat',
-    region: '강남구 · 하이/아이',
-    address: '',
-    latitude: 0,
-    longitude: 0,
-    dateTime: '2025-01-07T17:30:00.000Z',
-    registrationEnd: '2025-01-06T23:59:59.000Z',
-    participantCount: 0,
-    capacity: 6,
-    image: 'https://images.unsplash.com/photo-1536440136628-849c177e76a1?w=300',
-    description: '',
-    hostId: 1,
-    createdBy: '1',
-    updatedAt: '',
-    host: { id: 1, name: '김소소' },
-    isFavorited: false,
-  },
-];
+import { getMeetingById } from './services/meeting-detail.server';
 
 // ─── Page ────────────────────────────────────────────────────
 
-export default function MeetingDetailPage() {
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function MeetingDetailPage({ params }: Props) {
+  const { id } = await params;
+  const meetingId = Number(id);
+
+  const meetingData = await getMeetingById(meetingId);
+
+  const [meetingList] = await Promise.allSettled([
+    getMeetings({ region: meetingData.region, size: 4 }),
+  ]);
+
+  const recommendedMeetingsRaw: Meeting[] =
+    meetingList.status === 'fulfilled' ? (meetingList.value.data as unknown as Meeting[]) : [];
+  const recommendedMeetings = recommendedMeetingsRaw.filter((m) => m.id !== meetingId);
+
   return (
     <main className="space-y-[30px] py-10">
-      <MeetingHeroSection meeting={mockMeeting} />
+      <MeetingHeroSection meeting={meetingData} />
 
       <section>
         <h2 className="text-sosoeat-gray-900 mb-3 text-2xl font-semibold">모임 설명</h2>
         <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-12 py-10">
           <p className="text-sosoeat-gray-800 text-lg font-normal whitespace-pre-line">
-            {mockMeeting.description}
+            {meetingData.description}
           </p>
         </div>
       </section>
 
-      <MeetingLocationSection address={mockMeeting.address} />
-      <MeetingCommentSection comments={mockComments} />
-      <MeetingRecommendedSection meetings={mockRecommendedMeetings} />
+      <MeetingLocationSection address={meetingData.address} />
+      <MeetingRecommendedSection meetings={recommendedMeetings} />
     </main>
   );
 }

--- a/src/app/meetings/[id]/services/meeting-detail.queries.ts
+++ b/src/app/meetings/[id]/services/meeting-detail.queries.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { meetingsApi } from '@/services/meetings/meetings.api';
+
+export const useConfirmMeeting = (id: number, onSuccess?: () => void) =>
+  useMutation({
+    mutationFn: () => meetingsApi.updateStatus(id, { status: 'CONFIRMED' }),
+    retry: false,
+    onSuccess: () => {
+      toast.success('모임이 확정되었습니다.');
+      onSuccess?.();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '모임 확정 중 오류가 발생했습니다.');
+    },
+  });
+
+export const useDeleteMeeting = (id: number) => {
+  const router = useRouter();
+  return useMutation({
+    mutationFn: () => meetingsApi.deleteMeeting(id),
+    onSuccess: () => {
+      toast.success('모임이 삭제되었습니다.');
+      router.push('/meetings');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '모임 삭제 중 오류가 발생했습니다.');
+    },
+  });
+};
+
+export const useJoinMeeting = (id: number, onSuccess?: () => void) =>
+  useMutation({
+    mutationFn: () => meetingsApi.join(id),
+    retry: false,
+    onSuccess: () => {
+      toast.success('모임에 참여했습니다.');
+      onSuccess?.();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '모임 참여 중 오류가 발생했습니다.');
+    },
+  });
+
+export const useLeaveMeeting = (id: number, onSuccess?: () => void) =>
+  useMutation({
+    mutationFn: () => meetingsApi.leave(id),
+    retry: false,
+    onSuccess: () => {
+      toast.success('모임 참여를 취소했습니다.');
+      onSuccess?.();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '모임 참여 취소 중 오류가 발생했습니다.');
+    },
+  });

--- a/src/app/meetings/[id]/services/meeting-detail.server.ts
+++ b/src/app/meetings/[id]/services/meeting-detail.server.ts
@@ -1,0 +1,17 @@
+import { apiServer } from '@/lib/http/api-server';
+import type { Meeting } from '@/types/meeting';
+
+/**
+ * 모임 단건 조회 (서버 컴포넌트 전용)
+ * GET /meetings/:id
+ */
+export async function getMeetingById(id: number): Promise<Meeting> {
+  const response = await apiServer.get(`/meetings/${id}`);
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.message || '모임 조회에 실패했습니다.');
+  }
+
+  return response.json();
+}

--- a/src/components/common/meeting-edit-modal/meeting-edit-modal.tsx
+++ b/src/components/common/meeting-edit-modal/meeting-edit-modal.tsx
@@ -33,9 +33,10 @@ const MeetingEditForm = ({
   onClose,
   meetingId,
   defaultValues,
+  onSuccess,
 }: Omit<MeetingEditModalProps, 'open'>) => {
   const [activeTab, setActiveTab] = useState<MeetingEditTab>('basicInfo');
-  const { mutateAsync } = useUpdateMeeting(meetingId);
+  const { mutateAsync } = useUpdateMeeting(meetingId, onSuccess);
   const {
     mutateAsync: uploadImage,
     isPending: isUploadPending,
@@ -180,6 +181,7 @@ export const MeetingEditModal = ({
   onClose,
   meetingId,
   defaultValues,
+  onSuccess,
 }: MeetingEditModalProps) => {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) onClose();
@@ -200,7 +202,12 @@ export const MeetingEditModal = ({
         )}
       >
         <DialogTitle className="sr-only">모임 수정</DialogTitle>
-        <MeetingEditForm onClose={onClose} meetingId={meetingId} defaultValues={defaultValues} />
+        <MeetingEditForm
+          onClose={onClose}
+          meetingId={meetingId}
+          defaultValues={defaultValues}
+          onSuccess={onSuccess}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/common/meeting-edit-modal/meeting-edit-modal.types.ts
+++ b/src/components/common/meeting-edit-modal/meeting-edit-modal.types.ts
@@ -9,4 +9,5 @@ export interface MeetingEditModalProps {
   onClose: () => void;
   meetingId: number;
   defaultValues: MeetingEditFormData;
+  onSuccess?: () => void;
 }

--- a/src/services/meetings/meetings.api.ts
+++ b/src/services/meetings/meetings.api.ts
@@ -2,6 +2,7 @@ import { fetchClient } from '@/lib/http/fetch-client';
 import { CreateMeeting } from '@/types/generated-client/models/CreateMeeting';
 import { MeetingWithHost } from '@/types/generated-client/models/MeetingWithHost';
 import { UpdateMeeting } from '@/types/generated-client/models/UpdateMeeting';
+import { UpdateMeetingStatus } from '@/types/generated-client/models/UpdateMeetingStatus';
 
 /**
  * [Service Layer] meetingsApi
@@ -43,5 +44,43 @@ export const meetingsApi = {
     }
 
     return response.json();
+  },
+
+  async updateStatus(id: number, payload: UpdateMeetingStatus): Promise<MeetingWithHost> {
+    const response = await fetchClient.patch(`/meetings/${id}/status`, payload);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '모임 상태 변경에 실패했습니다.');
+    }
+
+    return response.json();
+  },
+
+  async deleteMeeting(id: number): Promise<void> {
+    const response = await fetchClient.delete(`/meetings/${id}`);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '모임 삭제에 실패했습니다.');
+    }
+  },
+
+  async join(id: number): Promise<void> {
+    const response = await fetchClient.post(`/meetings/${id}/join`);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '모임 참여에 실패했습니다.');
+    }
+  },
+
+  async leave(id: number): Promise<void> {
+    const response = await fetchClient.delete(`/meetings/${id}/join`);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '모임 참여 취소에 실패했습니다.');
+    }
   },
 };

--- a/src/services/meetings/meetings.queries.ts
+++ b/src/services/meetings/meetings.queries.ts
@@ -23,11 +23,12 @@ export const useCreateMeeting = () => {
   });
 };
 
-export const useUpdateMeeting = (id: number) =>
+export const useUpdateMeeting = (id: number, onSuccess?: () => void) =>
   useMutation({
     mutationFn: (payload: UpdateMeeting) => meetingsApi.update(id, payload),
     onSuccess: () => {
       toast.success('모임이 수정되었습니다.');
+      onSuccess?.();
     },
     onError: (error: Error) => {
       toast.error(error.message || '모임 수정 중 오류가 발생했습니다.');

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -14,15 +14,16 @@ export type Meeting = {
   participantCount: number;
   image: string;
   description: string;
-  canceledAt?: string;
-  confirmedAt?: string;
+  canceledAt?: string | null;
+  confirmedAt?: string | null;
   hostId: number;
-  createdBy: string;
+  createdBy: number;
   updatedAt: string;
   host: {
     id: number;
     name: string;
-    profileImage?: string;
+    image?: string;
   };
-  isFavorited: boolean;
+  isFavorited?: boolean;
+  isJoined?: boolean;
 };


### PR DESCRIPTION
### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- **모임 상세 페이지 (`/meetings/[id]`)**  
  - 서버에서 `getMeetingById`로 단건 조회 후, 같은 지역 기준 `getMeetings`로 추천 후보를 가져와 현재 모임을 제외해 표시.  
  - 페이지 구성: 히어로 + 모임 설명 + 위치 + 추천 섹션(댓글 영역은 이 PR 범위 아님).

- **`MeetingHeroSection`**  
  - `useMeetingRole`으로 host / participant / guest 구분, 참여·취소·확정·삭제 뮤테이션 및 수정 모달 연동.

- **`meeting-detail.server.ts` / `meeting-detail.queries.ts`**  
  - 단건 조회 및 참여·탈퇴·확정·삭제 등 클라이언트 뮤테이션 정리.

- **`MeetingDetailCard` 및 하위 컴포넌트**  
  - 역할·상태별 액션/메뉴, 정보 표시·유틸·타입·테스트·스토리 정리.

- **`MeetingRecommendedCard`**  
  - 추천 카드 데이터·찜 버튼 연동 관련 수정.

- **`meetings.api` / `meetings.queries`**  
  - 상세/히어로에서 쓰는 API·수정 플로우에 맞게 보강.

- **`Meeting` 타입 (`types/meeting.ts`)**  
  - 상세·추천에 필요한 필드 반영.

- **`meeting-edit-modal`**  
  - 상세 수정 플로우에 맞는 타입·연동 소폭 수정.

- **`meeting-comment-item`**  
  - 미사용 `id` 구조분해 제거(린트).

### 🧪 테스트 방법 (How to Test)

1. `npm run dev` 후 `/meetings/[id]` 접속.
2. 히어로·본문 카드·추천 영역이 API와 맞는지, 로딩/에러 흐름 확인.
3. 권한에 따른 수정 모달·액션 노출 확인.
4. `npm run type-check` 및 필요 시 `npm run test` 실행.

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [ ] API 스키마·에러 처리·권한(주최/참여) 리뷰 부탁드립니다.
- [ ] 배포 시 백엔드 엔드포인트·환경 변수 확인.