### PR TITLE
[Feat]: 모임 상세 댓글 연동 및 댓글 서버 동기화

### DIFF
--- a/src/app/api/comment-proxy/[...path]/route.ts
+++ b/src/app/api/comment-proxy/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { CookieStorage } from '@/lib/auth/cookie-storage';
+import { silentRefresh } from '@/lib/auth/silent-refresh';
 
 const COMMENT_SERVER_URL = process.env.COMMENT_SERVER_URL;
 
@@ -8,12 +9,24 @@ const COMMENT_SERVER_URL = process.env.COMMENT_SERVER_URL;
  * [BFF] /api/comment-proxy/[...path]
  * comment server(Railway Express)로 요청을 프록시합니다.
  * httpOnly 쿠키의 accessToken을 Authorization 헤더에 삽입합니다.
- * (인증이 필요없는 요청은 토큰 없이 그대로 전달됩니다.)
+ * 401 응답 시 refreshToken으로 토큰을 갱신하고 원래 요청을 1회 재시도합니다.
  */
 async function handler(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params;
   const targetUrl = `${COMMENT_SERVER_URL}/${path.join('/')}${request.nextUrl.search}`;
 
+  const body =
+    request.method !== 'GET' && request.method !== 'HEAD' ? await request.blob() : undefined;
+
+  return proxyRequest(request, targetUrl, body);
+}
+
+async function proxyRequest(
+  request: NextRequest,
+  targetUrl: string,
+  body: Blob | undefined,
+  retry = false
+): Promise<NextResponse> {
   const accessToken = await CookieStorage.getAccessToken();
 
   const headers = new Headers();
@@ -27,14 +40,18 @@ async function handler(request: NextRequest, { params }: { params: Promise<{ pat
     headers.set('Authorization', `Bearer ${accessToken}`);
   }
 
-  const body =
-    request.method !== 'GET' && request.method !== 'HEAD' ? await request.blob() : undefined;
-
   const response = await fetch(targetUrl, {
     method: request.method,
     headers,
     body,
   });
+
+  if (response.status === 401 && !retry) {
+    const refreshed = await silentRefresh();
+    if (refreshed) {
+      return proxyRequest(request, targetUrl, body, true);
+    }
+  }
 
   const responseHeaders = new Headers();
   response.headers.forEach((value, key) => {

--- a/src/app/meetings/[id]/_components/meeting-comment-section/comment-delete-modal.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/comment-delete-modal.tsx
@@ -1,0 +1,21 @@
+// comment-delete-modal.tsx
+import { AlertModal } from '@/components/common/alert-modal/alert-modal';
+
+interface CommentDeleteModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function CommentDeleteModal({ open, onCancel, onConfirm }: CommentDeleteModalProps) {
+  return (
+    <AlertModal
+      open={open}
+      title="댓글을 삭제하시겠습니까?"
+      description="삭제된 댓글은 복구할 수 없습니다."
+      confirmText="삭제하기"
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />
+  );
+}

--- a/src/app/meetings/[id]/_components/meeting-comment-section/format-date.ts
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/format-date.ts
@@ -1,0 +1,9 @@
+/**
+ * ISO 날짜 문자열을 'MM월 DD일' 형식으로 변환합니다.
+ */
+export function formatCommentDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${month}월 ${day}일`;
+}

--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.stories.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.stories.tsx
@@ -32,6 +32,7 @@ const meta = {
   args: {
     comment: mockComment,
     isReply: false,
+    meetingId: 1,
   },
 } satisfies Meta<typeof MeetingCommentItem>;
 

--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.test.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.test.tsx
@@ -1,8 +1,20 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { MeetingCommentItem } from './meeting-comment-item';
 import type { MeetingComment } from './meeting-comment-section.types';
+
+jest.mock('@/services/comments', () => ({
+  useLikeComment: jest.fn(() => ({ mutate: jest.fn() })),
+  useUpdateComment: jest.fn(() => ({ mutate: jest.fn() })),
+  useDeleteComment: jest.fn(() => ({ mutate: jest.fn() })),
+  useCreateComment: jest.fn(() => ({ mutate: jest.fn() })),
+}));
+
+jest.mock('./format-date', () => ({
+  formatCommentDate: jest.fn((date: string) => date),
+}));
 
 const mockComment: MeetingComment = {
   id: 1,
@@ -17,9 +29,20 @@ const mockComment: MeetingComment = {
   isMine: false,
 };
 
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
 describe('MeetingCommentItem', () => {
   it('닉네임, 본문, 날짜, 좋아요 수가 렌더링된다', () => {
-    render(<MeetingCommentItem comment={mockComment} />);
+    render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
+      wrapper: createWrapper(),
+    });
 
     expect(screen.getByText('마민준')).toBeInTheDocument();
     expect(screen.getByText('안녕하세요! 혼자 참여하는데 괜찮을까요?')).toBeInTheDocument();
@@ -29,13 +52,18 @@ describe('MeetingCommentItem', () => {
 
   describe('작성자 뱃지', () => {
     it('isHostComment가 true이면 "작성자" 뱃지가 표시된다', () => {
-      render(<MeetingCommentItem comment={{ ...mockComment, isHostComment: true }} />);
+      render(
+        <MeetingCommentItem comment={{ ...mockComment, isHostComment: true }} meetingId={1} />,
+        { wrapper: createWrapper() }
+      );
 
       expect(screen.getByText('작성자')).toBeInTheDocument();
     });
 
     it('isHostComment가 false이면 "작성자" 뱃지가 표시되지 않는다', () => {
-      render(<MeetingCommentItem comment={mockComment} />);
+      render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
 
       expect(screen.queryByText('작성자')).not.toBeInTheDocument();
     });
@@ -43,20 +71,26 @@ describe('MeetingCommentItem', () => {
 
   describe('수정/삭제 드롭다운', () => {
     it('isMine이 true이면 더보기 버튼이 표시된다', () => {
-      render(<MeetingCommentItem comment={{ ...mockComment, isMine: true }} />);
+      render(<MeetingCommentItem comment={{ ...mockComment, isMine: true }} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
 
       expect(screen.getByRole('button', { name: '더보기' })).toBeInTheDocument();
     });
 
     it('isMine이 false이면 더보기 버튼이 표시되지 않는다', () => {
-      render(<MeetingCommentItem comment={mockComment} />);
+      render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
 
       expect(screen.queryByRole('button', { name: '더보기' })).not.toBeInTheDocument();
     });
 
     it('더보기 클릭 시 수정하기/삭제하기가 표시된다', async () => {
       const user = userEvent.setup();
-      render(<MeetingCommentItem comment={{ ...mockComment, isMine: true }} />);
+      render(<MeetingCommentItem comment={{ ...mockComment, isMine: true }} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
 
       await user.click(screen.getByRole('button', { name: '더보기' }));
 
@@ -67,45 +101,51 @@ describe('MeetingCommentItem', () => {
 
   describe('삭제된 댓글', () => {
     it('isDeleted가 true이면 "삭제된 댓글입니다."가 표시된다', () => {
-      render(<MeetingCommentItem comment={{ ...mockComment, isDeleted: true }} />);
+      render(<MeetingCommentItem comment={{ ...mockComment, isDeleted: true }} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
 
       expect(screen.getByText('삭제된 댓글입니다.')).toBeInTheDocument();
     });
 
-    it('isDeleted가 true이면 좋아요/수정/삭제 버튼이 표시되지 않는다', () => {
-      render(<MeetingCommentItem comment={{ ...mockComment, isDeleted: true, isMine: true }} />);
+    it('isDeleted가 true이면 좋아요/답글 버튼이 표시되지 않는다', () => {
+      render(
+        <MeetingCommentItem
+          comment={{ ...mockComment, isDeleted: true, isMine: true }}
+          meetingId={1}
+        />,
+        { wrapper: createWrapper() }
+      );
 
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '좋아요' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '답글' })).not.toBeInTheDocument();
     });
   });
 
-  describe('좋아요 토글', () => {
-    it('좋아요 버튼 클릭 시 상태가 토글된다', async () => {
+  describe('좋아요', () => {
+    it('좋아요 버튼 클릭 시 useLikeComment mutate가 호출된다', async () => {
+      const mockMutate = jest.fn();
+      const commentsModule = jest.mocked(
+        jest.requireMock('@/services/comments') as { useLikeComment: jest.Mock }
+      );
+      commentsModule.useLikeComment.mockReturnValue({ mutate: mockMutate });
+
       const user = userEvent.setup();
-      render(<MeetingCommentItem comment={{ ...mockComment, isLiked: false }} />);
+      render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
 
-      const likeButton = screen.getByRole('button');
-      await user.click(likeButton);
+      await user.click(screen.getByRole('button', { name: '좋아요' }));
 
-      // 토글 후 fill 클래스가 적용된 Heart 아이콘 확인
-      expect(likeButton.querySelector('svg')).toHaveClass('fill-sosoeat-orange-600');
-    });
-
-    it('이미 좋아요한 상태에서 클릭하면 토글된다', async () => {
-      const user = userEvent.setup();
-      render(<MeetingCommentItem comment={{ ...mockComment, isLiked: true }} />);
-
-      const likeButton = screen.getByRole('button');
-      await user.click(likeButton);
-
-      expect(likeButton.querySelector('svg')).not.toHaveClass('fill-sosoeat-orange-600');
+      expect(mockMutate).toHaveBeenCalledWith({ commentId: 1, isLiked: false });
     });
   });
 
   describe('대댓글', () => {
     it('isReply가 true이면 배경색 클래스가 적용된다', () => {
       const { container } = render(
-        <MeetingCommentItem comment={{ ...mockComment, parentId: 1 }} isReply />
+        <MeetingCommentItem comment={{ ...mockComment, parentId: 1 }} isReply meetingId={1} />,
+        { wrapper: createWrapper() }
       );
 
       expect(container.firstChild?.firstChild).toHaveClass('bg-sosoeat-orange-100');
@@ -119,9 +159,28 @@ describe('MeetingCommentItem', () => {
         ],
       };
 
-      render(<MeetingCommentItem comment={commentWithReplies} />);
+      render(<MeetingCommentItem comment={commentWithReplies} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
 
       expect(screen.getByText('이소소')).toBeInTheDocument();
+    });
+
+    it('isReply가 false이면 답글 버튼이 표시된다', () => {
+      render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
+
+      expect(screen.getByRole('button', { name: '답글' })).toBeInTheDocument();
+    });
+
+    it('isReply가 true이면 답글 버튼이 표시되지 않는다', () => {
+      render(
+        <MeetingCommentItem comment={{ ...mockComment, parentId: 1 }} isReply meetingId={1} />,
+        { wrapper: createWrapper() }
+      );
+
+      expect(screen.queryByRole('button', { name: '답글' })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-item.tsx
@@ -2,38 +2,97 @@
 
 import { useState } from 'react';
 
-import { Heart, UserRound } from 'lucide-react';
+import { Heart, MessageCircle, UserRound } from 'lucide-react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useModal } from '@/hooks/use-modal';
 import { cn } from '@/lib/utils';
+import {
+  useCreateComment,
+  useDeleteComment,
+  useLikeComment,
+  useUpdateComment,
+} from '@/services/comments';
+import { useAuthStore } from '@/store/auth-store';
 
 import { EllipsisMenu } from '../meeting-detail-card/_components/ellipsis-menu';
 
+import { CommentDeleteModal } from './comment-delete-modal';
+import { formatCommentDate } from './format-date';
 import type { MeetingComment } from './meeting-comment-section.types';
 
 interface MeetingCommentItemProps {
   comment: MeetingComment;
   isReply?: boolean;
+  meetingId: number;
 }
 
-// ─── MeetingCommentItem ───────────────────────────────────────
-
-export function MeetingCommentItem({ comment, isReply = false }: MeetingCommentItemProps) {
+export function MeetingCommentItem({
+  comment,
+  isReply = false,
+  meetingId,
+}: MeetingCommentItemProps) {
   const {
-    id: _id, // TODO: 좋아요/수정/삭제 mutation에서 사용 예정
+    id,
     author,
     content,
     isDeleted,
     createdAt,
     likeCount,
-    isLiked: initialIsLiked,
+    isLiked,
     isHostComment,
     isMine,
     replies,
   } = comment;
 
-  // TODO: API 연동 시 useState 제거하고 useQuery 데이터의 isLiked 직접 사용
-  const [isLiked, setIsLiked] = useState(initialIsLiked);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState(content);
+  const [isReplying, setIsReplying] = useState(false);
+  const [replyText, setReplyText] = useState('');
+  const { isOpen: isDeleteModalOpen, open: openDeleteModal, close: closeDeleteModal } = useModal();
+
+  const { user } = useAuthStore();
+  const { mutate: likeComment } = useLikeComment(meetingId);
+  const { mutate: updateComment } = useUpdateComment(meetingId);
+  const { mutate: deleteComment } = useDeleteComment(meetingId);
+  const { mutate: createComment } = useCreateComment(meetingId, {
+    nickname: user?.name ?? '',
+    profileUrl: user?.image ?? null,
+  });
+
+  const handleLike = () => {
+    likeComment({ commentId: id, isLiked });
+  };
+
+  const handleEditSubmit = () => {
+    if (!editText.trim() || editText === content) {
+      setIsEditing(false);
+      return;
+    }
+    updateComment(
+      { commentId: id, payload: { content: editText.trim() } },
+      { onSuccess: () => setIsEditing(false) }
+    );
+  };
+
+  const handleDelete = () => {
+    deleteComment(id, {
+      onSuccess: closeDeleteModal,
+    });
+  };
+
+  const handleReplySubmit = () => {
+    if (!replyText.trim()) return;
+    createComment(
+      { content: replyText, parentId: id },
+      {
+        onSuccess: () => {
+          setReplyText('');
+          setIsReplying(false);
+        },
+      }
+    );
+  };
 
   return (
     <div>
@@ -47,7 +106,7 @@ export function MeetingCommentItem({ comment, isReply = false }: MeetingCommentI
             </AvatarFallback>
           </Avatar>
 
-          {/* ── 오른쪽 영역: 이름 + 날짜 / 본문 / 하단 액션 ── */}
+          {/* ── 오른쪽 영역 ── */}
           <div className="flex flex-1 flex-col">
             {/* 이름 + 날짜 + 더보기 */}
             <div className="flex items-center justify-between">
@@ -58,37 +117,109 @@ export function MeetingCommentItem({ comment, isReply = false }: MeetingCommentI
                 )}
               </div>
               <div className="flex items-center gap-1">
-                <span className="text-sosoeat-gray-600 text-xs">{createdAt}</span>
+                <span className="text-sosoeat-gray-600 text-xs">
+                  {formatCommentDate(createdAt)}
+                </span>
                 {isMine && !isDeleted && (
-                  <EllipsisMenu
-                    onEdit={() => {}} // TODO: useEditCommentMutation
-                    onDelete={() => {}} // TODO: useDeleteCommentMutation
-                  />
+                  <EllipsisMenu onEdit={() => setIsEditing(true)} onDelete={openDeleteModal} />
                 )}
               </div>
             </div>
 
             {/* 본문 */}
-            <p
-              className={cn(
-                'mt-1 text-base font-medium',
-                isDeleted ? 'text-sosoeat-gray-600 italic' : 'text-sosoeat-gray-800'
-              )}
-            >
-              {isDeleted ? '삭제된 댓글입니다.' : content}
-            </p>
+            {isEditing ? (
+              <div className="mt-1 flex flex-col gap-1">
+                <textarea
+                  className="w-full resize-none rounded-lg border px-3 py-2 text-sm outline-none"
+                  rows={2}
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                  autoFocus
+                />
+                <div className="flex justify-end gap-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditText(content);
+                      setIsEditing(false);
+                    }}
+                    className="cursor-pointer rounded-lg px-3 py-1 text-sm text-gray-500 hover:bg-gray-100"
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleEditSubmit}
+                    className="bg-sosoeat-orange-600 cursor-pointer rounded-lg px-3 py-1 text-sm text-white"
+                  >
+                    저장
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <p
+                className={cn(
+                  'mt-1 text-base font-medium',
+                  isDeleted ? 'text-sosoeat-gray-600 italic' : 'text-sosoeat-gray-800'
+                )}
+              >
+                {isDeleted ? '삭제된 댓글입니다.' : content}
+              </p>
+            )}
 
-            {/* 좋아요 */}
+            {/* 좋아요 + 답글 버튼 */}
             {!isDeleted && (
               <div className="mt-2 flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() => setIsLiked((prev) => !prev)} // TODO: useLikeCommentMutation으로 교체
-                  className="text-sosoeat-orange-600 flex items-center gap-1 text-sm transition-colors"
+                  aria-label="좋아요"
+                  onClick={handleLike}
+                  className="text-sosoeat-orange-600 flex cursor-pointer items-center gap-1 text-sm transition-colors"
                 >
                   <Heart className={cn('size-4', isLiked && 'fill-sosoeat-orange-600')} />
                   <span>{likeCount}</span>
                 </button>
+
+                {!isReply && (
+                  <button
+                    type="button"
+                    aria-label="답글"
+                    onClick={() => setIsReplying((prev) => !prev)}
+                    className="text-sosoeat-gray-500 hover:text-sosoeat-orange-600 flex cursor-pointer items-center gap-1 text-sm transition-colors"
+                  >
+                    <MessageCircle className="size-4" />
+                    <span>답글</span>
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* 대댓글 입력창 */}
+            {isReplying && (
+              <div className="mt-2 flex gap-2">
+                <textarea
+                  className="flex-1 resize-none rounded-lg border px-3 py-2 text-sm outline-none"
+                  rows={1}
+                  placeholder="답글을 입력하세요."
+                  value={replyText}
+                  onChange={(e) => setReplyText(e.target.value)}
+                />
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    onClick={() => setIsReplying(false)}
+                    className="cursor-pointer rounded-lg px-3 py-1 text-sm text-gray-500 hover:bg-gray-100"
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleReplySubmit}
+                    className="bg-sosoeat-orange-600 cursor-pointer rounded-lg px-3 py-1 text-sm text-white"
+                  >
+                    저장
+                  </button>
+                </div>
               </div>
             )}
           </div>
@@ -96,13 +227,22 @@ export function MeetingCommentItem({ comment, isReply = false }: MeetingCommentI
       </div>
 
       {/* ── 대댓글 목록 ── */}
-      {replies && replies.length > 0 && (
+      {replies && replies.filter((r) => !r.isDeleted).length > 0 && (
         <div className="mt-3 ml-[78px] space-y-3">
-          {replies.map((reply) => (
-            <MeetingCommentItem key={reply.id} comment={reply} isReply />
-          ))}
+          {replies
+            .filter((r) => !r.isDeleted)
+            .map((reply) => (
+              <MeetingCommentItem key={reply.id} comment={reply} isReply meetingId={meetingId} />
+            ))}
         </div>
       )}
+
+      {/* ── 삭제 확인 모달 ── */}
+      <CommentDeleteModal
+        open={isDeleteModalOpen}
+        onCancel={closeDeleteModal}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.stories.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.stories.tsx
@@ -82,114 +82,6 @@ const manyMockComments: MeetingComment[] = [
     isHostComment: false,
     isMine: false,
   },
-  {
-    id: 7,
-    parentId: null,
-    author: { nickname: '한소소', profileUrl: null },
-    content: '지난번에도 참여했었는데 정말 좋았어요. 이번에도 기대됩니다!',
-    isDeleted: false,
-    createdAt: '03월 16일',
-    likeCount: 5,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 8,
-    parentId: null,
-    author: { nickname: '오소소', profileUrl: null },
-    content: '메뉴가 미리 정해져 있나요? 아니면 당일에 결정하나요?',
-    isDeleted: false,
-    createdAt: '03월 16일',
-    likeCount: 0,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 9,
-    parentId: null,
-    author: { nickname: '윤소잇', profileUrl: null },
-    content: '처음 참여하는데 혼자 가도 어색하지 않을까요? 걱정이 되네요.',
-    isDeleted: false,
-    createdAt: '03월 17일',
-    likeCount: 2,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 10,
-    parentId: null,
-    author: { nickname: '임소소', profileUrl: null },
-    content: '모임 후기 어디서 볼 수 있나요?',
-    isDeleted: false,
-    createdAt: '03월 17일',
-    likeCount: 0,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 11,
-    parentId: null,
-    author: { nickname: '강모임', profileUrl: null },
-    content: '참여 확정 문자는 언제쯤 오나요?',
-    isDeleted: false,
-    createdAt: '03월 18일',
-    likeCount: 1,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 12,
-    parentId: null,
-    author: { nickname: '신소잇', profileUrl: null },
-    content: '당일 취소도 가능한가요?',
-    isDeleted: false,
-    createdAt: '03월 18일',
-    likeCount: 0,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 13,
-    parentId: null,
-    author: { nickname: '류소소', profileUrl: null },
-    content: '음료는 포함인가요?',
-    isDeleted: false,
-    createdAt: '03월 19일',
-    likeCount: 0,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 14,
-    parentId: null,
-    author: { nickname: '백소잇', profileUrl: null },
-    content: '장소가 지하철역에서 가깝나요?',
-    isDeleted: false,
-    createdAt: '03월 19일',
-    likeCount: 2,
-    isLiked: false,
-    isHostComment: false,
-    isMine: false,
-  },
-  {
-    id: 15,
-    parentId: null,
-    author: { nickname: '조모임', profileUrl: null },
-    content: '혹시 연령대 제한 있나요? 20대도 괜찮을까요?',
-    isDeleted: false,
-    createdAt: '03월 20일',
-    likeCount: 3,
-    isLiked: true,
-    isHostComment: false,
-    isMine: false,
-  },
 ];
 
 type AuthSnapshot = Pick<ReturnType<typeof useAuthStore.getState>, 'user' | 'isAuthenticated'>;
@@ -217,8 +109,8 @@ const meta = {
     ),
   ],
   args: {
-    comments: mockComments,
-    commentCount: mockComments.length,
+    meetingId: 1,
+    initialComments: mockComments,
   },
 } satisfies Meta<typeof MeetingCommentSection>;
 
@@ -227,16 +119,28 @@ type Story = StoryObj<typeof meta>;
 
 export const NotLoggedIn: Story = {
   name: '비로그인 (입력창 비활성화)',
+  args: {
+    meetingId: 1,
+    initialComments: mockComments,
+  },
   decorators: [withAuthState({ user: null, isAuthenticated: false })],
 };
 
 export const LoggedIn: Story = {
   name: '로그인 (입력창 활성화)',
+  args: {
+    meetingId: 1,
+    initialComments: mockComments,
+  },
   decorators: [withAuthState({ user: MOCK_USER, isAuthenticated: true })],
 };
 
 export const LoggedInWithProfileImage: Story = {
   name: '로그인 / 프로필 이미지',
+  args: {
+    meetingId: 1,
+    initialComments: mockComments,
+  },
   decorators: [
     withAuthState({
       user: {
@@ -251,8 +155,8 @@ export const LoggedInWithProfileImage: Story = {
 export const WithScroll: Story = {
   name: '스크롤 (댓글 6개 이상)',
   args: {
-    comments: manyMockComments,
-    commentCount: manyMockComments.length,
+    meetingId: 1,
+    initialComments: manyMockComments,
   },
   decorators: [withAuthState({ user: MOCK_USER, isAuthenticated: true })],
 };
@@ -260,8 +164,8 @@ export const WithScroll: Story = {
 export const Empty: Story = {
   name: '댓글 없음',
   args: {
-    comments: [],
-    commentCount: 0,
+    meetingId: 1,
+    initialComments: [],
   },
   decorators: [withAuthState({ user: MOCK_USER, isAuthenticated: true })],
 };

--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.test.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -5,6 +6,13 @@ import { useAuthStore } from '@/store/auth-store';
 
 import { MeetingCommentSection } from './meeting-comment-section';
 import type { MeetingComment } from './meeting-comment-section.types';
+
+const mockMutate = jest.fn();
+
+jest.mock('@/services/comments', () => ({
+  useComments: jest.fn(() => ({ data: [] })),
+  useCreateComment: jest.fn(() => ({ mutate: mockMutate, isPending: false })),
+}));
 
 const mockComments: MeetingComment[] = [
   {
@@ -23,48 +31,66 @@ const mockComments: MeetingComment[] = [
 
 const MOCK_USER = { id: 1, name: '홍길동', email: 'test@example.com' };
 
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
 beforeEach(() => {
   useAuthStore.setState({ user: null, isAuthenticated: false });
+  mockMutate.mockClear();
 });
 
 describe('MeetingCommentSection', () => {
   describe('비로그인 상태', () => {
     it('입력창이 비활성화된다', () => {
-      render(<MeetingCommentSection comments={mockComments} />);
+      render(<MeetingCommentSection meetingId={1} initialComments={mockComments} />, {
+        wrapper: createWrapper(),
+      });
 
       expect(screen.getByRole('textbox')).toBeDisabled();
     });
 
     it('로그인 안내 placeholder가 표시된다', () => {
-      render(<MeetingCommentSection comments={mockComments} />);
+      render(<MeetingCommentSection meetingId={1} initialComments={mockComments} />, {
+        wrapper: createWrapper(),
+      });
 
       expect(
         screen.getByPlaceholderText('로그인 후 댓글을 작성할 수 있습니다.')
       ).toBeInTheDocument();
     });
+  });
 
-    describe('로그인 상태', () => {
-      beforeEach(() => {
-        useAuthStore.setState({ user: MOCK_USER, isAuthenticated: true });
+  describe('로그인 상태', () => {
+    beforeEach(() => {
+      useAuthStore.setState({ user: MOCK_USER, isAuthenticated: true });
+    });
+
+    it('입력창이 활성화된다', () => {
+      render(<MeetingCommentSection meetingId={1} initialComments={mockComments} />, {
+        wrapper: createWrapper(),
       });
 
-      it('입력창이 활성화된다', () => {
-        render(<MeetingCommentSection comments={mockComments} />);
+      expect(screen.getByRole('textbox')).not.toBeDisabled();
+    });
 
-        expect(screen.getByRole('textbox')).not.toBeDisabled();
+    it('텍스트 입력 후 제출하면 입력창이 초기화된다', async () => {
+      const user = userEvent.setup();
+      render(<MeetingCommentSection meetingId={1} initialComments={mockComments} />, {
+        wrapper: createWrapper(),
       });
 
-      it('텍스트 입력 후 제출하면 입력창이 초기화된다', async () => {
-        const user = userEvent.setup();
-        render(<MeetingCommentSection comments={mockComments} />);
+      const textarea = screen.getByRole('textbox');
+      await user.type(textarea, '새 댓글입니다');
+      expect(textarea).toHaveValue('새 댓글입니다');
 
-        const textarea = screen.getByRole('textbox');
-        await user.type(textarea, '새 댓글입니다');
-        expect(textarea).toHaveValue('새 댓글입니다');
-
-        await user.click(screen.getByRole('button', { name: '댓글 전송' }));
-        expect(textarea).toHaveValue('');
-      });
+      await user.click(screen.getByRole('button', { name: '댓글 전송' }));
+      expect(textarea).toHaveValue('');
     });
   });
 });

--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.tsx
@@ -8,27 +8,57 @@ import { CommentInput } from '@/components/common/comment-input';
 import { CountingBadge } from '@/components/common/counting-badge/counting-badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
+import type { Comment } from '@/services/comments';
+import { useComments, useCreateComment } from '@/services/comments';
 import { useAuthStore } from '@/store/auth-store';
 
 import { buildCommentTree } from './comment-tree';
 import { MeetingCommentItem } from './meeting-comment-item';
-import type { MeetingCommentSectionProps } from './meeting-comment-section.types';
+import type { MeetingComment, MeetingCommentSectionProps } from './meeting-comment-section.types';
+
+function toMeetingCommentTree(raw: Comment[]): MeetingComment[] {
+  const list = raw as MeetingComment[];
+  if (list.some((c) => c.parentId != null)) {
+    return buildCommentTree(list);
+  }
+  return list;
+}
+
+function countNonDeleted(nodes: MeetingComment[]): number {
+  let n = 0;
+  const walk = (c: MeetingComment) => {
+    if (!c.isDeleted) n += 1;
+    c.replies?.forEach(walk);
+  };
+  nodes.forEach(walk);
+  return n;
+}
 
 export function MeetingCommentSection({
-  comments,
-  commentCount,
+  meetingId,
+  initialComments,
   className,
 }: MeetingCommentSectionProps) {
   const [commentText, setCommentText] = useState('');
-  const user = useAuthStore((state) => state.user);
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { isAuthenticated, user } = useAuthStore();
+  const { data: comments } = useComments(meetingId, initialComments as Comment[]);
+  const { mutate: createComment, isPending: isCreateCommentPending } = useCreateComment(meetingId, {
+    nickname: user?.name ?? '',
+    profileUrl: user?.image ?? null,
+  });
 
-  const totalCommentCount = commentCount ?? comments.length;
-  const treeComments = buildCommentTree(comments);
+  const tree = toMeetingCommentTree(comments ?? []);
+  const totalCommentCount = countNonDeleted(tree);
+  const visibleRoots = tree.filter(
+    (comment) => !comment.isDeleted || comment.replies?.some((r) => !r.isDeleted)
+  );
 
-  const commentList = treeComments.map((comment) => (
-    <MeetingCommentItem key={comment.id} comment={comment} />
-  ));
+  const handleSubmit = () => {
+    const trimmed = commentText.trim();
+    if (!trimmed) return;
+    createComment({ content: trimmed });
+    setCommentText('');
+  };
 
   return (
     <section
@@ -37,7 +67,6 @@ export function MeetingCommentSection({
         className
       )}
     >
-      {/* 헤더 */}
       <div className="flex items-center gap-2">
         <MessageSquareText className="text-sosoeat-orange-600 size-5" />
         <h2 className="text-sosoeat-gray-900 text-xl font-bold">댓글</h2>
@@ -49,22 +78,24 @@ export function MeetingCommentSection({
         </span>
       </div>
 
-      {/* 댓글 목록 */}
       <ScrollArea className="mt-4 *:data-radix-scroll-area-viewport:h-auto! *:data-radix-scroll-area-viewport:max-h-[994px]">
-        <div className="space-y-4 pr-4">{commentList}</div>
+        <div className="space-y-4 pr-4">
+          {visibleRoots.map((comment) => (
+            <MeetingCommentItem key={comment.id} comment={comment} meetingId={meetingId} />
+          ))}
+        </div>
       </ScrollArea>
 
-      {/* 댓글 입력창 */}
       <div className="mt-4 rounded-[24px] px-6 py-4">
         <CommentInput
           value={commentText}
           onChange={setCommentText}
-          onSubmit={() => setCommentText('')}
-          disabled={!isAuthenticated}
+          onSubmit={handleSubmit}
+          disabled={!isAuthenticated || isCreateCommentPending}
           placeholder={
             isAuthenticated ? '댓글을 입력하세요.' : '로그인 후 댓글을 작성할 수 있습니다.'
           }
-          currentUserName={user?.name}
+          currentUserName={user?.name ?? '사용자'}
           currentUserImageUrl={user?.image ?? undefined}
         />
       </div>

--- a/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.types.ts
+++ b/src/app/meetings/[id]/_components/meeting-comment-section/meeting-comment-section.types.ts
@@ -1,26 +1,22 @@
 export interface MeetingComment {
   id: number;
-  parentId: number | null; // 대댓글이면 부모 댓글 ID, 일반 댓글이면 null
+  parentId: number | null;
   content: string;
   isDeleted: boolean;
   createdAt: string;
-
   author: {
     nickname: string;
     profileUrl: string | null;
   };
-
   likeCount: number;
   isLiked: boolean;
-
-  isHostComment: boolean; // 모임 호스트가 단 댓글 → "작성자" 뱃지
-  isMine: boolean; // 내가 단 댓글 → 수정/삭제 버튼
-
+  isHostComment: boolean;
+  isMine: boolean;
   replies?: MeetingComment[];
 }
 
 export interface MeetingCommentSectionProps {
-  comments: MeetingComment[];
-  commentCount?: number;
+  meetingId: number;
+  initialComments?: MeetingComment[];
   className?: string;
 }

--- a/src/app/meetings/[id]/page.tsx
+++ b/src/app/meetings/[id]/page.tsx
@@ -1,6 +1,9 @@
+import { commentServer } from '@/lib/http/comment-server';
 import { getMeetings } from '@/services/meetings/meetings.server';
 import type { Meeting } from '@/types/meeting';
 
+import type { MeetingComment } from './_components/meeting-comment-section';
+import { MeetingCommentSection } from './_components/meeting-comment-section';
 import { MeetingHeroSection } from './_components/meeting-hero-section';
 import { MeetingLocationSection } from './_components/meeting-location-section';
 import { MeetingRecommendedSection } from './_components/meeting-recommended-section';
@@ -18,13 +21,19 @@ export default async function MeetingDetailPage({ params }: Props) {
 
   const meetingData = await getMeetingById(meetingId);
 
-  const [meetingList] = await Promise.allSettled([
+  const [meetingList, commentsResult] = await Promise.allSettled([
     getMeetings({ region: meetingData.region, size: 4 }),
+    commentServer.get(`/meetings/${meetingId}/comments`),
   ]);
 
   const recommendedMeetingsRaw: Meeting[] =
     meetingList.status === 'fulfilled' ? (meetingList.value.data as unknown as Meeting[]) : [];
   const recommendedMeetings = recommendedMeetingsRaw.filter((m) => m.id !== meetingId);
+
+  let initialComments: MeetingComment[] = [];
+  if (commentsResult.status === 'fulfilled' && commentsResult.value.ok) {
+    initialComments = await commentsResult.value.json();
+  }
 
   return (
     <main className="space-y-[30px] py-10">
@@ -40,6 +49,7 @@ export default async function MeetingDetailPage({ params }: Props) {
       </section>
 
       <MeetingLocationSection address={meetingData.address} />
+      <MeetingCommentSection meetingId={meetingId} initialComments={initialComments} />
       <MeetingRecommendedSection meetings={recommendedMeetings} />
     </main>
   );

--- a/src/lib/http/comment-client.ts
+++ b/src/lib/http/comment-client.ts
@@ -25,7 +25,6 @@ const request = async (url: string, options: RequestInit = {}): Promise<Response
 
   const response = await fetch(fullUrl, { ...options, headers });
 
-  // proxy를 경유한 요청에서 silentRefresh까지 실패한 401 → 세션 만료 알림 모달 띄우기
   if (response.status === 401 && fullUrl.startsWith('/api/comment-proxy/')) {
     onSessionExpired?.();
   }

--- a/src/lib/http/comment-server.ts
+++ b/src/lib/http/comment-server.ts
@@ -35,7 +35,6 @@ const request = async (
     if (refreshed) {
       return request(url, options, true);
     }
-    // silentRefresh 실패 시 세션 만료 → 로그인 페이지로
     redirect('/login');
   }
 

--- a/src/services/comments/comment.api.test.ts
+++ b/src/services/comments/comment.api.test.ts
@@ -1,0 +1,161 @@
+import { commentClient } from '@/lib/http/comment-client';
+
+import { commentApi } from './comment.api';
+
+jest.mock('@/lib/http/comment-client', () => ({
+  commentClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockClient = commentClient as unknown as {
+  get: jest.Mock;
+  post: jest.Mock;
+  patch: jest.Mock;
+  delete: jest.Mock;
+};
+
+const okResponse = (data: unknown) => ({
+  ok: true,
+  json: jest.fn().mockResolvedValue(data),
+});
+
+const errorResponse = (message?: string) => ({
+  ok: false,
+  json: jest.fn().mockResolvedValue(message ? { message } : {}),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('commentApi.getComments', () => {
+  it('올바른 URL로 GET 요청을 보낸다', async () => {
+    mockClient.get.mockResolvedValue(okResponse([]));
+    await commentApi.getComments(1);
+    expect(mockClient.get).toHaveBeenCalledWith('/meetings/1/comments');
+  });
+
+  it('응답 실패 시 서버 메시지로 에러를 throw 한다', async () => {
+    mockClient.get.mockResolvedValue(errorResponse('서버 오류'));
+    await expect(commentApi.getComments(1)).rejects.toThrow('서버 오류');
+  });
+
+  it('응답 실패 시 메시지 없으면 기본 에러를 throw 한다', async () => {
+    mockClient.get.mockResolvedValue(errorResponse());
+    await expect(commentApi.getComments(1)).rejects.toThrow('댓글을 불러오는데 실패했습니다.');
+  });
+});
+
+describe('commentApi.getCommentCount', () => {
+  it('올바른 URL로 GET 요청을 보낸다', async () => {
+    mockClient.get.mockResolvedValue(okResponse({ count: 5 }));
+    await commentApi.getCommentCount(1);
+    expect(mockClient.get).toHaveBeenCalledWith('/meetings/1/comments/count');
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.get.mockResolvedValue(errorResponse('조회 실패'));
+    await expect(commentApi.getCommentCount(1)).rejects.toThrow('조회 실패');
+  });
+});
+
+describe('commentApi.createComment', () => {
+  const payload = { content: '안녕하세요' };
+
+  it('올바른 URL과 payload로 POST 요청을 보낸다', async () => {
+    mockClient.post.mockResolvedValue(okResponse({ id: 1, content: '안녕하세요' }));
+    await commentApi.createComment(1, payload);
+    expect(mockClient.post).toHaveBeenCalledWith('/meetings/1/comments', payload);
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.post.mockResolvedValue(errorResponse('댓글 작성 실패'));
+    await expect(commentApi.createComment(1, payload)).rejects.toThrow('댓글 작성 실패');
+  });
+});
+
+describe('commentApi.updateComment', () => {
+  const payload = { content: '수정된 내용' };
+
+  it('올바른 URL과 payload로 PATCH 요청을 보낸다', async () => {
+    mockClient.patch.mockResolvedValue(okResponse({ id: 10, content: '수정된 내용' }));
+    await commentApi.updateComment(10, payload);
+    expect(mockClient.patch).toHaveBeenCalledWith('/comments/10', payload);
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.patch.mockResolvedValue(errorResponse('댓글 수정 실패'));
+    await expect(commentApi.updateComment(10, payload)).rejects.toThrow('댓글 수정 실패');
+  });
+});
+
+describe('commentApi.deleteComment', () => {
+  it('올바른 URL로 DELETE 요청을 보낸다', async () => {
+    mockClient.delete.mockResolvedValue(okResponse(null));
+    await commentApi.deleteComment(10);
+    expect(mockClient.delete).toHaveBeenCalledWith('/comments/10');
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.delete.mockResolvedValue(errorResponse('댓글 삭제 실패'));
+    await expect(commentApi.deleteComment(10)).rejects.toThrow('댓글 삭제 실패');
+  });
+});
+
+describe('commentApi.likeComment', () => {
+  it('올바른 URL로 POST 요청을 보낸다', async () => {
+    mockClient.post.mockResolvedValue(okResponse(null));
+    await commentApi.likeComment(10);
+    expect(mockClient.post).toHaveBeenCalledWith('/comments/10/likes');
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.post.mockResolvedValue(errorResponse('좋아요 실패'));
+    await expect(commentApi.likeComment(10)).rejects.toThrow('좋아요 실패');
+  });
+});
+
+describe('commentApi.unlikeComment', () => {
+  it('올바른 URL로 DELETE 요청을 보낸다', async () => {
+    mockClient.delete.mockResolvedValue(okResponse(null));
+    await commentApi.unlikeComment(10);
+    expect(mockClient.delete).toHaveBeenCalledWith('/comments/10/likes');
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.delete.mockResolvedValue(errorResponse('좋아요 취소 실패'));
+    await expect(commentApi.unlikeComment(10)).rejects.toThrow('좋아요 취소 실패');
+  });
+});
+
+describe('commentApi.syncCreateMeeting', () => {
+  const payload = { id: 1, hostId: 42, teamId: 'team-abc' };
+
+  it('올바른 URL과 payload로 POST 요청을 보낸다', async () => {
+    mockClient.post.mockResolvedValue(okResponse(null));
+    await commentApi.syncCreateMeeting(payload);
+    expect(mockClient.post).toHaveBeenCalledWith('/meetings', payload);
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.post.mockResolvedValue(errorResponse('동기화 실패'));
+    await expect(commentApi.syncCreateMeeting(payload)).rejects.toThrow('동기화 실패');
+  });
+});
+
+describe('commentApi.syncDeleteMeeting', () => {
+  it('올바른 URL로 DELETE 요청을 보낸다', async () => {
+    mockClient.delete.mockResolvedValue(okResponse(null));
+    await commentApi.syncDeleteMeeting(1);
+    expect(mockClient.delete).toHaveBeenCalledWith('/meetings/1');
+  });
+
+  it('응답 실패 시 에러를 throw 한다', async () => {
+    mockClient.delete.mockResolvedValue(errorResponse('삭제 동기화 실패'));
+    await expect(commentApi.syncDeleteMeeting(1)).rejects.toThrow('삭제 동기화 실패');
+  });
+});

--- a/src/services/comments/comment.api.ts
+++ b/src/services/comments/comment.api.ts
@@ -1,0 +1,120 @@
+import { commentClient } from '@/lib/http/comment-client';
+
+export type Comment = {
+  id: number;
+  parentId: number | null;
+  content: string;
+  isDeleted: boolean;
+  createdAt: string;
+  author: {
+    nickname: string;
+    profileUrl: string | null;
+  };
+  likeCount: number;
+  isLiked: boolean;
+  isHostComment: boolean;
+  isMine: boolean;
+  replies: Comment[];
+};
+
+export type CreateCommentRequest = {
+  content: string;
+  parentId?: number | null;
+};
+
+export type UpdateCommentRequest = {
+  content: string;
+};
+
+export type CommentCountResponse = {
+  count: number;
+};
+
+export type SyncMeetingRequest = {
+  id: number;
+  hostId: number;
+  teamId: string;
+};
+
+/**
+ * [Service Layer] commentApi
+ * comment server와 연동하여 댓글 관련 비동기 작업을 처리합니다.
+ * 클라이언트 컴포넌트 전용 (comment-client 사용)
+ */
+export const commentApi = {
+  async getComments(meetingId: number): Promise<Comment[]> {
+    const response = await commentClient.get(`/meetings/${meetingId}/comments`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '댓글을 불러오는데 실패했습니다.');
+    }
+    return response.json();
+  },
+
+  async getCommentCount(meetingId: number): Promise<CommentCountResponse> {
+    const response = await commentClient.get(`/meetings/${meetingId}/comments/count`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '댓글 수를 불러오는데 실패했습니다.');
+    }
+    return response.json();
+  },
+
+  async createComment(meetingId: number, payload: CreateCommentRequest): Promise<Comment> {
+    const response = await commentClient.post(`/meetings/${meetingId}/comments`, payload);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '댓글 작성에 실패했습니다.');
+    }
+    return response.json();
+  },
+
+  async updateComment(commentId: number, payload: UpdateCommentRequest): Promise<Comment> {
+    const response = await commentClient.patch(`/comments/${commentId}`, payload);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '댓글 수정에 실패했습니다.');
+    }
+    return response.json();
+  },
+
+  async deleteComment(commentId: number): Promise<void> {
+    const response = await commentClient.delete(`/comments/${commentId}`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '댓글 삭제에 실패했습니다.');
+    }
+  },
+
+  async likeComment(commentId: number): Promise<void> {
+    const response = await commentClient.post(`/comments/${commentId}/likes`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '좋아요에 실패했습니다.');
+    }
+  },
+
+  async unlikeComment(commentId: number): Promise<void> {
+    const response = await commentClient.delete(`/comments/${commentId}/likes`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '좋아요 취소에 실패했습니다.');
+    }
+  },
+
+  async syncCreateMeeting(payload: SyncMeetingRequest): Promise<void> {
+    const response = await commentClient.post('/meetings', payload);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '모임 동기화에 실패했습니다.');
+    }
+  },
+
+  async syncDeleteMeeting(meetingId: number): Promise<void> {
+    const response = await commentClient.delete(`/meetings/${meetingId}`);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '모임 삭제 동기화에 실패했습니다.');
+    }
+  },
+};

--- a/src/services/comments/comment.queries.test.ts
+++ b/src/services/comments/comment.queries.test.ts
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
+
+import { commentApi } from './comment.api';
+import { commentKeys, useCreateComment, useDeleteComment } from './comment.queries';
+
+jest.mock('./comment.api', () => ({
+  commentApi: {
+    createComment: jest.fn(),
+    deleteComment: jest.fn(),
+  },
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockCreateComment = commentApi.createComment as jest.Mock;
+const mockDeleteComment = commentApi.deleteComment as jest.Mock;
+
+const MEETING_ID = 1;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useCreateComment', () => {
+  it('성공 시 댓글 목록 쿼리를 invalidate 한다', async () => {
+    mockCreateComment.mockResolvedValue({ id: 1, content: '새 댓글' });
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useCreateComment(MEETING_ID, { nickname: '테스트', profileUrl: null }),
+      { wrapper }
+    );
+
+    result.current.mutate({ content: '새 댓글' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: commentKeys.list(MEETING_ID),
+    });
+  });
+
+  it('실패 시 error toast를 띄운다', async () => {
+    mockCreateComment.mockRejectedValue(new Error('댓글 작성 실패'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useCreateComment(MEETING_ID, { nickname: '테스트', profileUrl: null }),
+      { wrapper }
+    );
+
+    result.current.mutate({ content: '새 댓글' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith('댓글 작성 실패');
+  });
+});
+
+describe('useDeleteComment', () => {
+  it('성공 시 댓글 목록 쿼리를 invalidate 한다', async () => {
+    mockDeleteComment.mockResolvedValue(undefined);
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteComment(MEETING_ID), { wrapper });
+
+    result.current.mutate(10);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: commentKeys.list(MEETING_ID),
+    });
+  });
+
+  it('실패 시 error toast를 띄운다', async () => {
+    mockDeleteComment.mockRejectedValue(new Error('댓글 삭제 실패'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteComment(MEETING_ID), { wrapper });
+
+    result.current.mutate(10);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith('댓글 삭제 실패');
+  });
+});

--- a/src/services/comments/comment.queries.ts
+++ b/src/services/comments/comment.queries.ts
@@ -1,0 +1,225 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import {
+  Comment,
+  commentApi,
+  CreateCommentRequest,
+  SyncMeetingRequest,
+  UpdateCommentRequest,
+} from './comment.api';
+
+export const commentKeys = {
+  all: ['comments'] as const,
+  list: (meetingId: number) => ['comments', meetingId] as const,
+  count: (meetingId: number) => ['comments', meetingId, 'count'] as const,
+};
+
+const COMMENT_LIST_STALE_MS = 30_000;
+
+export const useComments = (meetingId: number, initialData?: Comment[]) => {
+  return useQuery({
+    queryKey: commentKeys.list(meetingId),
+    queryFn: () => commentApi.getComments(meetingId),
+    initialData,
+    staleTime: COMMENT_LIST_STALE_MS,
+    retry: false,
+  });
+};
+
+type CommentAuthor = {
+  nickname: string;
+  profileUrl: string | null;
+};
+
+export const useCreateComment = (meetingId: number, author: CommentAuthor) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateCommentRequest) => commentApi.createComment(meetingId, payload),
+    onMutate: async (payload: CreateCommentRequest) => {
+      await queryClient.cancelQueries({ queryKey: commentKeys.list(meetingId) });
+      const previousComments = queryClient.getQueryData(commentKeys.list(meetingId));
+
+      const optimisticComment: Comment = {
+        id: -Date.now(),
+        parentId: payload.parentId ?? null,
+        content: payload.content,
+        isDeleted: false,
+        createdAt: new Date().toISOString(),
+        author,
+        likeCount: 0,
+        isLiked: false,
+        isHostComment: false,
+        isMine: true,
+        replies: [],
+      };
+
+      queryClient.setQueryData(commentKeys.list(meetingId), (old: Comment[] | undefined) => {
+        if (!old) return [optimisticComment];
+        if (payload.parentId) {
+          return old.map((comment) =>
+            comment.id === payload.parentId
+              ? { ...comment, replies: [...(comment.replies ?? []), optimisticComment] }
+              : comment
+          );
+        }
+        return [...old, optimisticComment];
+      });
+
+      return { previousComments };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(meetingId) });
+      queryClient.invalidateQueries({ queryKey: commentKeys.count(meetingId) });
+    },
+    onError: (error: Error, _, context) => {
+      if (context?.previousComments) {
+        queryClient.setQueryData(commentKeys.list(meetingId), context.previousComments);
+      }
+      toast.error(error.message || '댓글 작성 중 오류가 발생했습니다.');
+    },
+  });
+};
+
+export const useUpdateComment = (meetingId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId, payload }: { commentId: number; payload: UpdateCommentRequest }) =>
+      commentApi.updateComment(commentId, payload),
+    onMutate: async ({ commentId, payload }) => {
+      await queryClient.cancelQueries({ queryKey: commentKeys.list(meetingId) });
+      const previousComments = queryClient.getQueryData(commentKeys.list(meetingId));
+
+      queryClient.setQueryData(commentKeys.list(meetingId), (old: Comment[] | undefined) => {
+        if (!old) return old;
+        return old.map((comment) => {
+          if (comment.id === commentId) {
+            return { ...comment, content: payload.content };
+          }
+          return {
+            ...comment,
+            replies: comment.replies?.map((reply) =>
+              reply.id === commentId ? { ...reply, content: payload.content } : reply
+            ),
+          };
+        });
+      });
+
+      return { previousComments };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(meetingId) });
+      toast.success('댓글이 수정되었습니다.');
+    },
+    onError: (error: Error, _, context) => {
+      if (context?.previousComments) {
+        queryClient.setQueryData(commentKeys.list(meetingId), context.previousComments);
+      }
+      toast.error(error.message || '댓글 수정 중 오류가 발생했습니다.');
+    },
+  });
+};
+
+export const useDeleteComment = (meetingId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentId: number) => commentApi.deleteComment(commentId),
+    onMutate: async (commentId: number) => {
+      await queryClient.cancelQueries({ queryKey: commentKeys.list(meetingId) });
+      const previousComments = queryClient.getQueryData(commentKeys.list(meetingId));
+
+      queryClient.setQueryData(commentKeys.list(meetingId), (old: Comment[] | undefined) => {
+        if (!old) return old;
+        return old.map((comment) => {
+          if (comment.id === commentId) {
+            return { ...comment, isDeleted: true };
+          }
+          return {
+            ...comment,
+            replies: comment.replies?.map((reply) =>
+              reply.id === commentId ? { ...reply, isDeleted: true } : reply
+            ),
+          };
+        });
+      });
+
+      return { previousComments };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(meetingId) });
+      queryClient.invalidateQueries({ queryKey: commentKeys.count(meetingId) });
+      toast.success('댓글이 삭제되었습니다.');
+    },
+    onError: (error: Error, _, context) => {
+      if (context?.previousComments) {
+        queryClient.setQueryData(commentKeys.list(meetingId), context.previousComments);
+      }
+      toast.error(error.message || '댓글 삭제 중 오류가 발생했습니다.');
+    },
+  });
+};
+
+export const useLikeComment = (meetingId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId, isLiked }: { commentId: number; isLiked: boolean }) =>
+      isLiked ? commentApi.unlikeComment(commentId) : commentApi.likeComment(commentId),
+
+    onMutate: async ({ commentId, isLiked }) => {
+      await queryClient.cancelQueries({ queryKey: commentKeys.list(meetingId) });
+      const previousComments = queryClient.getQueryData(commentKeys.list(meetingId));
+
+      queryClient.setQueryData(commentKeys.list(meetingId), (old: Comment[] | undefined) => {
+        if (!old) return old;
+        return old.map((comment) => {
+          if (comment.id === commentId) {
+            return {
+              ...comment,
+              isLiked: !isLiked,
+              likeCount: isLiked ? comment.likeCount - 1 : comment.likeCount + 1,
+            };
+          }
+          return {
+            ...comment,
+            replies: comment.replies?.map((reply) =>
+              reply.id === commentId
+                ? {
+                    ...reply,
+                    isLiked: !isLiked,
+                    likeCount: isLiked ? reply.likeCount - 1 : reply.likeCount + 1,
+                  }
+                : reply
+            ),
+          };
+        });
+      });
+
+      return { previousComments };
+    },
+
+    onError: (_, __, context) => {
+      if (context?.previousComments) {
+        queryClient.setQueryData(commentKeys.list(meetingId), context.previousComments);
+      }
+      toast.error('좋아요 처리 중 오류가 발생했습니다.');
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(meetingId) });
+    },
+  });
+};
+
+export const useSyncCreateMeeting = () => {
+  return useMutation({
+    mutationFn: (payload: SyncMeetingRequest) => commentApi.syncCreateMeeting(payload),
+    retry: 3,
+    onError: () => {
+      console.error('[syncCreateMeeting] 동기화 실패');
+    },
+  });
+};

--- a/src/services/comments/index.ts
+++ b/src/services/comments/index.ts
@@ -1,0 +1,17 @@
+export type {
+  Comment,
+  CommentCountResponse,
+  CreateCommentRequest,
+  SyncMeetingRequest,
+  UpdateCommentRequest,
+} from './comment.api';
+export { commentApi } from './comment.api';
+export {
+  commentKeys,
+  useComments,
+  useCreateComment,
+  useDeleteComment,
+  useLikeComment,
+  useSyncCreateMeeting,
+  useUpdateComment,
+} from './comment.queries';

--- a/src/services/meetings/meetings.queries.test.ts
+++ b/src/services/meetings/meetings.queries.test.ts
@@ -4,15 +4,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { toast } from 'sonner';
 
+import { commentApi } from '@/services/comments';
 import type { CreateMeeting } from '@/types/generated-client/models/CreateMeeting';
 
 import { meetingsApi } from './meetings.api';
 import { useCreateMeeting } from './meetings.queries';
-
-const mockPush = jest.fn();
-jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush }),
-}));
 
 jest.mock('./meetings.api', () => ({
   meetingsApi: {
@@ -27,7 +23,14 @@ jest.mock('sonner', () => ({
   },
 }));
 
+jest.mock('@/services/comments', () => ({
+  commentApi: {
+    syncCreateMeeting: jest.fn(),
+  },
+}));
+
 const mockCreate = meetingsApi.create as jest.Mock;
+const mockSyncCreateMeeting = commentApi.syncCreateMeeting as jest.Mock;
 
 const createWrapper = () => {
   const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
@@ -54,7 +57,9 @@ describe('useCreateMeeting', () => {
   });
 
   it('모임 생성 성공 시 isSuccess 상태가 되고 success toast를 띄운다', async () => {
-    mockCreate.mockResolvedValue({ id: 42 });
+    const mockMeeting = { id: 1, hostId: 42, teamId: 'team-abc' };
+    mockCreate.mockResolvedValue(mockMeeting);
+    mockSyncCreateMeeting.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useCreateMeeting(), {
       wrapper: createWrapper(),
@@ -64,20 +69,12 @@ describe('useCreateMeeting', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockCreate).toHaveBeenCalledTimes(1);
-    expect(toast.success).toHaveBeenCalled();
-  });
-
-  it('모임 생성 성공 시 생성된 모임 상세 페이지로 이동한다', async () => {
-    mockCreate.mockResolvedValue({ id: 42 });
-
-    const { result } = renderHook(() => useCreateMeeting(), {
-      wrapper: createWrapper(),
+    expect(mockSyncCreateMeeting).toHaveBeenCalledWith({
+      id: mockMeeting.id,
+      hostId: mockMeeting.hostId,
+      teamId: mockMeeting.teamId,
     });
-
-    result.current.mutate(MOCK_PAYLOAD);
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockPush).toHaveBeenCalledWith('/meetings/42');
+    expect(toast.success).toHaveBeenCalled();
   });
 
   it('모임 생성 실패 시 isError 상태가 되고 error toast를 띄운다', async () => {

--- a/src/services/meetings/meetings.queries.ts
+++ b/src/services/meetings/meetings.queries.ts
@@ -1,27 +1,27 @@
-import { useRouter } from 'next/navigation';
-
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
+import { commentApi } from '@/services/comments';
 import { CreateMeeting } from '@/types/generated-client/models/CreateMeeting';
 import { UpdateMeeting } from '@/types/generated-client/models/UpdateMeeting';
 
 import { meetingsApi } from './meetings.api';
 
-export const useCreateMeeting = () => {
-  const router = useRouter();
-
-  return useMutation({
+export const useCreateMeeting = () =>
+  useMutation({
     mutationFn: (payload: CreateMeeting) => meetingsApi.create(payload),
-    onSuccess: (data) => {
+    onSuccess: (meeting) => {
+      commentApi.syncCreateMeeting({
+        id: meeting.id,
+        hostId: meeting.hostId,
+        teamId: meeting.teamId,
+      });
       toast.success('모임이 생성되었습니다.');
-      router.push(`/meetings/${data.id}`);
     },
     onError: (error: Error) => {
       toast.error(error.message || '모임 생성 중 오류가 발생했습니다.');
     },
   });
-};
 
 export const useUpdateMeeting = (id: number, onSuccess?: () => void) =>
   useMutation({


### PR DESCRIPTION
### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

**범위:** 커밋 `287362d` — `feat/197-meeting-core` 대비 **댓글 서버 연동·모임 상세 댓글 UI·테스트**만 포함. (#197)

#### `src/services/comments/` (신규)

- `comment.api.ts`: 댓글 CRUD·목록·개수·좋아요/취소, 댓글 서버 쪽 **모임 동기화**(`syncCreateMeeting`, `syncDeleteMeeting`) 등 `commentClient` 기반 API 래핑. `Comment`·요청/응답 타입 정의.
- `comment.queries.ts`: `commentKeys`, `useComments`(초기 데이터·staleTime), `useCreateComment` / `useUpdateComment` / `useDeleteComment` / `useLikeComment` — **낙관적 업데이트·롤백·invalidate**, 토스트. `useSyncCreateMeeting`(재시도 3회) 노출.
- `index.ts`: 위 모듈 export.
- `comment.api.test.ts`, `comment.queries.test.ts`: API·쿼리 훅 단위 테스트.

#### 모임 상세 페이지 (`src/app/meetings/[id]/page.tsx`)

- `commentServer.get(\`/meetings/${meetingId}/comments\`)`로 **SSR 초기 댓글** 조회(`Promise.allSettled`로 추천 목록과 병렬).
- 응답이 성공일 때만 JSON 파싱해 `MeetingCommentSection`에 `initialComments`로 전달.
- 레이아웃: 위치 섹션 다음에 **`MeetingCommentSection`**, 이후 추천 섹션.

#### `meeting-comment-section` 일대

- `meeting-comment-section.tsx` / `.types.ts`: 서버에서 받은 초기 댓글·`meetingId`와 React Query 연동, 입력/목록 플로우 정리.
- `meeting-comment-item.tsx`: **실제 `comment.id`** 기준 수정·삭제·좋아요 뮤테이션 연동, UI 확장.
- `comment-delete-modal.tsx`: 삭제 확인 모달 추가.
- `format-date.ts`: 표시용 날짜 포맷 유틸.
- 스토리·테스트(`meeting-comment-section`, `meeting-comment-item`) 갱신.

#### BFF

- `src/app/api/comment-proxy/[...path]/route.ts`: `COMMENT_SERVER_URL`로 프록시, 쿠키 기반 `Authorization`, **401 시 `silentRefresh` 후 1회 재시도**.

#### 모임 생성 플로우와 댓글 서버 동기화 (`meetings.queries.ts`)

- `useCreateMeeting` 성공 시 `commentApi.syncCreateMeeting({ id, hostId, teamId })` 호출로 **댓글 DB에 모임 메타 동기화**.
- 이 diff 기준으로 **`useRouter` 및 생성 후 `/meetings/{id}`로 이동(`router.push`)은 제거됨** — 의도한 UX인지 리뷰 시 확인 필요.

#### `comment-client` / `comment-server`

- 주석 한 줄 제거 수준의 소규모 정리만 포함(동작 변경 아님).

#### `meetings.queries.test.ts`

- 위 `useCreateMeeting` 변경에 맞게 테스트 수정.

### 🧪 테스트 방법 (How to Test)

1. 코어가 반영된 브랜치에서 실행.
2. 댓글 목록·작성·(구현 시) 삭제·대댓글 등 시나리오 확인.
3. 네트워크 탭에서 댓글 API·프록시·인증 확인.
4. `npm run type-check`, 댓글 관련 Jest 및 회귀 테스트.

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [ ] 낙관적 업데이트·토스트·권한(본인 댓글 삭제 등) 확인 부탁드립니다.
- [ ] 프로덕션 댓글 백엔드·프록시 설정 확인.