### PR TITLE
[Feat]: 모임 장소 지도·주소 영역 및 상세 히어로 UX 개선 (#212)

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom';
 
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: jest.fn() },
+  writable: true,
+  configurable: true,
+});
+
 jest.mock('isomorphic-dompurify', () => ({
   __esModule: true,
   default: {

--- a/src/shared/lib/write-clipboard-text.ts
+++ b/src/shared/lib/write-clipboard-text.ts
@@ -1,0 +1,4 @@
+/** 클립보드에 텍스트를 쓴다. navigator.clipboard 직접 호출을 한곳에 모아 테스트에서 mock 하기 쉽게 한다. */
+export async function writeClipboardText(text: string): Promise<void> {
+  await navigator.clipboard.writeText(text);
+}

--- a/src/shared/types/kakao-maps.d.ts
+++ b/src/shared/types/kakao-maps.d.ts
@@ -29,7 +29,7 @@ declare namespace kakao.maps {
   }
 
   class CustomOverlay {
-    constructor(options: { position: LatLng; content: string; yAnchor?: number });
+    constructor(options: { position: LatLng; content: string; yAnchor?: number; xAnchor?: number });
     setMap(map: Map | null): void;
   }
 

--- a/src/shared/ui/kakao-map/kakao-map.test.tsx
+++ b/src/shared/ui/kakao-map/kakao-map.test.tsx
@@ -2,26 +2,23 @@ import { render } from '@testing-library/react';
 
 import { KakaoMap } from './kakao-map';
 
-const mockMarker = jest.fn();
+const mockCustomOverlay = jest.fn();
 const mockMap = jest.fn();
 const mockLatLng = jest.fn();
-const mockSize = jest.fn();
-const mockPoint = jest.fn();
-const mockMarkerImage = jest.fn();
 
 const mockKakao = {
   maps: {
     load: (cb: () => void) => cb(),
     LatLng: mockLatLng,
-    Size: mockSize,
-    Point: mockPoint,
     Map: mockMap,
-    MarkerImage: mockMarkerImage,
-    Marker: mockMarker,
+    CustomOverlay: mockCustomOverlay,
   },
 };
 
 beforeEach(() => {
+  mockCustomOverlay.mockImplementation(() => ({
+    setMap: jest.fn(),
+  }));
   window.kakao = mockKakao as unknown as typeof kakao;
 });
 
@@ -41,13 +38,15 @@ describe('KakaoMap', () => {
     expect(mockMap).toHaveBeenCalled();
   });
 
-  it('로고 마커 이미지를 생성한다', () => {
+  it('브랜드 라벨이 있는 커스텀 오버레이를 생성한다', () => {
     render(<KakaoMap latitude={37.5697} longitude={126.9822} />);
-    expect(mockMarkerImage).toHaveBeenCalledWith(
-      '/images/logo.svg',
-      expect.any(Object),
-      expect.objectContaining({ offset: expect.any(Object) })
+    expect(mockCustomOverlay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        yAnchor: 1,
+        xAnchor: 0.5,
+        content: expect.stringContaining('소소잇'),
+      })
     );
-    expect(mockMarker).toHaveBeenCalled();
+    expect(mockCustomOverlay.mock.results[0]?.value.setMap).toHaveBeenCalled();
   });
 });

--- a/src/shared/ui/kakao-map/kakao-map.tsx
+++ b/src/shared/ui/kakao-map/kakao-map.tsx
@@ -4,25 +4,22 @@ import { useEffect, useRef } from 'react';
 
 import type { KakaoMapProps } from './kakao-map.types';
 
-const BRAND_LABEL = '소소잇';
 const MARKER_ACCENT = '#FF6600';
 
-/** 카카오 CustomOverlay용 HTML (인라인 스타일만 사용 — SDK가 문자열로 삽입함) */
-function buildMeetingPlaceOverlayContent(label: string): string {
-  const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z" fill="${MARKER_ACCENT}"/></svg>`;
+const PIN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z" fill="${MARKER_ACCENT}"/></svg>`;
 
-  return `
+/** 카카오 CustomOverlay용 HTML (인라인 스타일만 사용 — SDK가 문자열로 삽입함) */
+const MEETING_PLACE_OVERLAY_CONTENT = `
     <div style="display:flex;flex-direction:column;align-items:center;user-select:none;-webkit-user-select:none;outline:none;">
       <div style="display:flex;align-items:center;gap:6px;background:${MARKER_ACCENT};color:#fff;font-size:13px;font-weight:600;padding:6px 14px 6px 6px;border-radius:999px;box-shadow:0 2px 8px rgba(0,0,0,0.22);white-space:nowrap;">
         <div style="width:28px;height:28px;border-radius:50%;background:#fff;display:flex;align-items:center;justify-content:center;flex-shrink:0;">
-          ${pinSvg}
+          ${PIN_SVG}
         </div>
-        <span>${label}</span>
+        <span>소소잇</span>
       </div>
       <div style="width:0;height:0;border-left:7px solid transparent;border-right:7px solid transparent;border-top:9px solid ${MARKER_ACCENT};margin-top:-1px;"></div>
     </div>
   `;
-}
 
 export function KakaoMap({ latitude, longitude }: KakaoMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -47,7 +44,7 @@ export function KakaoMap({ latitude, longitude }: KakaoMapProps) {
 
       const customOverlay = new window.kakao.maps.CustomOverlay({
         position,
-        content: buildMeetingPlaceOverlayContent(BRAND_LABEL),
+        content: MEETING_PLACE_OVERLAY_CONTENT,
         yAnchor: 1,
         xAnchor: 0.5,
       });

--- a/src/shared/ui/kakao-map/kakao-map.tsx
+++ b/src/shared/ui/kakao-map/kakao-map.tsx
@@ -4,28 +4,68 @@ import { useEffect, useRef } from 'react';
 
 import type { KakaoMapProps } from './kakao-map.types';
 
+const BRAND_LABEL = '소소잇';
+const MARKER_ACCENT = '#FF6600';
+
+/** 카카오 CustomOverlay용 HTML (인라인 스타일만 사용 — SDK가 문자열로 삽입함) */
+function buildMeetingPlaceOverlayContent(label: string): string {
+  const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z" fill="${MARKER_ACCENT}"/></svg>`;
+
+  return `
+    <div style="display:flex;flex-direction:column;align-items:center;user-select:none;-webkit-user-select:none;outline:none;">
+      <div style="display:flex;align-items:center;gap:6px;background:${MARKER_ACCENT};color:#fff;font-size:13px;font-weight:600;padding:6px 14px 6px 6px;border-radius:999px;box-shadow:0 2px 8px rgba(0,0,0,0.22);white-space:nowrap;">
+        <div style="width:28px;height:28px;border-radius:50%;background:#fff;display:flex;align-items:center;justify-content:center;flex-shrink:0;">
+          ${pinSvg}
+        </div>
+        <span>${label}</span>
+      </div>
+      <div style="width:0;height:0;border-left:7px solid transparent;border-right:7px solid transparent;border-top:9px solid ${MARKER_ACCENT};margin-top:-1px;"></div>
+    </div>
+  `;
+}
+
 export function KakaoMap({ latitude, longitude }: KakaoMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    const node = containerRef.current;
+    if (!node) return;
+
+    let cancelled = false;
+    let overlay: kakao.maps.CustomOverlay | null = null;
 
     window.kakao.maps.load(() => {
-      if (!containerRef.current) return;
+      if (cancelled || !containerRef.current) return;
+
+      containerRef.current.innerHTML = '';
 
       const position = new window.kakao.maps.LatLng(latitude, longitude);
       const map = new window.kakao.maps.Map(containerRef.current, {
         center: position,
-        level: 1,
+        level: 2,
       });
-      const markerImage = new window.kakao.maps.MarkerImage(
-        '/images/logo.svg',
-        new window.kakao.maps.Size(48, 48),
-        { offset: new window.kakao.maps.Point(24, 48) }
-      );
-      new window.kakao.maps.Marker({ map, position, image: markerImage });
+
+      const customOverlay = new window.kakao.maps.CustomOverlay({
+        position,
+        content: buildMeetingPlaceOverlayContent(BRAND_LABEL),
+        yAnchor: 1,
+        xAnchor: 0.5,
+      });
+      customOverlay.setMap(map);
+      overlay = customOverlay;
     });
+
+    return () => {
+      cancelled = true;
+      overlay?.setMap(null);
+      if (node) node.innerHTML = '';
+    };
   }, [latitude, longitude]);
 
-  return <div ref={containerRef} className="h-[240px] w-full md:h-[320px] lg:h-[352px]" />;
+  return (
+    <div
+      ref={containerRef}
+      className="h-[240px] w-full cursor-grab outline-none select-none **:outline-none **:select-none active:cursor-grabbing md:h-[320px] lg:h-[352px]"
+    />
+  );
 }

--- a/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
@@ -79,7 +79,13 @@ export function MeetingHeroSection({ meeting: initialMeeting }: MeetingHeroSecti
     <>
       <div className="flex flex-col gap-6 md:flex-row">
         <div className="relative h-[241px] w-full overflow-hidden rounded-[24px] md:h-auto md:min-w-0 md:flex-1">
-          <Image src={meeting.image} alt={meeting.name} fill className="object-cover" />
+          <Image
+            src={meeting.image}
+            alt={meeting.name}
+            fill
+            draggable={false}
+            className="object-cover"
+          />
         </div>
         <div className="min-w-0 flex-1">
           <MeetingDetailCard meeting={meeting} status={status} {...cardProps} />

--- a/src/widgets/meeting-detail/ui/meeting-location-section/_components/kakao-map-loader.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/_components/kakao-map-loader.tsx
@@ -7,7 +7,9 @@ import Script from 'next/script';
 
 const KakaoMap = dynamic(() => import('@/shared/ui/kakao-map/kakao-map').then((m) => m.KakaoMap), {
   ssr: false,
-  loading: () => <div className="bg-sosoeat-gray-100 h-[240px] w-full md:h-[320px] lg:h-[352px]" />,
+  loading: () => (
+    <div className="bg-sosoeat-gray-100 h-[240px] w-full cursor-grab outline-none select-none **:select-none md:h-[320px] lg:h-[352px]" />
+  ),
 });
 
 interface KakaoMapLoaderProps {
@@ -29,7 +31,7 @@ export function KakaoMapLoader({ appKey, latitude, longitude }: KakaoMapLoaderPr
       {sdkReady ? (
         <KakaoMap latitude={latitude} longitude={longitude} />
       ) : (
-        <div className="bg-sosoeat-gray-100 h-[240px] w-full md:h-[320px] lg:h-[352px]" />
+        <div className="bg-sosoeat-gray-100 h-[240px] w-full cursor-grab outline-none select-none **:select-none md:h-[320px] lg:h-[352px]" />
       )}
     </>
   );

--- a/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+
+import { writeClipboardText } from '@/shared/lib/write-clipboard-text';
+
+import { MeetingLocationAddressRow } from './meeting-location-address-row';
+
+jest.mock('@/shared/lib/write-clipboard-text', () => ({
+  writeClipboardText: jest.fn(),
+}));
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockedWriteClipboardText = jest.mocked(writeClipboardText);
+
+const TEST_ADDRESS = '서울 강남구 테헤란로 123';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedWriteClipboardText.mockResolvedValue(undefined);
+});
+
+describe('MeetingLocationAddressRow', () => {
+  it('주소 텍스트와 복사 버튼이 렌더링된다', () => {
+    render(<MeetingLocationAddressRow address={TEST_ADDRESS} />);
+
+    expect(screen.getByText(TEST_ADDRESS)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '주소 복사' })).toBeInTheDocument();
+  });
+
+  it('복사 버튼 클릭 시 clipboard.writeText가 주소와 함께 호출된다', async () => {
+    const user = userEvent.setup();
+    render(<MeetingLocationAddressRow address={TEST_ADDRESS} />);
+
+    await user.click(screen.getByRole('button', { name: '주소 복사' }));
+
+    await waitFor(() => {
+      expect(mockedWriteClipboardText).toHaveBeenCalledWith(TEST_ADDRESS);
+    });
+  });
+
+  it('복사 성공 시 toast.success가 호출된다', async () => {
+    const user = userEvent.setup();
+    render(<MeetingLocationAddressRow address={TEST_ADDRESS} />);
+
+    await user.click(screen.getByRole('button', { name: '주소 복사' }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('주소가 복사되었습니다.');
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('복사 실패 시 toast.error가 호출된다', async () => {
+    mockedWriteClipboardText.mockRejectedValue(new Error('denied'));
+    const user = userEvent.setup();
+    render(<MeetingLocationAddressRow address={TEST_ADDRESS} />);
+
+    await user.click(screen.getByRole('button', { name: '주소 복사' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('복사에 실패했습니다.');
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Copy } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface MeetingLocationAddressRowProps {
+  address: string;
+}
+
+export function MeetingLocationAddressRow({ address }: MeetingLocationAddressRowProps) {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      toast.success('주소가 복사되었습니다.');
+    } catch {
+      toast.error('복사에 실패했습니다.');
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-[12px] bg-white px-5 py-4">
+      <p className="text-sosoeat-gray-900 max-w-[calc(100%-5.5rem)] min-w-0 shrink text-sm font-bold wrap-break-word">
+        {address}
+      </p>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="text-sosoeat-orange-600 hover:text-sosoeat-orange-700 inline-flex shrink-0 cursor-pointer items-center gap-1 text-sm font-semibold transition-colors"
+        aria-label="주소 복사"
+      >
+        <Copy className="size-4" strokeWidth={2.25} />
+        복사
+      </button>
+    </div>
+  );
+}

--- a/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.tsx
@@ -3,6 +3,8 @@
 import { Copy } from 'lucide-react';
 import { toast } from 'sonner';
 
+import { writeClipboardText } from '@/shared/lib/write-clipboard-text';
+
 interface MeetingLocationAddressRowProps {
   address: string;
 }
@@ -10,7 +12,7 @@ interface MeetingLocationAddressRowProps {
 export function MeetingLocationAddressRow({ address }: MeetingLocationAddressRowProps) {
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(address);
+      await writeClipboardText(address);
       toast.success('주소가 복사되었습니다.');
     } catch {
       toast.error('복사에 실패했습니다.');
@@ -19,7 +21,7 @@ export function MeetingLocationAddressRow({ address }: MeetingLocationAddressRow
 
   return (
     <div className="flex flex-wrap items-center gap-[12px] bg-white px-5 py-4">
-      <p className="text-sosoeat-gray-900 max-w-[calc(100%-5.5rem)] min-w-0 shrink text-sm font-bold wrap-break-word">
+      <p className="text-sosoeat-gray-900 max-w-[calc(100%-5.5rem)] min-w-0 shrink text-sm font-bold break-words">
         {address}
       </p>
       <button

--- a/src/widgets/meeting-detail/ui/meeting-location-section/meeting-location-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/meeting-location-section.tsx
@@ -1,4 +1,5 @@
 import { KakaoMapLoader } from './_components/kakao-map-loader';
+import { MeetingLocationAddressRow } from './_components/meeting-location-address-row';
 
 function hasValidMapCoords(latitude: number | null, longitude: number | null): boolean {
   if (latitude == null || longitude == null) return false;
@@ -27,20 +28,20 @@ export function MeetingLocationSection({
 
   const showMap = mapCoords != null && kakaoMapAppKey !== '';
 
+  if (!showMap) {
+    return null;
+  }
+
   return (
     <section>
       <h2 className="text-sosoeat-gray-900 mb-3 text-2xl font-semibold">모임 장소</h2>
       <div className="border-sosoeat-gray-200 mt-5 overflow-hidden rounded-[16px] border">
-        {showMap ? (
-          <KakaoMapLoader
-            appKey={kakaoMapAppKey}
-            latitude={mapCoords.latitude}
-            longitude={mapCoords.longitude}
-          />
-        ) : null}
-        <div className="px-5 py-4">
-          <p className="text-sosoeat-gray-900 text-sm font-medium">{address}</p>
-        </div>
+        <KakaoMapLoader
+          appKey={kakaoMapAppKey}
+          latitude={mapCoords.latitude}
+          longitude={mapCoords.longitude}
+        />
+        <MeetingLocationAddressRow address={address} />
       </div>
     </section>
   );

--- a/src/widgets/search/ui/region-select-modal/region-select-modal.stories.tsx
+++ b/src/widgets/search/ui/region-select-modal/region-select-modal.stories.tsx
@@ -72,7 +72,7 @@ export const WithDropdownSubConfirm: Story = {
             onChange: setCommitted,
           }}
         />
-        <pre className="text-muted-foreground max-w-md text-xs wrap-break-word">
+        <pre className="text-muted-foreground max-w-md text-xs break-words">
           {JSON.stringify(committed, null, 2)}
         </pre>
       </div>
@@ -101,7 +101,7 @@ export const WithRegionCascade: Story = {
             onChange: setCommitted,
           }}
         />
-        <pre className="text-muted-foreground max-w-md text-xs wrap-break-word">
+        <pre className="text-muted-foreground max-w-md text-xs break-words">
           {JSON.stringify(committed, null, 2)}
         </pre>
       </div>
@@ -137,13 +137,13 @@ export const WithExternalDraft: Story = {
         <div className="text-muted-foreground grid gap-2 text-xs">
           <div>
             <span className="text-foreground font-medium">draft (외부 state)</span>
-            <pre className="bg-muted/50 mt-1 rounded-md p-2 wrap-break-word">
+            <pre className="bg-muted/50 mt-1 rounded-md p-2 break-words">
               {JSON.stringify(draft, null, 2)}
             </pre>
           </div>
           <div>
             <span className="text-foreground font-medium">committed (확인 후)</span>
-            <pre className="bg-muted/50 mt-1 rounded-md p-2 wrap-break-word">
+            <pre className="bg-muted/50 mt-1 rounded-md p-2 break-words">
               {JSON.stringify(committed, null, 2)}
             </pre>
           </div>


### PR DESCRIPTION
### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

**관련 이슈:** #212

- **모임 상세 히어로:** 커버 `Image`에 `draggable={false}`를 적용해, 드래그 시 이미지가 따라다니는 브라우저 기본 동작을 막았습니다.
- **카카오맵:** 로고 핀 마커 대신 **브랜드 라벨(소소잇) + 오렌지(#FF6600) 말풍선형 `CustomOverlay`**로 표시하고, 좌표 변경·언마운트 시 지도/오버레이가 겹치지 않도록 정리했습니다. `kakao-maps.d.ts`에 `CustomOverlay`의 `xAnchor`를 반영했습니다.
- **로더:** 지도 컨테이너(플레이스홀더 포함)에 `select-none` 등을 적용해, 지도 위를 드래그할 때 생기던 **선택/포커스 느낌의 사각 테두리**를 완화했습니다.
- **모임 장소 섹션:** 유효한 좌표와 카카오 앱 키가 있을 때만 **「모임 장소」 섹션 전체**를 보이게 했습니다. (지도 없으면 섹션 미노출)
- **주소 행:** 주소 옆에 **복사** UI(오렌지 톤, `cursor-pointer`)를 두고 클립보드 복사 시 토스트로 안내합니다. 주소와 복사 사이 간격은 디자인에 맞게 조정했습니다.
- *(PR에 포함된 경우)* **`comment-server-base-url.ts`:** 댓글 서버 `COMMENT_SERVER_URL` 정규화·URL 조합 유틸 추가.

### 🧪 테스트 방법 (How to Test)

1. 로컬에서 `.env`에 **`KAKAO_MAP_APP_KEY`**(또는 `NEXT_PUBLIC_KAKAO_MAP_APP_KEY`)가 설정된 상태로 앱을 실행합니다.
2. **좌표·키가 있는 모임** 상세(`/meetings/[id]`)로 이동합니다.
   - 「모임 장소」가 보이고, 지도에 **오렌지 말풍선 마커(소소잇)** 가 보이는지 확인합니다.
   - 지도를 드래그했을 때 **이전처럼 뚜렷한 사각 선택 테두리가 덜 보이는지** 확인합니다.
   - 주소 옆 **복사**를 눌러 클립보드에 주소가 들어가고 토스트가 뜨는지 확인합니다.
3. **좌표가 없거나(0,0 등) 키가 비어 있는 모임**에서는 「모임 장소」**섹션 전체가 안 보이는지** 확인합니다.
4. 모임 상세 **히어로 커버 이미지** 위에서 마우스로 끌어보고, **이미지 고스트가 따라오지 않는지** 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

**[위, 경도가 null 인 경우 -> 지도 section 없음]**
<img width="1044" height="712" alt="image" src="https://github.com/user-attachments/assets/18c0bf8c-9d14-4d44-8e17-ab44749d6ea6" />

**[copy 기능 추가]**
<img width="1013" height="395" alt="image" src="https://github.com/user-attachments/assets/0cbcf962-44bd-4510-b17f-0ca69d835687" />


### 🚨 기타 참고 사항 (Notes)

  - 카카오 `CustomOverlay`는 **인라인 HTML 문자열**이라, 이후 라벨을 동적으로 넣을 때는 XSS를 피하기 위해 이스케이프/상수만 쓰는지 검토하면 좋습니다.
  - 지도 노출에는 **카카오 맵 키**가 필요합니다.