### PR TITLE
[Fix]: 댓글 좋아요 UX 개선 및 카운트 서버 API 연동  

### DIFF
--- a/src/app/meetings/[id]/page.tsx
+++ b/src/app/meetings/[id]/page.tsx
@@ -6,7 +6,11 @@ import {
   MeetingLocationSection,
   MeetingRecommendedSection,
 } from '@/widgets/meeting-detail';
-import { fetchMeetingCommentsForPage, getMeetingById } from '@/widgets/meeting-detail/index.server';
+import {
+  fetchMeetingCommentCountForPage,
+  fetchMeetingCommentsForPage,
+  getMeetingById,
+} from '@/widgets/meeting-detail/index.server';
 
 // ─── Page ────────────────────────────────────────────────────
 
@@ -20,9 +24,10 @@ export default async function MeetingDetailPage({ params }: Props) {
 
   const meetingData = await getMeetingById(meetingId);
 
-  const [meetingList, initialComments] = await Promise.all([
+  const [meetingList, initialComments, initialCommentCount] = await Promise.all([
     getMeetings({ region: meetingData.region, size: 4 }).catch(() => ({ data: [] })),
     fetchMeetingCommentsForPage(meetingId, meetingData),
+    fetchMeetingCommentCountForPage(meetingId),
   ]);
 
   return (
@@ -49,6 +54,7 @@ export default async function MeetingDetailPage({ params }: Props) {
       <MeetingCommentSection
         meetingId={meetingId}
         initialComments={initialComments}
+        initialCommentCount={initialCommentCount}
         commentSync={{
           id: meetingData.id,
           hostId: meetingData.hostId,

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -8,6 +8,7 @@ export type {
 export { commentApi } from './api/comment.api';
 export {
   commentKeys,
+  useCommentCount,
   useComments,
   useCreateComment,
   useDeleteComment,

--- a/src/entities/comment/model/comment.queries.ts
+++ b/src/entities/comment/model/comment.queries.ts
@@ -173,48 +173,21 @@ export const useLikeComment = (meetingId: number) => {
     mutationFn: ({ commentId, isLiked }: { commentId: number; isLiked: boolean }) =>
       isLiked ? commentApi.unlikeComment(commentId) : commentApi.likeComment(commentId),
 
-    onMutate: async ({ commentId, isLiked }) => {
-      await queryClient.cancelQueries({ queryKey: commentKeys.list(meetingId) });
-      const previousComments = queryClient.getQueryData(commentKeys.list(meetingId));
-
-      queryClient.setQueryData(commentKeys.list(meetingId), (old: Comment[] | undefined) => {
-        if (!old) return old;
-        return old.map((comment) => {
-          if (comment.id === commentId) {
-            return {
-              ...comment,
-              isLiked: !isLiked,
-              likeCount: isLiked ? comment.likeCount - 1 : comment.likeCount + 1,
-            };
-          }
-          return {
-            ...comment,
-            replies: comment.replies?.map((reply) =>
-              reply.id === commentId
-                ? {
-                    ...reply,
-                    isLiked: !isLiked,
-                    likeCount: isLiked ? reply.likeCount - 1 : reply.likeCount + 1,
-                  }
-                : reply
-            ),
-          };
-        });
-      });
-
-      return { previousComments };
-    },
-
-    onError: (_, __, context) => {
-      if (context?.previousComments) {
-        queryClient.setQueryData(commentKeys.list(meetingId), context.previousComments);
-      }
+    onError: () => {
       toast.error('좋아요 처리 중 오류가 발생했습니다.');
     },
 
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: commentKeys.list(meetingId) });
     },
+  });
+};
+
+export const useCommentCount = (meetingId: number, initialCount?: number) => {
+  return useQuery({
+    queryKey: commentKeys.count(meetingId),
+    queryFn: () => commentApi.getCommentCount(meetingId),
+    initialData: initialCount !== undefined ? { count: initialCount } : undefined,
   });
 };
 

--- a/src/widgets/meeting-detail/index.server.ts
+++ b/src/widgets/meeting-detail/index.server.ts
@@ -1,2 +1,5 @@
-export { fetchMeetingCommentsForPage } from './model/meeting-comments.server';
+export {
+  fetchMeetingCommentCountForPage,
+  fetchMeetingCommentsForPage,
+} from './model/meeting-comments.server';
 export { getMeetingById } from './model/meeting-detail.server';

--- a/src/widgets/meeting-detail/model/meeting-comments.server.ts
+++ b/src/widgets/meeting-detail/model/meeting-comments.server.ts
@@ -30,3 +30,10 @@ export async function fetchMeetingCommentsForPage(
 
   return (await response.json()) as MeetingComment[];
 }
+
+export async function fetchMeetingCommentCountForPage(meetingId: number): Promise<number> {
+  const response = await commentServer.get(`/meetings/${meetingId}/comments/count`);
+  if (!response.ok) return 0;
+  const data = (await response.json()) as { count: number };
+  return data.count;
+}

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
@@ -123,21 +123,48 @@ describe('MeetingCommentItem', () => {
   });
 
   describe('좋아요', () => {
-    it('좋아요 버튼 클릭 시 useLikeComment mutate가 호출된다', async () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('좋아요 버튼 클릭 시 300ms 후 useLikeComment mutate가 호출된다', async () => {
       const mockMutate = jest.fn();
       const commentsModule = jest.mocked(
         jest.requireMock('@/entities/comment') as { useLikeComment: jest.Mock }
       );
       commentsModule.useLikeComment.mockReturnValue({ mutate: mockMutate });
 
-      const user = userEvent.setup();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
         wrapper: createWrapper(),
       });
 
       await user.click(screen.getByRole('button', { name: '좋아요' }));
+      jest.advanceTimersByTime(300);
 
-      expect(mockMutate).toHaveBeenCalledWith({ commentId: 1, isLiked: false });
+      expect(mockMutate).toHaveBeenCalledWith(
+        { commentId: 1, isLiked: false },
+        expect.objectContaining({ onError: expect.any(Function) })
+      );
+    });
+
+    it('연속 클릭 시 마지막 상태로 1번만 호출된다', async () => {
+      const mockMutate = jest.fn();
+      const commentsModule = jest.mocked(
+        jest.requireMock('@/entities/comment') as { useLikeComment: jest.Mock }
+      );
+      commentsModule.useLikeComment.mockReturnValue({ mutate: mockMutate });
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
+        wrapper: createWrapper(),
+      });
+
+      await user.click(screen.getByRole('button', { name: '좋아요' }));
+      await user.click(screen.getByRole('button', { name: '좋아요' }));
+      await user.click(screen.getByRole('button', { name: '좋아요' }));
+      jest.advanceTimersByTime(300);
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -88,11 +88,13 @@ export function MeetingCommentItem({
 
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
+      if (nextIsLiked === prevServerLike.isLiked) return;
+
       likeComment(
         { commentId: id, isLiked: localIsLiked },
         {
           onError: () => {
-            setLocalIsLiked(localIsLiked);
+            setLocalIsLiked(isLiked);
             setLocalLikeCount(likeCount);
           },
         }

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Heart, MessageCircle, UserRound } from 'lucide-react';
 
@@ -74,6 +74,12 @@ export function MeetingCommentItem({
   });
 
   const isPending = id < 0;
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
 
   const handleLike = () => {
     const nextIsLiked = !localIsLiked;

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Heart, MessageCircle, UserRound } from 'lucide-react';
 
@@ -51,7 +51,18 @@ export function MeetingCommentItem({
   const [editText, setEditText] = useState(content);
   const [isReplying, setIsReplying] = useState(false);
   const [replyText, setReplyText] = useState('');
+  const [prevServerLike, setPrevServerLike] = useState({ isLiked, likeCount });
+  const [localIsLiked, setLocalIsLiked] = useState(isLiked);
+  const [localLikeCount, setLocalLikeCount] = useState(likeCount);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { isOpen: isDeleteModalOpen, open: openDeleteModal, close: closeDeleteModal } = useModal();
+
+  // 서버 데이터 변경 시 렌더 중 동기화 (useEffect 대신 React 권장 파생 상태 패턴)
+  if (prevServerLike.isLiked !== isLiked || prevServerLike.likeCount !== likeCount) {
+    setPrevServerLike({ isLiked, likeCount });
+    setLocalIsLiked(isLiked);
+    setLocalLikeCount(likeCount);
+  }
 
   const { user } = useAuthStore();
   const { mutate: likeComment } = useLikeComment(meetingId);
@@ -62,8 +73,25 @@ export function MeetingCommentItem({
     profileUrl: user?.image ?? null,
   });
 
+  const isPending = id < 0;
+
   const handleLike = () => {
-    likeComment({ commentId: id, isLiked });
+    const nextIsLiked = !localIsLiked;
+    setLocalIsLiked(nextIsLiked);
+    setLocalLikeCount((prev) => (nextIsLiked ? prev + 1 : prev - 1));
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      likeComment(
+        { commentId: id, isLiked: localIsLiked },
+        {
+          onError: () => {
+            setLocalIsLiked(localIsLiked);
+            setLocalLikeCount(likeCount);
+          },
+        }
+      );
+    }, 300);
   };
 
   const handleEditSubmit = () => {
@@ -85,12 +113,15 @@ export function MeetingCommentItem({
 
   const handleReplySubmit = () => {
     if (!replyText.trim()) return;
+    const savedText = replyText;
+    setIsReplying(false);
+    setReplyText('');
     createComment(
-      { content: replyText, parentId: id },
+      { content: savedText, parentId: id },
       {
-        onSuccess: () => {
-          setReplyText('');
-          setIsReplying(false);
+        onError: () => {
+          setIsReplying(true);
+          setReplyText(savedText);
         },
       }
     );
@@ -176,10 +207,11 @@ export function MeetingCommentItem({
                   type="button"
                   aria-label="좋아요"
                   onClick={handleLike}
-                  className="text-sosoeat-orange-600 flex cursor-pointer items-center gap-1 text-sm transition-colors"
+                  disabled={isPending}
+                  className="text-sosoeat-orange-600 flex cursor-pointer items-center gap-1 text-sm transition-colors disabled:opacity-40"
                 >
-                  <Heart className={cn('size-4', isLiked && 'fill-sosoeat-orange-600')} />
-                  <span>{likeCount}</span>
+                  <Heart className={cn('size-4', localIsLiked && 'fill-sosoeat-orange-600')} />
+                  <span>{localLikeCount}</span>
                 </button>
 
                 {!isReply && (
@@ -187,7 +219,8 @@ export function MeetingCommentItem({
                     type="button"
                     aria-label="답글"
                     onClick={() => setIsReplying((prev) => !prev)}
-                    className="text-sosoeat-gray-500 hover:text-sosoeat-orange-600 flex cursor-pointer items-center gap-1 text-sm transition-colors"
+                    disabled={isPending}
+                    className="text-sosoeat-gray-500 hover:text-sosoeat-orange-600 flex cursor-pointer items-center gap-1 text-sm transition-colors disabled:opacity-40"
                   >
                     <MessageCircle className="size-4" />
                     <span>답글</span>

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.tsx
@@ -6,7 +6,7 @@ import { MessageSquareText } from 'lucide-react';
 
 import { useAuthStore } from '@/entities/auth';
 import type { Comment } from '@/entities/comment';
-import { CommentInput, useComments, useCreateComment } from '@/entities/comment';
+import { CommentInput, useCommentCount, useComments, useCreateComment } from '@/entities/comment';
 import { cn } from '@/shared/lib/utils';
 import { CountingBadge } from '@/shared/ui/counting-badge/counting-badge';
 import { ScrollArea } from '@/shared/ui/scroll-area';
@@ -23,32 +23,24 @@ function toMeetingCommentTree(raw: Comment[]): MeetingComment[] {
   return list;
 }
 
-function countNonDeleted(nodes: MeetingComment[]): number {
-  let n = 0;
-  const walk = (c: MeetingComment) => {
-    if (!c.isDeleted) n += 1;
-    c.replies?.forEach(walk);
-  };
-  nodes.forEach(walk);
-  return n;
-}
-
 export function MeetingCommentSection({
   meetingId,
   initialComments,
+  initialCommentCount,
   commentSync,
   className,
 }: MeetingCommentSectionProps) {
   const [commentText, setCommentText] = useState('');
   const { isAuthenticated, user } = useAuthStore();
   const { data: comments } = useComments(meetingId, initialComments as Comment[], commentSync);
+  const { data: countData } = useCommentCount(meetingId, initialCommentCount);
   const { mutate: createComment, isPending: isCreateCommentPending } = useCreateComment(meetingId, {
     nickname: user?.name ?? '',
     profileUrl: user?.image ?? null,
   });
 
   const tree = toMeetingCommentTree(comments ?? []);
-  const totalCommentCount = countNonDeleted(tree);
+  const totalCommentCount = countData?.count ?? 0;
   const visibleRoots = tree.filter(
     (comment) => !comment.isDeleted || comment.replies?.some((r) => !r.isDeleted)
   );

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.types.ts
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.types.ts
@@ -18,6 +18,7 @@ export interface MeetingComment {
 export interface MeetingCommentSectionProps {
   meetingId: number;
   initialComments?: MeetingComment[];
+  initialCommentCount?: number;
   /** 댓글 서버에 모임이 없을 때 동기화 후 재조회 (클라이언트 refetch에도 사용) */
   commentSync?: { id: number; hostId: number; teamId: string };
   className?: string;


### PR DESCRIPTION
  ### 📌 유형 (Type)                                                                                       
    
  - [x] **Feat (기능):** 새로운 기능 추가                                                                  
  - [x] **Fix (버그 수정):** 버그 수정               
                                                                                                                         
  ### 📝 변경 사항 (Changes)                                                                                             
                                                                                                                         
  closes #218                                                                                                            
                                                                                                                         
  **어떤 문제가 있었는지?**                                                                                              
                                                                                                                         
  - 좋아요 버튼을 연속으로 클릭하면 클릭 수만큼 API 요청이 발생하여 404 에러 유발                                        
  - 낙관적 업데이트(pending) 상태의 댓글에서 좋아요/대댓글 버튼이 활성화되어 잘못된 요청 가능                         
  - 대댓글 제출 후 서버 응답을 기다린 후에야 입력창이 닫혀 UX 지연                                                       
  - 댓글 카운트를 클라이언트에서 직접 계산(`countNonDeleted`)하여 서버 API(`/meetings/:id/comments/count`) 미활용        
  - `commentKeys.count`를 invalidate하는 코드가 있었지만 실제로 count를 조회하는 훅이 없어 의미 없는 코드였음            
                                                                                                                         
  **무엇을 어떻게 변경했는지?**                                                                                          
                                                                                                                         
  - 좋아요 UI를 로컬 state로 즉시 반영하고, API 요청은 300ms debounce 처리 — 마지막 상태로 1번만 호출                    
  - API 실패 시 로컬 state 롤백 처리                                                                                     
  - 낙관적 업데이트 중인 댓글(`id < 0`)의 좋아요/대댓글 버튼 `disabled` 처리                                             
  - 대댓글 제출 즉시 입력창 닫힘, 실패 시 입력값 및 입력창 복원                                                          
  - `useCommentCount` 훅 추가 및 SSR 초기값(`initialCommentCount`) 연동                                                  
  - 클라이언트 카운트 계산 로직(`countNonDeleted`) 제거                                                                  
                                                                                                                         
  ### 🧪 테스트 방법 (How to Test)                                                                                       
                                                                                                                         
  1. 로컬 환경에서 앱을 실행 후 모임 상세 페이지(`/meetings/:id`)로 이동합니다.                                          
                                                                                                                         
  2. **좋아요 debounce 확인**                                                                                            
     - 댓글의 좋아요 버튼을 빠르게 5회 연속 클릭합니다.                                                                  
     - UI는 클릭마다 즉시 반응하는지 확인합니다.                                                                         
     - 브라우저 Network 탭에서 API 요청이 마지막 1회만 발생하는지 확인합니다.                                            
                                                                                                                         
  3. **pending 댓글 버튼 비활성화 확인**                                                                                 
     - 댓글을 작성합니다.                                                                                                
     - 서버 응답 전 낙관적으로 추가된 댓글의 좋아요/대댓글 버튼이 흐리게(비활성화) 표시되는지 확인합니다.                
                                                                                                                         
  4. **대댓글 입력창 즉시 닫힘 확인**                                                                                    
     - 답글 버튼 클릭 후 내용을 입력하고 저장합니다.                                                                     
     - 저장 버튼 클릭 즉시 입력창이 닫히는지 확인합니다.                                                                 
                                                                                                                         
  5. **댓글 카운트 갱신 확인**                                                                                           
     - 댓글을 작성/삭제합니다.                                                                                           
     - 상단 CountingBadge 숫자가 서버 응답 후 정확하게 갱신되는지 확인합니다.                                            
                                                                                                                                                                                
                                                                                                                         
  ### 🚨 기타 참고 사항 (Notes)                                                                                          
                                                                                                                         
  - [x] **`useLikeComment`의 `onMutate` 제거** — optimistic update 책임이 훅에서 `MeetingCommentItem` 컴포넌트로         
  이전되었습니다. 리뷰 시 확인 부탁드립니다.                                                                             
  - [x] **서버 데이터 동기화 방식** — `useEffect` 대신 렌더 중 파생 상태 패턴(`if (prev !== current) setState(...)`)     
  사용. ESLint `react-hooks/set-state-in-effect` 규칙 준수를 위한 React 권장 방식입니다. 