### PR TITLE
fix: #235-하트 버튼 중복 요청 방지 및 pending 상태 처리

### DIFF
--- a/src/features/favorites/model/use-favorites.ts
+++ b/src/features/favorites/model/use-favorites.ts
@@ -1,19 +1,29 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { favoritesApi } from '../api/favorites.api';
 
 export const useFavoriteMeeting = (initialIsFavorited: boolean) => {
   const [isFavorited, setIsFavorited] = useState(initialIsFavorited);
+  const [isPending, setIsPending] = useState(false);
+  const isPendingRef = useRef(false);
 
   useEffect(() => {
     setIsFavorited(initialIsFavorited);
   }, [initialIsFavorited]);
 
   const toggleFavorite = async (meetingId: number) => {
+    if (isPendingRef.current) {
+      return;
+    }
+
+    isPendingRef.current = true;
+    setIsPending(true);
+
     const prev = isFavorited;
     setIsFavorited(!prev); // Optimistic UI
+
     try {
       if (prev) {
         await favoritesApi.favoriteDelete(meetingId);
@@ -22,9 +32,12 @@ export const useFavoriteMeeting = (initialIsFavorited: boolean) => {
       }
     } catch (error) {
       console.error('Failed to toggle favorite:', error);
-      setIsFavorited(prev); // 롤백
+      setIsFavorited(prev); // Roll back on failure
+    } finally {
+      isPendingRef.current = false;
+      setIsPending(false);
     }
   };
 
-  return { isFavorited, toggleFavorite };
+  return { isFavorited, isPending, toggleFavorite };
 };

--- a/src/features/favorites/ui/heart-button/heart-button.test.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from '@testing-library/react';
 
 import { HeartButton } from './heart-button';
 
+const mockUseFavoriteMeeting = jest.fn();
+
+jest.mock('../../model/use-favorites', () => ({
+  useFavoriteMeeting: (initialIsFavorited: boolean) => mockUseFavoriteMeeting(initialIsFavorited),
+}));
+
 jest.mock('next/image', () => ({
   __esModule: true,
   default: ({ src, alt, ...rest }: { src: string; alt: string; [key: string]: unknown }) => (
@@ -18,9 +24,16 @@ jest.mock('framer-motion', () => ({
   },
 }));
 
-//하트버튼
 describe('HeartButton', () => {
-  it('기본 상태에서 빈 하트 아이콘이 렌더링된다', () => {
+  beforeEach(() => {
+    mockUseFavoriteMeeting.mockReturnValue({
+      isFavorited: false,
+      isPending: false,
+      toggleFavorite: jest.fn(),
+    });
+  });
+
+  it('renders the empty heart icon by default', () => {
     render(<HeartButton meetingId={1} isFavorited={false} />);
 
     expect(screen.getByRole('button', { name: '좋아요' })).toBeInTheDocument();
@@ -30,7 +43,13 @@ describe('HeartButton', () => {
     );
   });
 
-  it('찜 상태에서 채운 하트 아이콘이 렌더링된다', () => {
+  it('renders the filled heart icon when favorited', () => {
+    mockUseFavoriteMeeting.mockReturnValue({
+      isFavorited: true,
+      isPending: false,
+      toggleFavorite: jest.fn(),
+    });
+
     render(<HeartButton meetingId={1} isFavorited />);
 
     expect(screen.getByRole('button', { name: '좋아요' })).toBeInTheDocument();
@@ -40,9 +59,21 @@ describe('HeartButton', () => {
     );
   });
 
-  it('className이 CardAction에 합쳐진다', () => {
+  it('applies the custom wrapper className', () => {
     const { container } = render(<HeartButton meetingId={1} className="custom-heart-class" />);
 
     expect(container.querySelector('.custom-heart-class')).toBeInTheDocument();
+  });
+
+  it('disables the button while a favorite request is pending', () => {
+    mockUseFavoriteMeeting.mockReturnValue({
+      isFavorited: false,
+      isPending: true,
+      toggleFavorite: jest.fn(),
+    });
+
+    render(<HeartButton meetingId={1} isFavorited={false} />);
+
+    expect(screen.getByRole('button', { name: '좋아요' })).toBeDisabled();
   });
 });

--- a/src/features/favorites/ui/heart-button/heart-button.test.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.test.tsx
@@ -33,6 +33,10 @@ describe('HeartButton', () => {
     });
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders the empty heart icon by default', () => {
     render(<HeartButton meetingId={1} isFavorited={false} />);
 

--- a/src/features/favorites/ui/heart-button/heart-button.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.tsx
@@ -36,7 +36,8 @@ export function HeartButton({
   isFavorited = false,
   meetingId,
 }: HeartButtonProps) {
-  const { isFavorited: isFavoritedState, toggleFavorite } = useFavoriteMeeting(isFavorited);
+  const { isFavorited: isFavoritedState, isPending, toggleFavorite } =
+    useFavoriteMeeting(isFavorited);
 
   const src = isFavoritedState ? '/icons/main-page-heart.svg' : '/icons/main-page-not-heart.svg';
   const iconPx = sizeIcon[size];
@@ -47,8 +48,10 @@ export function HeartButton({
         variant="ghost"
         size="icon"
         className={cn(HEART_BUTTON_CLASS, ringSizeClass[size])}
+        disabled={isPending}
+        aria-busy={isPending}
         onClick={() => {
-          if (meetingId === undefined) {
+          if (meetingId === undefined || isPending) {
             if (process.env.NODE_ENV !== 'production') {
               console.error(
                 'HeartButton: meetingId is required for toggleFavorite but was undefined.'
@@ -60,13 +63,16 @@ export function HeartButton({
         }}
       >
         <motion.div
-          animate={{ scale: 1 }}
+          animate={{
+            opacity: isPending ? 0.55 : 1,
+            scale: 1,
+          }}
           transition={{ duration: 0.2, ease: 'easeOut' }}
           whileTap={{
-            scale: isFavoritedState ? 1 : [0.1, 1.15, 0.6, 1],
+            scale: isPending || isFavoritedState ? 1 : [0.1, 1.15, 0.6, 1],
             transition: { duration: 1, ease: 'easeOut' },
           }}
-          className={HEART_BUTTON_ICON_WRAPPER_CLASS}
+          className={cn(HEART_BUTTON_ICON_WRAPPER_CLASS, 'transition-opacity')}
         >
           <Image src={src} alt="좋아요" width={iconPx} height={iconPx} />
         </motion.div>

--- a/src/features/favorites/ui/heart-button/heart-button.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.tsx
@@ -23,7 +23,7 @@ const sizeIcon = {
   sm: 24,
 } as const;
 
-/** 바깥 원(ring) — 버튼 크기 */
+/** 바깥 ring 버튼 크기 */
 const ringSizeClass = {
   lg: 'size-[60px]',
   md: 'size-[50px]',
@@ -51,7 +51,7 @@ export function HeartButton({
         disabled={isPending}
         aria-busy={isPending}
         onClick={() => {
-          if (meetingId === undefined || isPending) {
+          if (meetingId === undefined) {
             if (process.env.NODE_ENV !== 'production') {
               console.error(
                 'HeartButton: meetingId is required for toggleFavorite but was undefined.'
@@ -59,6 +59,7 @@ export function HeartButton({
             }
             return;
           }
+
           toggleFavorite(meetingId);
         }}
       >
@@ -72,7 +73,7 @@ export function HeartButton({
             scale: isPending || isFavoritedState ? 1 : [0.1, 1.15, 0.6, 1],
             transition: { duration: 1, ease: 'easeOut' },
           }}
-          className={cn(HEART_BUTTON_ICON_WRAPPER_CLASS, 'transition-opacity')}
+          className={HEART_BUTTON_ICON_WRAPPER_CLASS}
         >
           <Image src={src} alt="좋아요" width={iconPx} height={iconPx} />
         </motion.div>

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx
@@ -106,8 +106,20 @@ const mockPostDetailResponse = {
   isLiked: false,
 };
 
+let currentPostDetailResponse = mockPostDetailResponse;
+
 describe('SosoTalkPostDetailPage', () => {
   beforeEach(() => {
+    currentPostDetailResponse = {
+      ...mockPostDetailResponse,
+      author: { ...mockPostDetailResponse.author },
+      count: { ...mockPostDetailResponse.count },
+      comments: mockPostDetailResponse.comments.map((comment) => ({
+        ...comment,
+        author: { ...comment.author },
+      })),
+    };
+
     window.history.pushState({}, '', '/sosotalk/1');
 
     Object.defineProperty(navigator, 'share', {
@@ -148,11 +160,11 @@ describe('SosoTalkPostDetailPage', () => {
         })
     );
 
-    useGetSosoTalkPostDetail.mockReturnValue({
-      data: mockPostDetailResponse,
+    useGetSosoTalkPostDetail.mockImplementation(() => ({
+      data: currentPostDetailResponse,
       isLoading: false,
       isError: false,
-    });
+    }));
 
     useCreateSosoTalkComment.mockReturnValue({
       mutateAsync: mockCreateCommentMutateAsync,
@@ -208,7 +220,7 @@ describe('SosoTalkPostDetailPage', () => {
       })
     );
 
-    render(<SosoTalkPostDetailPage postId="1" />);
+    const { rerender } = render(<SosoTalkPostDetailPage postId="1" />);
 
     await user.click(screen.getByRole('button', { name: '좋아요 24개' }));
 
@@ -218,7 +230,19 @@ describe('SosoTalkPostDetailPage', () => {
     resolveLike?.();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: '좋아요 24개' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '좋아요 25개' })).toBeInTheDocument();
+    });
+
+    currentPostDetailResponse = {
+      ...currentPostDetailResponse,
+      likeCount: 25,
+      isLiked: true,
+    };
+
+    rerender(<SosoTalkPostDetailPage postId="1" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '좋아요 25개' })).toBeInTheDocument();
     });
   });
 

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -53,8 +53,19 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
   const comments = data?.comments ?? [];
   const isLiked = optimisticIsLiked ?? data?.isLiked ?? false;
   const displayedLikeCount = (data?.likeCount ?? 0) + (isLiked ? 1 : 0) - (data?.isLiked ? 1 : 0);
+  const isLikePending = createLikeMutation.isPending || deleteLikeMutation.isPending;
   const isEditingCommentMissing =
     editingCommentId != null && !comments.some((comment) => comment.id === editingCommentId);
+
+  useEffect(() => {
+    if (optimisticIsLiked == null || isLikePending || !data) {
+      return;
+    }
+
+    if (data.isLiked === optimisticIsLiked) {
+      setOptimisticIsLiked(null);
+    }
+  }, [data, isLikePending, optimisticIsLiked]);
 
   const handleCommentClick = () => {
     commentSectionRef.current?.scrollIntoView({
@@ -64,7 +75,7 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
   };
 
   const handleLikeClick = async () => {
-    if (!isValidPostId || createLikeMutation.isPending || deleteLikeMutation.isPending || !data) {
+    if (!isValidPostId || isLikePending || !data) {
       return;
     }
 
@@ -78,8 +89,6 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
         await deleteLikeMutation.mutateAsync(numericPostId);
       }
     } catch {
-      setOptimisticIsLiked(data.isLiked);
-    } finally {
       setOptimisticIsLiked(null);
     }
   };
@@ -259,6 +268,7 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
           viewCount={data.viewCount}
           isAuthor={currentUser?.id === data.author.id}
           isLiked={isLiked}
+          isLikePending={isLikePending}
           onEditClick={handleEditClick}
           onDeleteClick={() => void handleDeleteClick()}
           onLikeClick={() => void handleLikeClick()}

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -51,21 +51,14 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
 
   const commentCount = data?.count?.comments ?? data?.comments?.length ?? 0;
   const comments = data?.comments ?? [];
-  const isLiked = optimisticIsLiked ?? data?.isLiked ?? false;
-  const displayedLikeCount = (data?.likeCount ?? 0) + (isLiked ? 1 : 0) - (data?.isLiked ? 1 : 0);
+  const serverIsLiked = data?.isLiked ?? false;
   const isLikePending = createLikeMutation.isPending || deleteLikeMutation.isPending;
+  const shouldUseOptimisticLike =
+    optimisticIsLiked != null && (isLikePending || serverIsLiked !== optimisticIsLiked);
+  const isLiked = shouldUseOptimisticLike ? optimisticIsLiked : serverIsLiked;
+  const displayedLikeCount = (data?.likeCount ?? 0) + (isLiked ? 1 : 0) - (serverIsLiked ? 1 : 0);
   const isEditingCommentMissing =
     editingCommentId != null && !comments.some((comment) => comment.id === editingCommentId);
-
-  useEffect(() => {
-    if (optimisticIsLiked == null || isLikePending || !data) {
-      return;
-    }
-
-    if (data.isLiked === optimisticIsLiked) {
-      setOptimisticIsLiked(null);
-    }
-  }, [data, isLikePending, optimisticIsLiked]);
 
   const handleCommentClick = () => {
     commentSectionRef.current?.scrollIntoView({

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail-actions.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail-actions.tsx
@@ -13,6 +13,7 @@ export function SosoTalkPostDetailActions({
   likeCount = 0,
   commentCount = 0,
   isLiked = false,
+  isLikePending = false,
   onLikeClick,
   onCommentClick,
   onShareClick,
@@ -41,16 +42,18 @@ export function SosoTalkPostDetailActions({
       <div className="flex items-center gap-4 md:gap-6">
         <motion.button
           type="button"
+          disabled={isLikePending}
+          aria-busy={isLikePending}
           aria-pressed={isLiked}
           aria-label={`좋아요 ${likeCount}개`}
           onClick={onLikeClick}
           whileHover={{ y: -2, scale: 1.04 }}
-          whileTap={{ scale: 0.92 }}
+          whileTap={{ scale: isLikePending ? 1 : 0.92 }}
           className={`inline-flex items-center gap-2 transition-colors duration-150 ${
             isLiked
               ? 'text-sosoeat-orange-600'
               : 'text-sosoeat-gray-900 hover:text-sosoeat-orange-600'
-          }`}
+          } ${isLikePending ? 'cursor-not-allowed opacity-55' : ''}`}
         >
           <motion.span
             animate={

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SosoTalkPostDetail } from './sosotalk-post-detail';
 
 describe('SosoTalkPostDetail', () => {
-  it('props로 받은 액션 핸들러를 호출한다', async () => {
+  it('passes action handlers through the action buttons', async () => {
     const user = userEvent.setup();
     const onLikeClick = jest.fn();
     const onCommentClick = jest.fn();
@@ -12,8 +12,8 @@ describe('SosoTalkPostDetail', () => {
 
     render(
       <SosoTalkPostDetail
-        title="마포 고기집 같이 가실 분?"
-        contentHtml="<p>본문입니다.</p>"
+        title="맛포 고깃집 같이 가실 분"
+        contentHtml="<p>본문입니다</p>"
         authorName="김민수"
         createdAt="6시간 전"
         likeCount={24}
@@ -25,7 +25,7 @@ describe('SosoTalkPostDetail', () => {
         inputValue=""
         onChangeInput={() => undefined}
         onSubmitComment={() => undefined}
-        currentUserName="마민준"
+        currentUserName="마루준"
       />
     );
 
@@ -38,10 +38,10 @@ describe('SosoTalkPostDetail', () => {
     expect(onShareClick).toHaveBeenCalledTimes(1);
   });
 
-  it('댓글과 입력창을 함께 렌더링한다', () => {
+  it('renders comments and the comment input', () => {
     render(
       <SosoTalkPostDetail
-        title="마포 고기집 같이 가실 분?"
+        title="맛포 고깃집 같이 가실 분"
         contentHtml="<p><strong>삼겹살</strong> 드실 분 구해요.</p>"
         authorName="김민수"
         createdAt="6시간 전"
@@ -56,15 +56,36 @@ describe('SosoTalkPostDetail', () => {
           },
         ]}
         inputValue=""
-        inputPlaceholder="댓글을 입력하세요."
+        inputPlaceholder="댓글을 입력해보세요"
         onChangeInput={() => undefined}
         onSubmitComment={() => undefined}
-        currentUserName="마민준"
+        currentUserName="마루준"
       />
     );
 
     expect(screen.getByText('삼겹살', { selector: 'strong' })).toBeInTheDocument();
     expect(screen.getByText('박지연')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('댓글을 입력하세요.')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('댓글을 입력해보세요')).toBeInTheDocument();
+  });
+
+  it('disables the like button while a like request is pending', () => {
+    render(
+      <SosoTalkPostDetail
+        title="맛포 고깃집 같이 가실 분"
+        contentHtml="<p>본문입니다</p>"
+        authorName="김민수"
+        createdAt="6시간 전"
+        likeCount={24}
+        commentCount={3}
+        isLikePending
+        comments={[]}
+        inputValue=""
+        onChangeInput={() => undefined}
+        onSubmitComment={() => undefined}
+        currentUserName="마루준"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '좋아요 24개' })).toBeDisabled();
   });
 });

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.tsx
@@ -21,6 +21,7 @@ export function SosoTalkPostDetail({
   viewCount,
   isAuthor = false,
   isLiked = false,
+  isLikePending = false,
   onMoreClick,
   onEditClick,
   onDeleteClick,
@@ -57,6 +58,7 @@ export function SosoTalkPostDetail({
               likeCount={likeCount}
               commentCount={commentCount}
               isLiked={isLiked}
+              isLikePending={isLikePending}
               onLikeClick={onLikeClick}
               onCommentClick={onCommentClick}
               onShareClick={onShareClick}

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.types.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.types.ts
@@ -14,6 +14,7 @@ export interface SosoTalkPostDetailProps {
   viewCount?: number;
   isAuthor?: boolean;
   isLiked?: boolean;
+  isLikePending?: boolean;
   onMoreClick?: () => void;
   onEditClick?: () => void;
   onDeleteClick?: () => void;
@@ -53,6 +54,7 @@ export interface SosoTalkPostActionsProps {
   likeCount?: number;
   commentCount?: number;
   isLiked?: boolean;
+  isLikePending?: boolean;
   onLikeClick?: () => void;
   onCommentClick?: () => void;
   onShareClick?: () => void | Promise<void>;


### PR DESCRIPTION
## PR 제목: [Fix]: 하트 상호작용 pending 상태 개선

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### ✨ 변경 사항 (Changes)

이 PR에서 변경된 내용을 **간결하고 명확하게** 설명해주세요.

- 하트 버튼 요청 중 중복 클릭이 발생하지 않도록 pending 상태를 반영했습니다.
- 공용 `HeartButton`에 `disabled`, `aria-busy` 상태를 적용하고 pending 중 애니메이션/클릭 처리 방식을 정리했습니다.
- 소소톡 상세 좋아요 버튼에도 pending 비활성화 상태를 추가했습니다.
- 소소톡 상세에서 좋아요 성공 후 서버 데이터 재조회 전 잠깐 이전 상태로 돌아가던 깜빡임을 수정했습니다.
- 관련 테스트를 보강했습니다.

### 🧪 테스트 방법 (How to Test)

변경 사항을 확인하기 위해 **테스트해야 할 단계 및 시나리오**를 상세히 설명해주세요.

1. 소소톡 상세 페이지에서 좋아요가 안 눌린 게시글에 진입합니다.
2. 좋아요 버튼을 클릭합니다.
3. 버튼이 즉시 눌린 상태로 바뀌고, 요청 중에는 비활성화되는지 확인합니다.
4. 응답이 완료될 때까지 하트가 다시 안 눌린 상태로 깜빡이지 않는지 확인합니다.
5. 공용 하트 버튼이 사용되는 화면(예: 메인/검색/마이페이지 카드)에서도 pending 중 중복 클릭이 막히는지 확인합니다.

### 📷 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### ✅ 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
  - 소소톡 상세 좋아요의 optimistic 상태가 서버 재조회 시점까지 자연스럽게 유지되는지 확인 부탁드립니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
