### PR TITLE
[Fix]: 소소토크 문자열 인코딩 깨짐 복구

### DIFF
--- a/src/widgets/sosotalk/ui/sosotalk-card/sosotalk-card.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-card/sosotalk-card.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { Heart, MessageCircle } from 'lucide-react';
 
 import { getSosoTalkPostDetail } from '@/entities/post';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar/avatar';
@@ -64,12 +65,12 @@ export function SosoTalkCard({
             </div>
 
             <div className="flex items-center gap-[10px]">
-              <span className="flex items-center gap-[2px]">
-                <span>좋아요</span>
+              <span className="flex items-center gap-[4px]">
+                <Heart className="h-3.5 w-3.5 shrink-0" />
                 <span>{likeCount}</span>
               </span>
-              <span className="flex items-center gap-[2px]">
-                <span>댓글</span>
+              <span className="flex items-center gap-[4px]">
+                <MessageCircle className="h-3.5 w-3.5 shrink-0" />
                 <span>{commentCount}</span>
               </span>
             </div>

--- a/src/widgets/sosotalk/ui/sosotalk-card/sosotalk-card.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-card/sosotalk-card.tsx
@@ -65,11 +65,11 @@ export function SosoTalkCard({
 
             <div className="flex items-center gap-[10px]">
               <span className="flex items-center gap-[2px]">
-                <span>♥</span>
+                <span>좋아요</span>
                 <span>{likeCount}</span>
               </span>
               <span className="flex items-center gap-[2px]">
-                <span>💬</span>
+                <span>댓글</span>
                 <span>{commentCount}</span>
               </span>
             </div>

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx
@@ -72,7 +72,7 @@ const mockPostDetailResponse = {
   id: 1,
   teamId: 'dallaem',
   title: '마포 고깃집 같이 가실 분?',
-  content: '<p>오늘 저녁 같이 식사하실 분 구해요</p>',
+  content: '<p>오늘 저녁 같이 식사하실 분 구해요.</p>',
   image: 'https://example.com/post-image.jpg',
   authorId: 10,
   viewCount: 20,
@@ -98,7 +98,7 @@ const mockPostDetailResponse = {
         name: '마루준',
         image: 'https://example.com/comment-author.jpg',
       },
-      content: '참여하고 싶어요!',
+      content: '참여하고 싶어요.',
       createdAt: new Date('2026-03-18T09:05:00.000Z'),
       updatedAt: new Date('2026-03-18T09:05:00.000Z'),
     },
@@ -229,13 +229,13 @@ describe('SosoTalkPostDetailPage', () => {
     render(<SosoTalkPostDetailPage postId="1" />);
 
     const textarea = screen.getByPlaceholderText('댓글을 입력해 주세요');
-    await user.type(textarea, '새 댓글입니다');
+    await user.type(textarea, '새 댓글입니다.');
     await user.click(screen.getByRole('button', { name: '댓글 전송' }));
 
     expect(mockCreateCommentMutateAsync).toHaveBeenCalledWith({
       postId: 1,
       payload: {
-        content: '새 댓글입니다',
+        content: '새 댓글입니다.',
       },
     });
     expect(textarea).toHaveValue('');
@@ -252,14 +252,14 @@ describe('SosoTalkPostDetailPage', () => {
 
     const [editTextarea] = screen.getAllByRole('textbox');
     await user.clear(editTextarea);
-    await user.type(editTextarea, '수정된 댓글입니다');
+    await user.type(editTextarea, '수정된 댓글입니다.');
     await user.click(screen.getByRole('button', { name: '댓글 수정' }));
 
     expect(mockUpdateCommentMutateAsync).toHaveBeenCalledWith({
       postId: 1,
       commentId: 101,
       payload: {
-        content: '수정된 댓글입니다',
+        content: '수정된 댓글입니다.',
       },
     });
     expect(screen.queryByRole('button', { name: '취소' })).not.toBeInTheDocument();

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx
@@ -71,8 +71,8 @@ const mockDeleteLikeMutateAsync = jest.fn();
 const mockPostDetailResponse = {
   id: 1,
   teamId: 'dallaem',
-  title: '마포 고깃집 같이 가실 분',
-  content: '<p>오늘 저녁 같이 식사하실 분 구해요.</p>',
+  title: '마포 고깃집 같이 가실 분?',
+  content: '<p>오늘 저녁 같이 식사하실 분 구해요</p>',
   image: 'https://example.com/post-image.jpg',
   authorId: 10,
   viewCount: 20,
@@ -228,14 +228,14 @@ describe('SosoTalkPostDetailPage', () => {
 
     render(<SosoTalkPostDetailPage postId="1" />);
 
-    const textarea = screen.getByPlaceholderText('댓글을 입력해 주세요.');
-    await user.type(textarea, '새 댓글입니다.');
+    const textarea = screen.getByPlaceholderText('댓글을 입력해 주세요');
+    await user.type(textarea, '새 댓글입니다');
     await user.click(screen.getByRole('button', { name: '댓글 전송' }));
 
     expect(mockCreateCommentMutateAsync).toHaveBeenCalledWith({
       postId: 1,
       payload: {
-        content: '새 댓글입니다.',
+        content: '새 댓글입니다',
       },
     });
     expect(textarea).toHaveValue('');
@@ -252,14 +252,14 @@ describe('SosoTalkPostDetailPage', () => {
 
     const [editTextarea] = screen.getAllByRole('textbox');
     await user.clear(editTextarea);
-    await user.type(editTextarea, '수정된 댓글입니다.');
+    await user.type(editTextarea, '수정된 댓글입니다');
     await user.click(screen.getByRole('button', { name: '댓글 수정' }));
 
     expect(mockUpdateCommentMutateAsync).toHaveBeenCalledWith({
       postId: 1,
       commentId: 101,
       payload: {
-        content: '수정된 댓글입니다.',
+        content: '수정된 댓글입니다',
       },
     });
     expect(screen.queryByRole('button', { name: '취소' })).not.toBeInTheDocument();

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
@@ -137,7 +137,7 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
       });
       handleCancelEditComment();
     } catch {
-      // 수정 실패 시 입력값을 유지해서 다시 시도할 수 있도록 둡니다.
+      // 수정 입력값을 유지해서 다시 시도할 수 있도록 둡니다.
     }
   };
 
@@ -278,7 +278,7 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
             })
           )}
           inputValue={commentInput}
-          inputPlaceholder="댓글을 입력해 주세요."
+          inputPlaceholder="댓글을 입력해 주세요"
           onChangeInput={setCommentInput}
           onSubmitComment={() => void handleSubmitComment()}
           currentUserName={currentUser?.name}

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail-actions.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail-actions.tsx
@@ -28,7 +28,7 @@ export function SosoTalkPostDetailActions({
       {hasMeta ? (
         <div className="text-sosoeat-gray-500 flex items-center gap-2 text-sm font-medium md:text-base">
           {createdDateLabel ? <span>{createdDateLabel}</span> : null}
-          {createdDateLabel && typeof viewCount === 'number' ? <span aria-hidden>·</span> : null}
+          {createdDateLabel && typeof viewCount === 'number' ? <span aria-hidden>|</span> : null}
           {typeof viewCount === 'number' ? (
             <span className="inline-flex items-center gap-1.5">
               <Eye className="h-4 w-4 shrink-0" />

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
@@ -9,12 +9,12 @@ import { SosoTalkPostDetail } from './sosotalk-post-detail';
 const comments = [
   {
     id: '1',
-    authorName: '마민준',
+    authorName: '마루준',
     authorImageUrl:
       'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop',
     createdAt: '03월 18일 18:42',
     relativeTime: '12분 전',
-    content: '혹시 1명 더 신청 가능할까요? 퇴근하고 바로 가면 시간 맞을 것 같아요.',
+    content: '혹시 1명 더 요청 가능할까요? 퇴근하고 바로 가면 시간 맞을 것 같아요.',
   },
   {
     id: '2',
@@ -23,7 +23,7 @@ const comments = [
       'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?auto=format&fit=crop&q=80&w=400',
     createdAt: '03월 18일 18:50',
     relativeTime: '방금 전',
-    content: '가능해요. 오시기 전에 댓글 한 번만 더 남겨주시면 자리 잡아둘게요.',
+    content: '가능해요! 오시기 전에 댓글 한 번만 더 남겨주시면 자리 잡아둘게요.',
     isAuthorComment: true,
   },
 ];
@@ -67,7 +67,7 @@ function InteractiveDetail(args: ComponentProps<typeof SosoTalkPostDetail>) {
       inputPlaceholder="댓글을 입력해 주세요"
       onChangeInput={setValue}
       onSubmitComment={() => setValue('')}
-      currentUserName="마민준"
+      currentUserName="마루준"
       currentUserImageUrl="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?q=80&w=120&auto=format&fit=crop"
     />
   );
@@ -77,7 +77,7 @@ export const Default: Story = {
   args: {
     title: '마포 고깃집 같이 가실 분?',
     contentHtml:
-      '<p>저녁 7시에 마포 고깃집에서 <strong>삼겹살</strong> 먹을 분 구합니다. 1인당 2만원 예상됩니다.</p><p><br></p><p><em>편하게 식사하고 이야기 나누실 분</em>이면 좋겠어요. 시간 맞는 분은 댓글로 남겨주세요.</p>',
+      '<p>오늘 7시에 마포 고깃집에서 <strong>삼겹살</strong> 드실 분 구합니다. 1인당 2만원 예상입니다.</p><p><br></p><p><em>편하게 식사하고 이야기 나누실 분</em>이면 좋겠어요. 시간 맞는 분은 댓글로 남겨주세요.</p>',
     imageUrl:
       'https://images.unsplash.com/photo-1552566626-52f8b828add9?auto=format&fit=crop&q=80&w=1200',
     authorName: '김민수',
@@ -99,7 +99,7 @@ export const WithoutImage: Story = {
     title: '모임 추천 부탁드려요 :D',
     contentHtml:
       '<p>안녕하세요. 요즘 모임을 찾아보고 있는데 어떤 모임이 좋을지 모르겠어요.</p><p><br></p><p>저는 <strong>자연</strong>, <em>풍경 보는 것</em>을 좋아하고 강아지에도 관심이 많습니다.</p><ul><li>추천 모임</li><li>주의할 점</li></ul><p>자유롭게 댓글 달아주세요.</p>',
-    authorName: '달래리',
+    authorName: '오채린',
     likeCount: 8,
     commentCount: 3,
     createdAt: '2024.01.25',

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.stories.tsx
@@ -64,7 +64,7 @@ function InteractiveDetail(args: ComponentProps<typeof SosoTalkPostDetail>) {
       onShareClick={() => undefined}
       comments={comments}
       inputValue={value}
-      inputPlaceholder="댓글을 입력해 주세요"
+      inputPlaceholder="댓글을 입력해 주세요."
       onChangeInput={setValue}
       onSubmitComment={() => setValue('')}
       currentUserName="마루준"

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.test.tsx
@@ -12,7 +12,7 @@ describe('SosoTalkPostDetail', () => {
 
     render(
       <SosoTalkPostDetail
-        title="마포 고기집 같이 가실 분?"
+        title="마포 고깃집 같이 가실 분?"
         contentHtml="<p>본문입니다.</p>"
         authorName="김민수"
         createdAt="6시간 전"
@@ -25,7 +25,7 @@ describe('SosoTalkPostDetail', () => {
         inputValue=""
         onChangeInput={() => undefined}
         onSubmitComment={() => undefined}
-        currentUserName="마민준"
+        currentUserName="마루준"
       />
     );
 
@@ -41,8 +41,8 @@ describe('SosoTalkPostDetail', () => {
   it('댓글과 입력창을 함께 렌더링한다', () => {
     render(
       <SosoTalkPostDetail
-        title="마포 고기집 같이 가실 분?"
-        contentHtml="<p><strong>삼겹살</strong> 드실 분 구해요.</p>"
+        title="마포 고깃집 같이 가실 분?"
+        contentHtml="<p><strong>삼겹살</strong> 드실 분 구해요</p>"
         authorName="김민수"
         createdAt="6시간 전"
         likeCount={24}
@@ -50,21 +50,21 @@ describe('SosoTalkPostDetail', () => {
         comments={[
           {
             id: '1',
-            authorName: '박지연',
+            authorName: '박지수',
             createdAt: '03월 18일 18:54',
             content: '저도 관심 있습니다.',
           },
         ]}
         inputValue=""
-        inputPlaceholder="댓글을 입력하세요."
+        inputPlaceholder="댓글을 입력해 주세요"
         onChangeInput={() => undefined}
         onSubmitComment={() => undefined}
-        currentUserName="마민준"
+        currentUserName="마루준"
       />
     );
 
     expect(screen.getByText('삼겹살', { selector: 'strong' })).toBeInTheDocument();
-    expect(screen.getByText('박지연')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('댓글을 입력하세요.')).toBeInTheDocument();
+    expect(screen.getByText('박지수')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('댓글을 입력해 주세요')).toBeInTheDocument();
   });
 });

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.test.tsx
@@ -42,7 +42,7 @@ describe('SosoTalkPostDetail', () => {
     render(
       <SosoTalkPostDetail
         title="마포 고깃집 같이 가실 분?"
-        contentHtml="<p><strong>삼겹살</strong> 드실 분 구해요</p>"
+        contentHtml="<p><strong>삼겹살</strong> 드실 분 구해요.</p>"
         authorName="김민수"
         createdAt="6시간 전"
         likeCount={24}
@@ -56,7 +56,7 @@ describe('SosoTalkPostDetail', () => {
           },
         ]}
         inputValue=""
-        inputPlaceholder="댓글을 입력해 주세요"
+        inputPlaceholder="댓글을 입력해 주세요."
         onChangeInput={() => undefined}
         onSubmitComment={() => undefined}
         currentUserName="마루준"
@@ -65,6 +65,6 @@ describe('SosoTalkPostDetail', () => {
 
     expect(screen.getByText('삼겹살', { selector: 'strong' })).toBeInTheDocument();
     expect(screen.getByText('박지수')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('댓글을 입력해 주세요')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('댓글을 입력해 주세요.')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## PR 제목: [Fix]: 소소토크 문자열 인코딩 깨짐 복구

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 스타일, 포맷팅 수정 등 (코드 동작 영향 없음)
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

이번 PR에서는 소소토크 영역에서 깨져 보이던 한글 문자열을 복구했습니다.

- 소소토크 상세 페이지의 상태 메시지, 버튼 라벨, 메뉴 문구를 정상 한글로 수정했습니다.
- 소소토크 카드의 이미지 alt 및 메타 텍스트를 정상 문구로 정리했습니다.
- 댓글 섹션 제목과 관련 접근성 라벨을 정상 문구로 복구했습니다.
- 소소토크 상세 관련 테스트와 스토리의 깨진 mock 문자열도 함께 정리했습니다.
- 공용 컴포넌트나 `favorites`, `navigation` 영역은 수정하지 않았습니다.

### 🧪 테스트 방법 (How to Test)

1. `npm.cmd test -- --runTestsByPath src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.test.tsx --runInBand` 실행
2. 소소토크 상세 페이지 진입
3. 좋아요, 댓글, 공유, 게시글 메뉴 문구가 정상 한글로 보이는지 확인
4. 잘못된 게시글, 로딩, 에러 상태 문구가 정상 한글로 보이는지 확인
5. 소소토크 카드의 이미지 alt 및 좋아요/댓글 텍스트가 정상 표시되는지 확인

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
- 소소토크 상세 관련 파일이 `#235` 브랜치와 일부 겹치므로 머지 순서에 따라 충돌 가능성이 있습니다.
- 공용 영역이 아니라 소소토크 범위만 수정했는지 확인 부탁드립니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
