### PR TITLE
[Style]: 소소토크 및 모임 찾기 상단 레이아웃 반응형 정리

### DIFF
--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -45,7 +45,7 @@ export default function SearchPage() {
 
   return (
     <div className="bg-sosoeat-gray-100 min-h-[calc(100vh-156px)] pb-8">
-      <div className="mx-auto flex max-w-[1140px] flex-col items-center justify-center gap-4 md:px-4">
+      <div className="mx-auto flex max-w-[1140px] flex-col items-center justify-center gap-4 md:px-4 md:pt-4">
         <MeetingSearchBanner />
         <div className="flex w-full flex-col gap-4 px-4 md:px-0">
           <MeetingFilterBar

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
@@ -51,47 +51,49 @@ export const SosoTalkMainPage = ({ className }: SosoTalkMainPageProps) => {
 
   return (
     <div className={cn('bg-background min-h-screen w-full bg-[#f9f9f9] pb-24 md:pb-28', className)}>
-      <main className="mx-auto flex w-full max-w-[1280px] flex-col px-4 pt-4 md:px-6 md:pt-6 xl:px-0">
+      <main className="mx-auto flex w-full max-w-[1280px] flex-col pt-0 xl:pt-4 xl:px-0">
         <SosoTalkBanner imageUrl={SOSOTALK_BANNER_IMAGE} alt="소소톡 배너 이미지" />
 
-        <SosoTalkFilterBar
-          activeTab={activeTab}
-          activeSort={activeSort}
-          onTabChange={setActiveTab}
-          onSortChange={setActiveSort}
-        />
+        <div className="px-4 md:px-6 xl:px-0">
+          <SosoTalkFilterBar
+            activeTab={activeTab}
+            activeSort={activeSort}
+            onTabChange={setActiveTab}
+            onSortChange={setActiveSort}
+          />
 
-        <section className="pt-2">
-          {isLoading ? (
-            <div className="flex min-h-[240px] items-center justify-center">
-              <p className="text-sosoeat-gray-500 text-sm">게시글을 불러오는 중이에요.</p>
-            </div>
-          ) : null}
+          <section className="pt-2">
+            {isLoading ? (
+              <div className="flex min-h-[240px] items-center justify-center">
+                <p className="text-sosoeat-gray-500 text-sm">게시글을 불러오는 중이에요.</p>
+              </div>
+            ) : null}
 
-          {isError ? (
-            <div className="flex min-h-[240px] items-center justify-center">
-              <p className="text-sosoeat-gray-500 text-sm">
-                게시글 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
-              </p>
-            </div>
-          ) : null}
+            {isError ? (
+              <div className="flex min-h-[240px] items-center justify-center">
+                <p className="text-sosoeat-gray-500 text-sm">
+                  게시글 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
+                </p>
+              </div>
+            ) : null}
 
-          {!isLoading && !isError ? (
-            <>
-              {posts.length > 0 ? (
-                <div className="grid grid-cols-1 justify-items-center gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:justify-items-stretch">
-                  {posts.map((post) => (
-                    <SosoTalkCard key={post.id} {...post} />
-                  ))}
-                </div>
-              ) : (
-                <div className="flex min-h-[240px] items-center justify-center">
-                  <p className="text-sosoeat-gray-400 text-sm">아직 등록된 게시글이 없어요.</p>
-                </div>
-              )}
-            </>
-          ) : null}
-        </section>
+            {!isLoading && !isError ? (
+              <>
+                {posts.length > 0 ? (
+                  <div className="grid grid-cols-1 justify-items-center gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:justify-items-stretch">
+                    {posts.map((post) => (
+                      <SosoTalkCard key={post.id} {...post} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex min-h-[240px] items-center justify-center">
+                    <p className="text-sosoeat-gray-400 text-sm">아직 등록된 게시글이 없어요.</p>
+                  </div>
+                )}
+              </>
+            ) : null}
+          </section>
+        </div>
       </main>
 
       <Button

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
@@ -299,7 +299,7 @@ function SosoTalkPostDetailPageLayout({ children }: { children: ReactNode }) {
     <div className="bg-sosoeat-gray-100 flex min-h-screen flex-col">
       <main className="flex-1 px-4 py-8 md:px-6 md:py-10">
         <div className="mx-auto w-full max-w-[1280px]">
-          <div className="mx-auto w-full max-w-[860px] xl:max-w-[960px]">{children}</div>
+          <div className="mx-auto w-full xl:max-w-[1280px]">{children}</div>
         </div>
       </main>
     </div>

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
@@ -298,9 +298,7 @@ function SosoTalkPostDetailPageLayout({ children }: { children: ReactNode }) {
   return (
     <div className="bg-sosoeat-gray-100 flex min-h-screen flex-col">
       <main className="flex-1 px-4 py-8 md:px-6 md:py-10">
-        <div className="mx-auto w-full max-w-[1280px]">
-          <div className="mx-auto w-full xl:max-w-[1280px]">{children}</div>
-        </div>
+        <div className="mx-auto w-full max-w-[1280px]">{children}</div>
       </main>
     </div>
   );


### PR DESCRIPTION
## PR 제목: [Style]: 소소토크 및 모임 찾기 상단 레이아웃 반응형 정리

### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [x] **Style (스타일):** 코드 스타일, 포맷팅 수정 등 (코드 동작 영향 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

이번 PR에서는 소소토크와 모임 찾기 페이지의 상단 레이아웃 및 반응형 간격을 정리했습니다.

- 소소토크 메인 페이지에서 필터바와 카드 리스트가 같은 내부 컨테이너를 사용하도록 구조를 정리했습니다.
- 소소토크 메인 배너는 모바일/태블릿에서 상단 네비게이션과 붙도록 하고, PC(`xl`)에서는 다시 상단 여백이 생기도록 조정했습니다.
- 소소토크 상세 페이지는 `1280px` 구간에서 콘텐츠 영역이 갑자기 좁아지지 않도록 너비 제한을 완화했습니다.
- 모임 찾기 페이지는 태블릿/PC에서 배너가 상단 네비게이션과 너무 붙지 않도록 `16px` 상단 여백을 추가했습니다.

### 🧪 테스트 방법 (How to Test)

1. `/sosotalk` 페이지 진입
2. 배너 아래 필터바(`전체 TALK`, `인기 TALK`)와 카드 리스트의 좌우 시작선이 맞는지 확인
3. 모바일/태블릿에서는 소소토크 배너가 상단 네비게이션과 붙어 보이고, PC에서는 상단 여백이 있는지 확인
4. `/sosotalk/[id]` 상세 페이지 진입 후 `1280px` 부근에서 콘텐츠 영역이 갑자기 좁아지지 않는지 확인
5. `/search` 페이지에서 태블릿/PC 기준 배너가 상단 네비게이션과 약간 떨어져 보이는지 확인

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
<img width="1213" height="267" alt="image" src="https://github.com/user-attachments/assets/983789d3-ea4b-42f3-8e7b-1f2813ec2508" />
<img width="1240" height="437" alt="image" src="https://github.com/user-attachments/assets/a9341973-0897-476e-9216-7162545cd8db" />
<img width="1249" height="636" alt="image" src="https://github.com/user-attachments/assets/80151373-72e8-4968-b341-ebf388d36347" />


### 🚨 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
- 소소토크 메인/상세와 모임 찾기 상단 간격만 조정했으며, 기능 로직은 변경하지 않았습니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
