### PR TITLE
[Refactor]: #249_소소톡 캐시 정책 정리 및 좋아요 캐시 동기화 개선

### DIFF
--- a/src/entities/post/model/post.queries.test.tsx
+++ b/src/entities/post/model/post.queries.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import {
+  createSosoTalkPostLike,
+  deleteSosoTalkPostLike,
+  getSosoTalkPostDetail,
+  getSosoTalkPostList,
+} from '../api/posts.api';
+
+import type {
+  GetSosoTalkPostDetailResponse,
+  GetSosoTalkPostListResponse,
+} from './post.types';
+import {
+  sosotalkPostDetailQueryOptions,
+  sosotalkPostListQueryOptions,
+  sosotalkQueryKeys,
+  useCreateSosoTalkPostLike,
+  useDeleteSosoTalkPostLike,
+} from './post.queries';
+
+jest.mock('../api/posts.api', () => ({
+  createSosoTalkPostLike: jest.fn(),
+  deleteSosoTalkPostLike: jest.fn(),
+  getSosoTalkPostDetail: jest.fn(),
+  getSosoTalkPostList: jest.fn(),
+}));
+
+const mockCreateSosoTalkPostLike = createSosoTalkPostLike as jest.Mock;
+const mockDeleteSosoTalkPostLike = deleteSosoTalkPostLike as jest.Mock;
+const mockGetSosoTalkPostDetail = getSosoTalkPostDetail as jest.Mock;
+const mockGetSosoTalkPostList = getSosoTalkPostList as jest.Mock;
+
+const POST_ID = 1;
+const LIST_PARAMS = {
+  type: 'all',
+  sortBy: 'createdAt',
+  sortOrder: 'desc',
+  size: 10,
+} as const;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+};
+
+const createPostDetail = (): GetSosoTalkPostDetailResponse => ({
+  id: POST_ID,
+  teamId: 'dallaem',
+  title: '소소톡 게시글',
+  content: '<p>본문입니다.</p>',
+  image: 'https://example.com/post.jpg',
+  authorId: 10,
+  viewCount: 10,
+  likeCount: 4,
+  createdAt: new Date('2026-03-18T09:00:00.000Z'),
+  updatedAt: new Date('2026-03-18T09:00:00.000Z'),
+  author: {
+    id: 10,
+    name: '작성자',
+    image: 'https://example.com/author.jpg',
+    email: 'writer@example.com',
+  },
+  count: {
+    comments: 2,
+  },
+  comments: [],
+  isLiked: false,
+});
+
+const createPostList = (): GetSosoTalkPostListResponse => ({
+  data: [
+    {
+      id: POST_ID,
+      teamId: 'dallaem',
+      title: '소소톡 게시글',
+      content: '<p>본문입니다.</p>',
+      image: 'https://example.com/post.jpg',
+      authorId: 10,
+      viewCount: 10,
+      likeCount: 4,
+      createdAt: new Date('2026-03-18T09:00:00.000Z'),
+      updatedAt: new Date('2026-03-18T09:00:00.000Z'),
+      author: {
+        id: 10,
+        name: '작성자',
+        image: 'https://example.com/author.jpg',
+      },
+      count: {
+        comments: 2,
+      },
+    },
+  ],
+  hasMore: false,
+});
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
+
+describe('sosotalk query options', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('목록/상세 쿼리 옵션에 동일한 캐시 정책을 적용한다', () => {
+    const listOptions = sosotalkPostListQueryOptions(LIST_PARAMS);
+    const detailOptions = sosotalkPostDetailQueryOptions(POST_ID);
+
+    expect(listOptions.staleTime).toBe(30_000);
+    expect(listOptions.gcTime).toBe(600_000);
+    expect(detailOptions.staleTime).toBe(30_000);
+    expect(detailOptions.gcTime).toBe(600_000);
+  });
+});
+
+describe('sosotalk like mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSosoTalkPostDetail.mockResolvedValue(createPostDetail());
+    mockGetSosoTalkPostList.mockResolvedValue(createPostList());
+  });
+
+  it('좋아요 추가 시 상세/목록 캐시를 낙관적으로 함께 갱신한다', async () => {
+    const deferred = createDeferred<unknown>();
+    mockCreateSosoTalkPostLike.mockReturnValue(deferred.promise);
+
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(sosotalkQueryKeys.postDetail(POST_ID), createPostDetail());
+    queryClient.setQueryData(sosotalkQueryKeys.postList(LIST_PARAMS), createPostList());
+
+    const { result } = renderHook(() => useCreateSosoTalkPostLike(), { wrapper });
+
+    let mutationPromise!: Promise<unknown>;
+    act(() => {
+      mutationPromise = result.current.mutateAsync(POST_ID);
+    });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<GetSosoTalkPostDetailResponse>(sosotalkQueryKeys.postDetail(POST_ID))
+      ).toMatchObject({
+        isLiked: true,
+        likeCount: 5,
+      })
+    );
+    expect(
+      queryClient.getQueryData<GetSosoTalkPostListResponse>(sosotalkQueryKeys.postList(LIST_PARAMS))
+    ).toMatchObject({
+        data: [expect.objectContaining({ id: POST_ID, likeCount: 5 })],
+      });
+
+    deferred.resolve({});
+    await mutationPromise;
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('좋아요 취소 실패 시 상세/목록 캐시를 이전 상태로 롤백한다', async () => {
+    mockDeleteSosoTalkPostLike.mockRejectedValue(new Error('좋아요 취소 실패'));
+
+    const { queryClient, wrapper } = createWrapper();
+    const likedDetail = {
+      ...createPostDetail(),
+      likeCount: 5,
+      isLiked: true,
+    };
+    const likedList = {
+      ...createPostList(),
+      data: createPostList().data.map((post) => ({
+        ...post,
+        likeCount: 5,
+      })),
+    };
+
+    queryClient.setQueryData(sosotalkQueryKeys.postDetail(POST_ID), likedDetail);
+    queryClient.setQueryData(sosotalkQueryKeys.postList(LIST_PARAMS), likedList);
+
+    const { result } = renderHook(() => useDeleteSosoTalkPostLike(), { wrapper });
+
+    await expect(result.current.mutateAsync(POST_ID)).rejects.toThrow('좋아요 취소 실패');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(
+      queryClient.getQueryData<GetSosoTalkPostDetailResponse>(sosotalkQueryKeys.postDetail(POST_ID))
+    ).toMatchObject({
+      isLiked: true,
+      likeCount: 5,
+    });
+    expect(
+      queryClient.getQueryData<GetSosoTalkPostListResponse>(sosotalkQueryKeys.postList(LIST_PARAMS))
+    ).toMatchObject({
+      data: [expect.objectContaining({ id: POST_ID, likeCount: 5 })],
+    });
+  });
+});

--- a/src/entities/post/model/post.queries.ts
+++ b/src/entities/post/model/post.queries.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   createSosoTalkComment,
@@ -17,11 +17,16 @@ import type {
   CommentMutationParams,
   CreateSosoTalkCommentParams,
   CreateSosoTalkPostParams,
+  GetSosoTalkPostDetailResponse,
   GetSosoTalkPostListParams,
+  GetSosoTalkPostListResponse,
   SosoTalkPostMutationParams,
   UpdateSosoTalkCommentParams,
   UpdateSosoTalkPostParams,
 } from './post.types';
+
+const SOSOTALK_QUERY_STALE_TIME = 30_000;
+const SOSOTALK_QUERY_GC_TIME = 1000 * 60 * 10;
 
 export const sosotalkQueryKeys = {
   all: ['sosotalk'] as const,
@@ -29,14 +34,16 @@ export const sosotalkQueryKeys = {
   postDetail: (postId?: number) => ['sosotalk-post-detail', postId] as const,
 };
 
-export const useGetSosoTalkPostList = (params?: GetSosoTalkPostListParams) =>
-  useQuery({
+export const sosotalkPostListQueryOptions = (params?: GetSosoTalkPostListParams) =>
+  queryOptions({
     queryKey: sosotalkQueryKeys.postList(params),
     queryFn: () => getSosoTalkPostList(params),
+    staleTime: SOSOTALK_QUERY_STALE_TIME,
+    gcTime: SOSOTALK_QUERY_GC_TIME,
   });
 
-export const useGetSosoTalkPostDetail = (postId?: number) =>
-  useQuery({
+export const sosotalkPostDetailQueryOptions = (postId?: number) =>
+  queryOptions({
     queryKey: sosotalkQueryKeys.postDetail(postId),
     queryFn: () => {
       if (postId == null) {
@@ -46,7 +53,128 @@ export const useGetSosoTalkPostDetail = (postId?: number) =>
       return getSosoTalkPostDetail(postId);
     },
     enabled: postId != null,
+    staleTime: SOSOTALK_QUERY_STALE_TIME,
+    gcTime: SOSOTALK_QUERY_GC_TIME,
   });
+
+export const useGetSosoTalkPostList = (params?: GetSosoTalkPostListParams) =>
+  useQuery(sosotalkPostListQueryOptions(params));
+
+export const useGetSosoTalkPostDetail = (postId?: number) =>
+  useQuery(sosotalkPostDetailQueryOptions(postId));
+
+const SOSOTALK_POST_LIST_QUERY_PREFIX = ['sosotalk-post-list'] as const;
+
+type SosoTalkLikeMutationContext = {
+  previousDetail?: GetSosoTalkPostDetailResponse;
+  previousLists: Array<readonly [readonly unknown[], GetSosoTalkPostListResponse | undefined]>;
+};
+
+const updateSosoTalkPostDetailLikeCache = (
+  previousDetail: GetSosoTalkPostDetailResponse | undefined,
+  nextIsLiked: boolean
+): GetSosoTalkPostDetailResponse | undefined => {
+  if (!previousDetail) {
+    return previousDetail;
+  }
+
+  const likeDiff = nextIsLiked === previousDetail.isLiked ? 0 : nextIsLiked ? 1 : -1;
+
+  return {
+    ...previousDetail,
+    isLiked: nextIsLiked,
+    likeCount: Math.max(0, previousDetail.likeCount + likeDiff),
+  };
+};
+
+const updateSosoTalkPostListLikeCache = (
+  previousList: GetSosoTalkPostListResponse | undefined,
+  postId: number,
+  likeDiff: number
+): GetSosoTalkPostListResponse | undefined => {
+  if (!previousList) {
+    return previousList;
+  }
+
+  return {
+    ...previousList,
+    data: previousList.data.map((post) =>
+      post.id === postId
+        ? {
+            ...post,
+            likeCount: Math.max(0, post.likeCount + likeDiff),
+          }
+        : post
+    ),
+  };
+};
+
+const invalidateSosoTalkListQueries = (queryClient: ReturnType<typeof useQueryClient>) =>
+  queryClient.invalidateQueries({ queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX });
+
+const restoreSosoTalkLikeCache = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  postId: number,
+  context?: SosoTalkLikeMutationContext
+) => {
+  if (context?.previousDetail) {
+    queryClient.setQueryData(sosotalkQueryKeys.postDetail(postId), context.previousDetail);
+  }
+
+  context?.previousLists.forEach(([queryKey, previousList]) => {
+    queryClient.setQueryData(queryKey, previousList);
+  });
+};
+
+const createSosoTalkLikeMutation = (
+  nextIsLiked: boolean,
+  mutationFn: (postId: number) => Promise<unknown>
+) => {
+  return () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+      mutationFn,
+      onMutate: async (postId): Promise<SosoTalkLikeMutationContext> => {
+        await Promise.all([
+          queryClient.cancelQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
+          queryClient.cancelQueries({ queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX }),
+        ]);
+
+        const previousDetail = queryClient.getQueryData<GetSosoTalkPostDetailResponse>(
+          sosotalkQueryKeys.postDetail(postId)
+        );
+        const previousLists = queryClient.getQueriesData<GetSosoTalkPostListResponse>({
+          queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX,
+        });
+
+        queryClient.setQueryData<GetSosoTalkPostDetailResponse>(
+          sosotalkQueryKeys.postDetail(postId),
+          (currentDetail) => updateSosoTalkPostDetailLikeCache(currentDetail, nextIsLiked)
+        );
+        queryClient.setQueriesData<GetSosoTalkPostListResponse>(
+          { queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX },
+          (currentList) =>
+            updateSosoTalkPostListLikeCache(currentList, postId, nextIsLiked ? 1 : -1)
+        );
+
+        return {
+          previousDetail,
+          previousLists,
+        };
+      },
+      onError: (_error, postId, context) => {
+        restoreSosoTalkLikeCache(queryClient, postId, context);
+      },
+      onSettled: (_data, _error, postId) => {
+        void Promise.all([
+          queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
+          invalidateSosoTalkListQueries(queryClient),
+        ]);
+      },
+    });
+  };
+};
 
 export const useCreateSosoTalkPost = () => {
   const queryClient = useQueryClient();
@@ -54,38 +182,17 @@ export const useCreateSosoTalkPost = () => {
   return useMutation({
     mutationFn: (params: CreateSosoTalkPostParams) => createSosoTalkPost(params),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['sosotalk-post-list'] });
+      void invalidateSosoTalkListQueries(queryClient);
     },
   });
 };
 
-export const useCreateSosoTalkPostLike = () => {
-  const queryClient = useQueryClient();
+export const useCreateSosoTalkPostLike = createSosoTalkLikeMutation(true, createSosoTalkPostLike);
 
-  return useMutation({
-    mutationFn: (postId: number) => createSosoTalkPostLike(postId),
-    onSuccess: (_data, postId) => {
-      void Promise.all([
-        queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
-        queryClient.invalidateQueries({ queryKey: ['sosotalk-post-list'] }),
-      ]);
-    },
-  });
-};
-
-export const useDeleteSosoTalkPostLike = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (postId: number) => deleteSosoTalkPostLike(postId),
-    onSuccess: (_data, postId) => {
-      void Promise.all([
-        queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
-        queryClient.invalidateQueries({ queryKey: ['sosotalk-post-list'] }),
-      ]);
-    },
-  });
-};
+export const useDeleteSosoTalkPostLike = createSosoTalkLikeMutation(
+  false,
+  deleteSosoTalkPostLike
+);
 
 export const useCreateSosoTalkComment = () => {
   const queryClient = useQueryClient();
@@ -93,7 +200,10 @@ export const useCreateSosoTalkComment = () => {
   return useMutation({
     mutationFn: (params: CreateSosoTalkCommentParams) => createSosoTalkComment(params),
     onSuccess: (_data, { postId }) => {
-      void queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) });
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
+        invalidateSosoTalkListQueries(queryClient),
+      ]);
     },
   });
 };
@@ -115,7 +225,10 @@ export const useDeleteSosoTalkComment = () => {
   return useMutation({
     mutationFn: (params: CommentMutationParams) => deleteSosoTalkComment(params),
     onSuccess: (_data, { postId }) => {
-      void queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) });
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
+        invalidateSosoTalkListQueries(queryClient),
+      ]);
     },
   });
 };
@@ -128,7 +241,7 @@ export const useUpdateSosoTalkPost = () => {
     onSuccess: (_data, { postId }) => {
       void Promise.all([
         queryClient.invalidateQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
-        queryClient.invalidateQueries({ queryKey: ['sosotalk-post-list'] }),
+        invalidateSosoTalkListQueries(queryClient),
       ]);
     },
   });
@@ -140,7 +253,7 @@ export const useDeleteSosoTalkPost = () => {
   return useMutation({
     mutationFn: (params: SosoTalkPostMutationParams) => deleteSosoTalkPost(params),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['sosotalk-post-list'] });
+      void invalidateSosoTalkListQueries(queryClient);
     },
   });
 };

--- a/src/widgets/sosotalk/ui/sosotalk-card/sosotalk-card.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-card/sosotalk-card.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useQueryClient } from '@tanstack/react-query';
 import { Heart, MessageCircle } from 'lucide-react';
 
-import { getSosoTalkPostDetail } from '@/entities/post';
+import { sosotalkPostDetailQueryOptions } from '@/entities/post';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar/avatar';
 
 import type { SosoTalkCardProps } from './sosotalk-card.types';
@@ -25,11 +25,7 @@ export function SosoTalkCard({
   const queryClient = useQueryClient();
 
   const prefetchPostDetail = () => {
-    void queryClient.prefetchQuery({
-      queryKey: ['sosotalk-post-detail', id],
-      queryFn: () => getSosoTalkPostDetail(id),
-      staleTime: 30_000,
-    });
+    void queryClient.prefetchQuery(sosotalkPostDetailQueryOptions(id));
   };
 
   return (


### PR DESCRIPTION
### PR 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 변경 사항 (Changes)

- #249 소소톡 React Query 캐시 전략을 정리했습니다.
- 게시글 목록/상세 쿼리에 `staleTime`, `gcTime`을 적용해 캐시 정책을 명확히 했습니다.
- 상세 카드 프리패치와 실제 상세 조회가 동일한 query options를 사용하도록 공통화했습니다.
- 좋아요 mutation에서 `invalidateQueries`에만 의존하지 않고 `setQueryData`를 사용해 목록/상세 캐시를 함께 optimistic update 하도록 변경했습니다.
- 좋아요 실패 시 이전 캐시로 롤백되도록 처리했습니다.
- 소소톡 캐시 로직 검증용 테스트를 추가했습니다.

### 테스트 방법 (How to Test)

1. `npm run test -- src/entities/post/model/post.queries.test.tsx --runInBand` 실행
2. `npm run test -- src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx --runInBand` 실행
3. `/sosotalk` 진입 후 게시글 카드 hover/focus 시 상세 프리패치가 정상 동작하는지 확인
4. `/sosotalk/[id]`에서 좋아요 클릭 후 상세와 목록 간 좋아요 수가 자연스럽게 동기화되는지 확인

### 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
좋아요 mutation의 optimistic update 범위를 목록/상세 캐시까지 확장한 부분을 중점적으로 봐주시면 좋습니다.

- [x] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
현재 전체 `type-check`는 이번 PR과 무관한 기존 `profile-edit` 영역의 `react-easy-crop` 타입 이슈로 실패합니다.  
소소톡 관련 테스트는 별도로 통과 확인했습니다.
