### PR TITLE
[Feat]: 홈 CTA 모임 생성/검색 이동 및 모임타입 필터 연동

### DIFF
--- a/src/widgets/home/ui/cta-section/cta-section.tsx
+++ b/src/widgets/home/ui/cta-section/cta-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 import { Star, Users } from 'lucide-react';
 

--- a/src/widgets/home/ui/cta-section/cta-section.tsx
+++ b/src/widgets/home/ui/cta-section/cta-section.tsx
@@ -1,10 +1,34 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 import { Star, Users } from 'lucide-react';
 
+import { useAuthStore } from '@/entities/auth';
+import { MeetingCreateModal, useCreateMeeting } from '@/features/meeting-create';
+import { useModal } from '@/shared/lib/use-modal';
 import { Button } from '@/shared/ui/button';
 
 export function CtaSection() {
+  const router = useRouter();
+  const { isOpen, open, close } = useModal();
+  const { mutateAsync: createMeeting } = useCreateMeeting();
+  const { isAuthenticated, setLoginRequired } = useAuthStore();
+
+  const handleOpenCreateModal = () => {
+    if (!isAuthenticated) {
+      setLoginRequired(true);
+      return;
+    }
+    open();
+  };
+
+  const handleGoToSearch = () => {
+    router.push('/search');
+  };
+
   return (
-    <section className="bg-sosoeat-orange-600 mt-16 flex w-full flex-col items-center justify-center gap-8 px-6 py-16 text-white md:mt-[100px] md:py-24">
+    <section className="bg-sosoeat-orange-600 relative z-10 mt-16 flex w-full flex-col items-center justify-center gap-8 px-6 py-16 text-white md:mt-[100px] md:py-24">
       <div className="flex flex-col items-center gap-3 text-center">
         <h2 className="text-2xl leading-tight font-bold md:text-3xl">지금 바로 시작해볼까요?</h2>
         <p className="max-w-[280px] text-sm font-medium text-white/80 md:max-w-none md:text-base">
@@ -13,11 +37,15 @@ export function CtaSection() {
       </div>
 
       <div className="flex w-full max-w-[400px] flex-row gap-2 px-4 sm:w-auto sm:max-w-none sm:px-0">
-        <Button className="text-sosoeat-orange-600 h-[56px] flex-1 cursor-pointer rounded-2xl bg-white text-base font-bold hover:bg-white/90 sm:w-[180px]">
+        <Button
+          onClick={handleOpenCreateModal}
+          className="text-sosoeat-orange-600 h-[56px] flex-1 cursor-pointer rounded-2xl bg-white text-base font-bold hover:bg-white/90 sm:w-[180px]"
+        >
           <Star className="mr-1 h-4 w-4" />
           모임 만들기
         </Button>
         <Button
+          onClick={handleGoToSearch}
           variant="outline"
           className="h-[56px] flex-1 cursor-pointer rounded-2xl border-[1.2px] border-white/40 bg-white/15 text-base font-bold text-white hover:bg-white/20 hover:text-white sm:w-[180px]"
         >
@@ -25,6 +53,8 @@ export function CtaSection() {
           모임 둘러보기
         </Button>
       </div>
+
+      <MeetingCreateModal open={isOpen} onClose={close} onSubmit={createMeeting} />
     </section>
   );
 }

--- a/src/widgets/home/ui/meeting-type-section/meeting-type-section.tsx
+++ b/src/widgets/home/ui/meeting-type-section/meeting-type-section.tsx
@@ -9,7 +9,7 @@ export function MeetingTypeSection() {
       <div className="flex gap-3 md:gap-6 lg:gap-9">
         {/* 함께먹기 */}
         <Link
-          href="/meetings?type=group-eat"
+          href="/search?typeFilter=groupEat"
           className="bg-sosoeat-orange-600 relative flex-1 overflow-hidden rounded-2xl p-4 md:p-5 lg:p-6"
         >
           <div className="flex flex-col gap-2">
@@ -32,7 +32,7 @@ export function MeetingTypeSection() {
 
         {/* 공동구매 */}
         <Link
-          href="/meetings?type=group-buy"
+          href="/search?typeFilter=groupBuy"
           className="bg-sosoeat-blue-600 relative flex-1 overflow-hidden rounded-2xl p-4 md:p-5 lg:p-6"
         >
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## PR 제목: [Feat]: 홈 CTA 모임 생성/검색 이동 및 모임타입 필터 연동
### 📌 유형 (Type)
다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.
- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등
### 📝 변경 사항 (Changes)
- 홈 CTA 섹션의 "모임 만들기" 버튼을 실제 모임 생성 모달 플로우와 연동했습니다.
  - 비로그인 시 `setLoginRequired(true)` 호출
  - 로그인 시 `MeetingCreateModal` 오픈
- 홈 CTA 섹션의 "모임 둘러보기" 버튼 클릭 시 `/search`로 이동하도록 연결했습니다.
- 홈 모임타입 카드 링크를 검색 페이지 필터 파라미터 구조에 맞게 수정했습니다.
  - `/meetings?type=group-eat` -> `/search?typeFilter=groupEat`
  - `/meetings?type=group-buy` -> `/search?typeFilter=groupBuy`
- 관련 커밋:
  - `ffc61927ec296a0607b1cb0d4ce22d9eae482992`
  - `6a613fda0ac7ceb16c0c3971090d199809e779de`
### 🧪 테스트 방법 (How to Test)
1. 로컬에서 앱 실행 후 홈 페이지로 이동합니다.
2. **로그인되지 않은 상태**에서 CTA의 `모임 만들기` 클릭
3. 로그인 요구 플로우(로그인 모달/상태 유도)가 동작하는지 확인합니다.
4. **로그인된 상태**에서 CTA의 `모임 만들기` 클릭
5. `MeetingCreateModal`이 열리는지 확인합니다.
6. CTA의 `모임 둘러보기` 클릭 후 `/search`로 이동하는지 확인합니다.
7. `함께먹기`, `공동구매` 카드 클릭 후 각각
   - `/search?typeFilter=groupEat`
   - `/search?typeFilter=groupBuy`
   로 이동 및 필터 반영되는지 확인합니다.
### 📸 스크린샷 또는 영상 (Optional)
(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)
| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |
### 🚨 기타 참고 사항 (Notes)
- 없음.