### PR TITLE
[Feat]: 검색 페이지 무한 스크롤 구현 및 쿼리 키 factory 패턴 적용

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,10 @@
       "Bash(cmd /c \"gh --version\")",
       "Bash(npx jest:*)",
       "Bash(npx eslint:*)",
-      "Bash(ov add-resource:*)"
+      "Bash(ov add-resource:*)",
+      "Bash(gh api:*)",
+      "Bash(gh label:*)",
+      "Bash(gh pr:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,9 @@
       "Bash(ov add-resource:*)",
       "Bash(gh api:*)",
       "Bash(gh label:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(git push:*)",
+      "Skill(plan-eng-review)"
     ]
   }
 }

--- a/src/entities/meeting/index.ts
+++ b/src/entities/meeting/index.ts
@@ -1,6 +1,7 @@
 export { meetingsApi } from './api/meetings.api';
 export type { Meeting, MeetingCategory } from './model/meeting.types';
 export { meetingsQueryOptions } from './model/meetings.options';
+export { useSearchInfiniteOptions } from './model/search.queries';
 export { useDetailRouter } from './model/use-detail-router';
 export { DeadlineBadge } from './ui/deadline-badge';
 export { EstablishmentStatusBadge } from './ui/establishment-status-badge';

--- a/src/entities/meeting/model/meetings.options.ts
+++ b/src/entities/meeting/model/meetings.options.ts
@@ -1,29 +1,42 @@
-import { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
+import type { MeetingList, TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
 
 import { meetingsApi } from '../api/meetings.api';
 
+const searchKeys = {
+  all: () => ['search'] as const,
+  detail: (id: number) => ['search', 'detail', id] as const,
+  options: (options: Omit<TeamIdMeetingsGetRequest, 'teamId'>) =>
+    ['search', 'list', options] as const,
+  infiniteOptions: (options: Omit<TeamIdMeetingsGetRequest, 'teamId'>) =>
+    ['search', 'infinite-list', options] as const,
+} as const;
+
 export const meetingsQueryOptions = {
   all: () => ({
-    queryKey: ['meetings'],
+    queryKey: searchKeys.all(),
     queryFn: () => meetingsApi.getList(),
     staleTime: 1000 * 60 * 5, // 5분
     gcTime: 1000 * 60 * 10, // 10분
   }),
   detail: (id: number) => ({
-    queryKey: ['meetings', 'detail', id],
+    queryKey: searchKeys.detail(id),
     queryFn: async () => meetingsApi.getById(id),
     staleTime: 1000 * 60 * 5, // 5분
     gcTime: 1000 * 60 * 10, // 10분
   }),
   options: (options: Omit<TeamIdMeetingsGetRequest, 'teamId'>) => ({
-    queryKey: [
-      'meetings',
-      {
-        ...options,
-      },
-    ],
+    queryKey: searchKeys.options(options),
     queryFn: () => meetingsApi.getByFilter(options),
     staleTime: 1000 * 60 * 5, // 5분
     gcTime: 1000 * 60 * 10, // 10분
+  }),
+  infiniteOptions: (options: Omit<TeamIdMeetingsGetRequest, 'teamId'>) => ({
+    queryKey: searchKeys.infiniteOptions(options),
+    queryFn: ({ pageParam }: { pageParam?: string }) =>
+      meetingsApi.getByFilter({ ...options, cursor: pageParam }),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage: MeetingList) => {
+      return lastPage.hasMore ? lastPage.nextCursor : undefined;
+    },
   }),
 };

--- a/src/entities/meeting/model/search.queries.tsx
+++ b/src/entities/meeting/model/search.queries.tsx
@@ -1,0 +1,17 @@
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+
+import { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client/apis/MeetingsApi';
+
+import { meetingsQueryOptions } from './meetings.options';
+
+export const useSearchList = () => {
+  return useQuery(meetingsQueryOptions.all());
+};
+
+export const useSearchOptions = (options: Omit<TeamIdMeetingsGetRequest, 'teamId'>) => {
+  return useQuery(meetingsQueryOptions.options(options));
+};
+
+export const useSearchInfiniteOptions = (options: Omit<TeamIdMeetingsGetRequest, 'teamId'>) => {
+  return useInfiniteQuery(meetingsQueryOptions.infiniteOptions(options));
+};

--- a/src/widgets/search/model/use-search-page.test.tsx
+++ b/src/widgets/search/model/use-search-page.test.tsx
@@ -1,4 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 import { startOfDay } from 'date-fns';
 import { withNuqsTestingAdapter } from 'nuqs/adapters/testing';
@@ -7,7 +9,7 @@ import useSearchPage from './use-search-page';
 
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
-  useQuery: jest.fn(),
+  useInfiniteQuery: jest.fn(),
 }));
 
 const renderHookWithClient = (hook: () => ReturnType<typeof useSearchPage>) => {
@@ -18,10 +20,13 @@ const renderHookWithClient = (hook: () => ReturnType<typeof useSearchPage>) => {
 
 describe('useSearchPage', () => {
   beforeEach(() => {
-    (useQuery as jest.Mock).mockReturnValue({
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: false,
+      hasNextPage: false,
+      isFetching: false,
+      fetchNextPage: jest.fn(),
     });
   });
 
@@ -95,5 +100,24 @@ describe('useSearchPage', () => {
 
     expect(result.current.sortBy).toBe('dateTime');
     expect(result.current.sortOrder).toBe('desc');
+  });
+
+  it('pages 데이터를 flatMap하여 meetingData를 반환해야 한다', () => {
+    const page1 = { data: [{ id: 1 }, { id: 2 }], nextCursor: 'c1', hasMore: true };
+    const page2 = { data: [{ id: 3 }], nextCursor: '', hasMore: false };
+
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [page1, page2], pageParams: [undefined, 'c1'] },
+      isLoading: false,
+      isError: false,
+      hasNextPage: false,
+      isFetching: false,
+      fetchNextPage: jest.fn(),
+    });
+
+    const { result } = renderHookWithClient(() => useSearchPage());
+
+    expect(result.current.meetingData).toHaveLength(3);
+    expect(result.current.meetingData.map((m) => m.id)).toEqual([1, 2, 3]);
   });
 });

--- a/src/widgets/search/model/use-search-page.ts
+++ b/src/widgets/search/model/use-search-page.ts
@@ -1,11 +1,10 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import { startOfDay } from 'date-fns';
 import { parseAsIsoDate, parseAsJson, parseAsStringLiteral, useQueryState } from 'nuqs';
 
-import { meetingsQueryOptions } from '@/entities/meeting';
-import type { MeetingList, TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
+import { useSearchInfiniteOptions } from '@/entities/meeting';
+import type { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
 
 import type { MeetingFilterBarProps } from '../ui/meeting-filter-bar';
 import type { RegionSelection } from '../ui/region-select-modal';
@@ -87,8 +86,12 @@ const useSearchPage = () => {
     data: meetingList,
     isLoading,
     isError,
-  } = useQuery<MeetingList>(meetingsQueryOptions.options(options));
-  const meetingData = meetingList?.data ?? [];
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+  } = useSearchInfiniteOptions(options);
+  const meetingData = meetingList?.pages.flatMap((page) => page.data) ?? [];
 
   const handleTypeFilterChange = (value: 'all' | 'groupEat' | 'groupBuy') => {
     setTypeFilter(value);
@@ -137,6 +140,10 @@ const useSearchPage = () => {
     sortOrder,
     isLoading,
     isError,
+    hasNextPage,
+    fetchNextPage,
+    isFetching,
+    isFetchingNextPage,
   };
 };
 

--- a/src/widgets/search/ui/search-page/search-page.test.tsx
+++ b/src/widgets/search/ui/search-page/search-page.test.tsx
@@ -1,4 +1,6 @@
-import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useInView } from 'react-intersection-observer';
+
+import { QueryClient, QueryClientProvider, useInfiniteQuery } from '@tanstack/react-query';
 import { fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { withNuqsTestingAdapter } from 'nuqs/adapters/testing';
 
@@ -10,35 +12,26 @@ import { useSearchPage } from '../..';
 
 import SearchPage from './search-page';
 
-const createQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
+const NuqsWrapper = withNuqsTestingAdapter({ searchParams: {} });
+const renderWithNuqs = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient();
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        <NuqsWrapper>{children}</NuqsWrapper>
+      </QueryClientProvider>
+    ),
   });
-
-const renderWithClient = (ui: React.ReactElement) => {
-  const queryClient = createQueryClient();
-  const NuqsWrapper = withNuqsTestingAdapter({ searchParams: {} });
-  const Wrapper = ({ children }: { children: React.ReactNode }) => (
-    <NuqsWrapper>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </NuqsWrapper>
-  );
-  return render(ui, { wrapper: Wrapper });
 };
 
-const renderHookWithClient = <T,>(hook: () => T) => {
-  const queryClient = createQueryClient();
-  const NuqsWrapper = withNuqsTestingAdapter({ searchParams: {} });
-  const Wrapper = ({ children }: { children: React.ReactNode }) => (
-    <NuqsWrapper>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </NuqsWrapper>
-  );
-  return renderHook(hook, { wrapper: Wrapper });
-};
+const renderHookWithNuqs = <T,>(hook: () => T) =>
+  renderHook(hook, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={new QueryClient()}>
+        <NuqsWrapper>{children}</NuqsWrapper>
+      </QueryClientProvider>
+    ),
+  });
 
 export const mockHost: Host = {
   id: 1,
@@ -111,19 +104,42 @@ export const mockEmptyMeetingList: MeetingList = {
   hasMore: false,
 };
 
+const mockInfiniteData = (list: MeetingList) => ({
+  pages: [list],
+  pageParams: [undefined],
+});
+
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
-  useQuery: jest.fn(),
+  useInfiniteQuery: jest.fn(),
 }));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+jest.mock('react-intersection-observer', () => ({
+  useInView: jest.fn(),
+}));
+
+const defaultInfiniteReturn = {
+  data: mockInfiniteData(mockMeetingList),
+  isLoading: false,
+  isError: false,
+  hasNextPage: false,
+  isFetching: false,
+  fetchNextPage: jest.fn(),
+};
 
 describe('SearchPage', () => {
   beforeEach(() => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: mockMeetingList,
-      isLoading: false,
-      isError: false,
+    (useInfiniteQuery as jest.Mock).mockReturnValue(defaultInfiniteReturn);
+    (useInView as jest.Mock).mockReturnValue({
+      ref: jest.fn(),
+      inView: false,
     });
-
     useAuthStore.setState({
       isAuthenticated: false,
       user: null,
@@ -132,57 +148,83 @@ describe('SearchPage', () => {
   });
 
   it('isLoading일때 SearchSkeleton을 렌더링해야 한다', () => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: mockMeetingList,
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
+      data: undefined,
       isLoading: true,
-      isError: false,
     });
-    // Test implementation will go here
-    const { result } = renderHookWithClient(() => useSearchPage());
+    const { result } = renderHookWithNuqs(() => useSearchPage());
     expect(result.current.isLoading).toBe(true);
   });
 
   it('isError일때 에러 메시지를 렌더링해야 한다', () => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: mockMeetingList,
-      isLoading: false,
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
       isError: true,
     });
-    // Test implementation will go here
-    const { result } = renderHookWithClient(() => useSearchPage());
+    const { result } = renderHookWithNuqs(() => useSearchPage());
     expect(result.current.isError).toBe(true);
   });
 
   it('meetingData=[] 일때 Empty Page가 보여야한다.', () => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: mockEmptyMeetingList,
-      isLoading: false,
-      isError: false,
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
+      data: mockInfiniteData(mockEmptyMeetingList),
     });
-    renderWithClient(<SearchPage />);
-    // Test implementation will go here
+    renderWithNuqs(<SearchPage />);
     expect(screen.getAllByAltText('Empty Page')).toHaveLength(2);
   });
 
-  it('meetingData가 있을 때, 검색 결과를 렌더링해야 한다', () => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: mockMeetingList,
-      isLoading: false,
-      isError: false,
-    });
-    // Test implementation will go here
-    const { result } = renderHookWithClient(() => useSearchPage());
+  it('meetingData가 있을 때 검색 결과를 렌더링해야 한다', () => {
+    const { result } = renderHookWithNuqs(() => useSearchPage());
     expect(result.current.meetingData).toEqual(mockMeetingList.data);
   });
 
-  it('비로그인 + 모임만들기 버튼 클릭 시 로그인 모달이 열려야 한다', () => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: mockEmptyMeetingList,
-      isLoading: false,
-      isError: false,
+  it('isFetching=true일 때 SearchSkeleton이 보여야 한다', () => {
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+    });
+    (useInView as jest.Mock).mockReturnValue({
+      ref: jest.fn(),
+      inView: true,
     });
 
-    renderWithClient(<SearchPage />);
+    renderWithNuqs(<SearchPage />);
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('hasNextPage=false일 때 "더 이상 모임이 없습니다" 텍스트가 보여야 한다', () => {
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
+      hasNextPage: false,
+      isFetching: false,
+    });
+    renderWithNuqs(<SearchPage />);
+    expect(screen.getByText('더 이상 모임이 없습니다.')).toBeInTheDocument();
+  });
+
+  it('hasNextPage=true이고 isFetching=false일 때 "더 이상 모임이 없습니다" 텍스트가 보이지 않아야 한다', () => {
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
+      hasNextPage: true,
+      isFetching: false,
+    });
+
+    renderWithNuqs(<SearchPage />);
+    expect(screen.queryByText('더 이상 모임이 없습니다.')).not.toBeInTheDocument();
+  });
+
+  it('비로그인 + 모임만들기 버튼 클릭 시 로그인 모달이 열려야 한다', () => {
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
+      data: mockInfiniteData(mockEmptyMeetingList),
+    });
+
+    renderWithNuqs(<SearchPage />);
 
     const createMeetingButton = screen.getByRole('button', { name: /모임 만들기/i });
     fireEvent.click(createMeetingButton);
@@ -191,10 +233,9 @@ describe('SearchPage', () => {
   });
 
   it('로그인 + 모임만들기 버튼 클릭 시 모임 생성 모달이 열려야한다.', () => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: mockEmptyMeetingList,
-      isLoading: false,
-      isError: false,
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      ...defaultInfiniteReturn,
+      data: mockInfiniteData(mockEmptyMeetingList),
     });
 
     useAuthStore.setState({
@@ -207,7 +248,7 @@ describe('SearchPage', () => {
       },
     });
 
-    renderWithClient(<SearchPage />);
+    renderWithNuqs(<SearchPage />);
 
     const createMeetingButton = screen.getByRole('button', { name: /모임 만들기/i });
     fireEvent.click(createMeetingButton);

--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+
 import { useAuthStore } from '@/entities/auth';
 import { MainPageCard } from '@/entities/meeting';
 import { HeartButton } from '@/features/favorites';
@@ -18,6 +21,11 @@ export default function SearchPage() {
   const { isOpen, open, close } = useModal();
   const { mutateAsync: createMeeting } = useCreateMeeting();
   const { isAuthenticated, setLoginRequired } = useAuthStore();
+
+  const { ref, inView } = useInView({
+    threshold: 0.5,
+    root: null,
+  });
 
   const handleOpenCreateModal = () => {
     if (!isAuthenticated) {
@@ -41,7 +49,17 @@ export default function SearchPage() {
     sortOrder,
     isLoading,
     isError,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    fetchNextPage,
   } = useSearchPage();
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
     <div className="bg-sosoeat-gray-100 min-h-[calc(100vh-156px)] pb-8">
@@ -87,7 +105,21 @@ export default function SearchPage() {
                   )}
                 />
               ))}
+              <div ref={ref} className="col-span-full flex h-1 items-center justify-center" />
             </div>
+          )}
+          {isFetching ? (
+            <span className="text-sosoeat-gray-600 col-span-full flex justify-center">
+              Loading...
+            </span>
+          ) : inView && hasNextPage ? (
+            <SearchSkeleton />
+          ) : (
+            !hasNextPage && (
+              <span className="text-sosoeat-gray-600 col-span-full flex justify-center">
+                더 이상 모임이 없습니다.
+              </span>
+            )
           )}
           <MeetingMakeButton onClick={handleOpenCreateModal} />
         </div>

--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -115,7 +115,8 @@ export default function SearchPage() {
           ) : inView && hasNextPage ? (
             <SearchSkeleton />
           ) : (
-            !hasNextPage && (
+            !hasNextPage &&
+            meetingData.length !== 0 && (
               <span className="text-sosoeat-gray-600 col-span-full flex justify-center">
                 더 이상 모임이 없습니다.
               </span>

--- a/src/widgets/search/ui/search-page/search-skeleton.tsx
+++ b/src/widgets/search/ui/search-page/search-skeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/shared/ui/skeleton';
 
 const SearchSkeleton = () => {
   return (
-    <div className="grid grid-cols-1 justify-center justify-items-center gap-1 md:grid-cols-2 md:gap-5 lg:grid-cols-3 lg:gap-6.75">
+    <div className="grid w-full grid-cols-1 justify-center justify-items-center gap-1 md:grid-cols-2 md:gap-5 lg:grid-cols-3 lg:gap-6.75">
       {Array.from({ length: 10 }).map((_, index) => (
         <div
           key={`meeting-skeleton-${index}`}


### PR DESCRIPTION
## PR 제목: [Feat]: 검색 페이지 무한 스크롤 구현 및 쿼리 키 factory 패턴 적용

### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

관련 이슈: #254

- **무한 스크롤 구현**: `react-intersection-observer`의 `useInView`로 스크롤 하단 감지 후 `fetchNextPage()` 자동 호출. 마지막 페이지 도달 시 "더 이상 모임이 없습니다." 표시
- **`useInfiniteQuery` 전환**: 기존 `useQuery` → `useInfiniteQuery`로 교체하고 `pages.flatMap`으로 데이터 평탄화
- **쿼리 키 factory 패턴 적용**: raw 배열 대신 `searchKeys` factory 함수로 쿼리 키를 일관되게 관리
- **`useSearchInfiniteOptions` 훅 분리**: `search.queries.tsx`에 `useInfiniteQuery` 래핑 훅 신규 생성
- **테스트 업데이트**: `useQuery` → `useInfiniteQuery` mock 전환, `useInView` mock 추가, 무한 스크롤 관련 케이스 추가

### 🧪 테스트 방법 (How to Test)

1. `npm run dev`로 개발 서버 실행 후 검색 페이지(`/`) 진입
2. 모임 목록을 아래로 스크롤하여 하단 도달 → 다음 페이지 데이터 자동 로드 확인
3. 더 이상 데이터가 없을 때 "더 이상 모임이 없습니다." 텍스트 노출 확인
4. 다음 페이지 로딩 중 스켈레톤 UI 표시 확인
5. `npm run test` 실행하여 관련 단위 테스트 통과 확인

### 🚨 기타 참고 사항 (Notes)

- [ ] `meetingsQueryOptions.infiniteOptions`의 `getNextPageParam`에서 `lastPage.nextCursor` 처리 방식 리뷰 요청
- [ ] `useSearchInfiniteOptions`를 `@/entities/meeting/model/search.queries` 내부 경로로 직접 import하는 부분 — FSD public API 규칙 위반 여부 확인 요청