### PR TITLE
[Feat]: 소소톡 상세 페이지 책임 분리 및 model 구조 정리

### DIFF
--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/index.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/index.ts
@@ -1,0 +1,8 @@
+export {
+  SOSOTALK_AUTHOR_IMAGE_FALLBACK,
+  formatSosoTalkRelativeTime,
+  mapCommentToCommentItemData,
+} from './sosotalk-post-detail-page.utils';
+export { useSosoTalkPostDetailCommentActions } from './use-sosotalk-post-detail-comment-actions';
+export { useSosoTalkPostDetailPage } from './use-sosotalk-post-detail-page';
+export { useSosoTalkPostDetailPostActions } from './use-sosotalk-post-detail-post-actions';

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/sosotalk-post-detail-page.utils.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/sosotalk-post-detail-page.utils.ts
@@ -1,0 +1,103 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+import type { CommentItemData } from '@/entities/comment';
+import type { GetSosoTalkPostDetailResponse } from '@/entities/post';
+import type { Comment } from '@/shared/types/generated-client/models/Comment';
+
+const SOSOTALK_AUTHOR_IMAGE_FALLBACK =
+  'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?q=80&w=300&auto=format&fit=crop';
+
+interface MapCommentToCommentItemDataOptions {
+  currentUserId?: number;
+  editingCommentId: number | null;
+  editingCommentInput: string;
+  isEditPending: boolean;
+  onEditClick: () => void;
+  onDeleteClick: () => void;
+  onEditValueChange: (value: string) => void;
+  onEditSubmit: () => void;
+  onEditCancel: () => void;
+}
+
+export function mapCommentToCommentItemData(
+  comment: Comment,
+  {
+    currentUserId,
+    editingCommentId,
+    editingCommentInput,
+    isEditPending,
+    onEditClick,
+    onDeleteClick,
+    onEditValueChange,
+    onEditSubmit,
+    onEditCancel,
+  }: MapCommentToCommentItemDataOptions
+): CommentItemData {
+  return {
+    id: String(comment.id),
+    authorName: comment.author.name,
+    authorImageUrl: comment.author.image || SOSOTALK_AUTHOR_IMAGE_FALLBACK,
+    createdAt: format(comment.createdAt, 'M월 d일 HH:mm', { locale: ko }),
+    relativeTime: formatSosoTalkRelativeTime(comment.createdAt),
+    content: comment.content,
+    isAuthorComment: currentUserId === comment.author.id,
+    isEditing: editingCommentId === comment.id,
+    editValue: editingCommentId === comment.id ? editingCommentInput : comment.content,
+    isEditPending,
+    onEditClick,
+    onDeleteClick,
+    onEditValueChange,
+    onEditSubmit,
+    onEditCancel,
+  };
+}
+
+export function formatSosoTalkRelativeTime(createdAt: Date, now: Date = new Date()): string {
+  const diffMs = now.getTime() - createdAt.getTime();
+
+  if (diffMs < 60_000) {
+    return '방금 전';
+  }
+
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 60) {
+    return `${diffMinutes}분 전`;
+  }
+
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  if (diffHours < 24) {
+    return `${diffHours}시간 전`;
+  }
+
+  const diffDays = Math.floor(diffMs / 86_400_000);
+  return `${diffDays}일 전`;
+}
+
+export function getSosoTalkCommentCount(data?: GetSosoTalkPostDetailResponse) {
+  return data?.count?.comments ?? data?.comments?.length ?? 0;
+}
+
+export function getSosoTalkComments(data?: GetSosoTalkPostDetailResponse) {
+  return data?.comments ?? [];
+}
+
+export function getSosoTalkLikeState(
+  data: GetSosoTalkPostDetailResponse | undefined,
+  optimisticIsLiked: boolean | null,
+  isLikePending: boolean
+) {
+  const serverIsLiked = data?.isLiked ?? false;
+  const shouldUseOptimisticLike =
+    optimisticIsLiked != null && (isLikePending || serverIsLiked !== optimisticIsLiked);
+  const isLiked = shouldUseOptimisticLike ? optimisticIsLiked : serverIsLiked;
+  const displayedLikeCount = (data?.likeCount ?? 0) + (isLiked ? 1 : 0) - (serverIsLiked ? 1 : 0);
+
+  return {
+    displayedLikeCount,
+    isLiked,
+    serverIsLiked,
+  };
+}
+
+export { SOSOTALK_AUTHOR_IMAGE_FALLBACK };

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-comment-actions.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-comment-actions.ts
@@ -2,6 +2,8 @@
 
 import { useRef, useState } from 'react';
 
+import { toast } from 'sonner';
+
 import {
   useCreateSosoTalkComment,
   useDeleteSosoTalkComment,
@@ -54,7 +56,7 @@ export function useSosoTalkPostDetailCommentActions({
       });
       setCommentInput('');
     } catch {
-      // Keep the current input so the user can retry.
+      toast.error('댓글 등록에 실패했어요. 다시 시도해 주세요.');
     }
   };
 
@@ -91,7 +93,7 @@ export function useSosoTalkPostDetailCommentActions({
       });
       handleCancelEditComment();
     } catch {
-      // Keep the current input so the user can retry.
+      toast.error('댓글 수정에 실패했어요. 다시 시도해 주세요.');
     }
   };
 
@@ -115,7 +117,7 @@ export function useSosoTalkPostDetailCommentActions({
         handleCancelEditComment();
       }
     } catch {
-      // Keep the current screen so the user can retry.
+      toast.error('댓글 삭제에 실패했어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-comment-actions.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-comment-actions.ts
@@ -1,0 +1,137 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+import {
+  useCreateSosoTalkComment,
+  useDeleteSosoTalkComment,
+  useUpdateSosoTalkComment,
+} from '@/entities/post';
+import type { Comment } from '@/shared/types/generated-client/models/Comment';
+
+interface UseSosoTalkPostDetailCommentActionsParams {
+  comments: Comment[];
+  isValidPostId: boolean;
+  postId: number;
+}
+
+export function useSosoTalkPostDetailCommentActions({
+  comments,
+  isValidPostId,
+  postId,
+}: UseSosoTalkPostDetailCommentActionsParams) {
+  const [commentInput, setCommentInput] = useState('');
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editingCommentInput, setEditingCommentInput] = useState('');
+  const commentSectionRef = useRef<HTMLDivElement>(null);
+  const createCommentMutation = useCreateSosoTalkComment();
+  const updateCommentMutation = useUpdateSosoTalkComment();
+  const deleteCommentMutation = useDeleteSosoTalkComment();
+
+  const isEditingCommentMissing =
+    editingCommentId != null && !comments.some((comment) => comment.id === editingCommentId);
+
+  const handleCommentClick = () => {
+    commentSectionRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  };
+
+  const handleSubmitComment = async () => {
+    const trimmedComment = commentInput.trim();
+
+    if (!isValidPostId || !trimmedComment || createCommentMutation.isPending) {
+      return;
+    }
+
+    try {
+      await createCommentMutation.mutateAsync({
+        postId,
+        payload: {
+          content: trimmedComment,
+        },
+      });
+      setCommentInput('');
+    } catch {
+      // Keep the current input so the user can retry.
+    }
+  };
+
+  const handleStartEditComment = (comment: Comment) => {
+    setEditingCommentId(comment.id);
+    setEditingCommentInput(comment.content);
+  };
+
+  const handleCancelEditComment = () => {
+    setEditingCommentId(null);
+    setEditingCommentInput('');
+  };
+
+  const handleSubmitEditComment = async () => {
+    const trimmedComment = editingCommentInput.trim();
+
+    if (
+      !isValidPostId ||
+      editingCommentId == null ||
+      !trimmedComment ||
+      updateCommentMutation.isPending ||
+      isEditingCommentMissing
+    ) {
+      return;
+    }
+
+    try {
+      await updateCommentMutation.mutateAsync({
+        postId,
+        commentId: editingCommentId,
+        payload: {
+          content: trimmedComment,
+        },
+      });
+      handleCancelEditComment();
+    } catch {
+      // Keep the current input so the user can retry.
+    }
+  };
+
+  const handleDeleteComment = async (commentId: number) => {
+    if (!isValidPostId || deleteCommentMutation.isPending || typeof window === 'undefined') {
+      return;
+    }
+
+    const shouldDelete = window.confirm('댓글을 삭제할까요?');
+    if (!shouldDelete) {
+      return;
+    }
+
+    try {
+      await deleteCommentMutation.mutateAsync({
+        postId,
+        commentId,
+      });
+
+      if (editingCommentId === commentId) {
+        handleCancelEditComment();
+      }
+    } catch {
+      // Keep the current screen so the user can retry.
+    }
+  };
+
+  return {
+    commentSectionRef,
+    commentInput,
+    editingCommentId,
+    editingCommentInput,
+    isEditPending: updateCommentMutation.isPending,
+    setCommentInput,
+    setEditingCommentInput,
+    handleCancelEditComment,
+    handleCommentClick,
+    handleDeleteComment,
+    handleStartEditComment,
+    handleSubmitComment,
+    handleSubmitEditComment,
+  };
+}

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-page.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-page.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useAuthStore } from '@/entities/auth';
+import { useGetSosoTalkPostDetail } from '@/entities/post';
+
+import { getSosoTalkCommentCount, getSosoTalkComments } from './sosotalk-post-detail-page.utils';
+import { useSosoTalkPostDetailCommentActions } from './use-sosotalk-post-detail-comment-actions';
+import { useSosoTalkPostDetailPostActions } from './use-sosotalk-post-detail-post-actions';
+
+export function useSosoTalkPostDetailPage(postId: string) {
+  const currentUser = useAuthStore((state) => state.user);
+  const numericPostId = Number(postId);
+  const isValidPostId = Number.isInteger(numericPostId) && numericPostId > 0;
+  const { data, isLoading, isError } = useGetSosoTalkPostDetail(
+    isValidPostId ? numericPostId : undefined
+  );
+
+  const comments = getSosoTalkComments(data);
+  const commentCount = getSosoTalkCommentCount(data);
+  const commentActions = useSosoTalkPostDetailCommentActions({
+    comments,
+    isValidPostId,
+    postId: numericPostId,
+  });
+  const postActions = useSosoTalkPostDetailPostActions({
+    data,
+    isValidPostId,
+    postId: numericPostId,
+  });
+
+  return {
+    commentSectionRef: commentActions.commentSectionRef,
+    currentUser,
+    data,
+    comments,
+    commentCount,
+    isError,
+    isLoading,
+    isValidPostId,
+    ...commentActions,
+    ...postActions,
+  };
+}

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-page.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-page.ts
@@ -29,7 +29,6 @@ export function useSosoTalkPostDetailPage(postId: string) {
   });
 
   return {
-    commentSectionRef: commentActions.commentSectionRef,
     currentUser,
     data,
     comments,

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-post-actions.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-post-actions.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import {
+  useCreateSosoTalkPostLike,
+  useDeleteSosoTalkPost,
+  useDeleteSosoTalkPostLike,
+} from '@/entities/post';
+import type { GetSosoTalkPostDetailResponse } from '@/entities/post';
+
+import { getSosoTalkLikeState } from './sosotalk-post-detail-page.utils';
+
+interface UseSosoTalkPostDetailPostActionsParams {
+  data?: GetSosoTalkPostDetailResponse;
+  isValidPostId: boolean;
+  postId: number;
+}
+
+export function useSosoTalkPostDetailPostActions({
+  data,
+  isValidPostId,
+  postId,
+}: UseSosoTalkPostDetailPostActionsParams) {
+  const router = useRouter();
+  const [optimisticIsLiked, setOptimisticIsLiked] = useState<boolean | null>(null);
+  const createLikeMutation = useCreateSosoTalkPostLike();
+  const deletePostMutation = useDeleteSosoTalkPost();
+  const deleteLikeMutation = useDeleteSosoTalkPostLike();
+  const isLikePending = createLikeMutation.isPending || deleteLikeMutation.isPending;
+  const { displayedLikeCount, isLiked } = getSosoTalkLikeState(
+    data,
+    optimisticIsLiked,
+    isLikePending
+  );
+
+  const handleLikeClick = async () => {
+    if (!isValidPostId || isLikePending || !data) {
+      return;
+    }
+
+    const nextIsLiked = !isLiked;
+    setOptimisticIsLiked(nextIsLiked);
+
+    try {
+      if (nextIsLiked) {
+        await createLikeMutation.mutateAsync(postId);
+      } else {
+        await deleteLikeMutation.mutateAsync(postId);
+      }
+    } catch {
+      setOptimisticIsLiked(null);
+    }
+  };
+
+  const handleShareClick = async () => {
+    if (!data || typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const shareData = {
+        title: data.title,
+        text: `${data.author.name}님의 소소톡 게시글`,
+        url: window.location.href,
+      };
+
+      if (navigator.share) {
+        await navigator.share(shareData);
+        return;
+      }
+
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(window.location.href);
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+    }
+  };
+
+  const handleDeleteClick = async () => {
+    if (!isValidPostId || deletePostMutation.isPending || typeof window === 'undefined') {
+      return;
+    }
+
+    const shouldDelete = window.confirm('게시글을 삭제할까요?');
+    if (!shouldDelete) {
+      return;
+    }
+
+    try {
+      await deletePostMutation.mutateAsync({ postId });
+      router.push('/sosotalk');
+    } catch {
+      // Keep the current screen so the user can retry.
+    }
+  };
+
+  const handleEditClick = () => {
+    if (!isValidPostId) {
+      return;
+    }
+
+    router.push(`/sosotalk/write?postId=${postId}`);
+  };
+
+  return {
+    displayedLikeCount,
+    isLikePending,
+    isLiked,
+    handleDeleteClick,
+    handleEditClick,
+    handleLikeClick,
+    handleShareClick,
+  };
+}

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-post-actions.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-post-actions.ts
@@ -4,6 +4,8 @@ import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { toast } from 'sonner';
+
 import {
   useCreateSosoTalkPostLike,
   useDeleteSosoTalkPost,
@@ -52,6 +54,7 @@ export function useSosoTalkPostDetailPostActions({
       }
     } catch {
       setOptimisticIsLiked(null);
+      toast.error('좋아요 처리에 실패했어요. 다시 시도해 주세요.');
     }
   };
 
@@ -74,11 +77,14 @@ export function useSosoTalkPostDetailPostActions({
 
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(window.location.href);
+        toast.success('링크를 복사했어요.');
       }
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         return;
       }
+
+      toast.error('공유에 실패했어요. 다시 시도해 주세요.');
     }
   };
 
@@ -96,7 +102,7 @@ export function useSosoTalkPostDetailPostActions({
       await deletePostMutation.mutateAsync({ postId });
       router.push('/sosotalk');
     } catch {
-      // Keep the current screen so the user can retry.
+      toast.error('게시글 삭제에 실패했어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.tsx
@@ -1,224 +1,52 @@
 'use client';
 
-import { type ReactNode, useRef, useState } from 'react';
-
-import { useRouter } from 'next/navigation';
+import { type ReactNode } from 'react';
 
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
-import { useAuthStore } from '@/entities/auth';
-import type { CommentItemData } from '@/entities/comment';
 import {
-  useCreateSosoTalkComment,
-  useCreateSosoTalkPostLike,
-  useDeleteSosoTalkComment,
-  useDeleteSosoTalkPost,
-  useDeleteSosoTalkPostLike,
-  useGetSosoTalkPostDetail,
-  useUpdateSosoTalkComment,
-} from '@/entities/post';
-import type { Comment } from '@/shared/types/generated-client/models/Comment';
-
+  SOSOTALK_AUTHOR_IMAGE_FALLBACK,
+  formatSosoTalkRelativeTime,
+  mapCommentToCommentItemData,
+  useSosoTalkPostDetailPage,
+} from './model';
 import { SosoTalkPostDetail } from './sosotalk-post-detail/sosotalk-post-detail';
 
 interface SosoTalkPostDetailPageProps {
   postId: string;
 }
 
-const SOSOTALK_AUTHOR_IMAGE_FALLBACK =
-  'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?q=80&w=300&auto=format&fit=crop';
-
 export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) {
-  const router = useRouter();
-  const [commentInput, setCommentInput] = useState('');
-  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
-  const [editingCommentInput, setEditingCommentInput] = useState('');
-  const [optimisticIsLiked, setOptimisticIsLiked] = useState<boolean | null>(null);
-  const commentSectionRef = useRef<HTMLDivElement>(null);
-  const currentUser = useAuthStore((state) => state.user);
-  const numericPostId = Number(postId);
-  const isValidPostId = Number.isInteger(numericPostId) && numericPostId > 0;
-  const createCommentMutation = useCreateSosoTalkComment();
-  const updateCommentMutation = useUpdateSosoTalkComment();
-  const deleteCommentMutation = useDeleteSosoTalkComment();
-  const createLikeMutation = useCreateSosoTalkPostLike();
-  const deletePostMutation = useDeleteSosoTalkPost();
-  const deleteLikeMutation = useDeleteSosoTalkPostLike();
-  const { data, isLoading, isError } = useGetSosoTalkPostDetail(
-    isValidPostId ? numericPostId : undefined
-  );
-
-  const commentCount = data?.count?.comments ?? data?.comments?.length ?? 0;
-  const comments = data?.comments ?? [];
-  const serverIsLiked = data?.isLiked ?? false;
-  const isLikePending = createLikeMutation.isPending || deleteLikeMutation.isPending;
-  const shouldUseOptimisticLike =
-    optimisticIsLiked != null && (isLikePending || serverIsLiked !== optimisticIsLiked);
-  const isLiked = shouldUseOptimisticLike ? optimisticIsLiked : serverIsLiked;
-  const displayedLikeCount = (data?.likeCount ?? 0) + (isLiked ? 1 : 0) - (serverIsLiked ? 1 : 0);
-  const isEditingCommentMissing =
-    editingCommentId != null && !comments.some((comment) => comment.id === editingCommentId);
-
-  const handleCommentClick = () => {
-    commentSectionRef.current?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'start',
-    });
-  };
-
-  const handleLikeClick = async () => {
-    if (!isValidPostId || isLikePending || !data) {
-      return;
-    }
-
-    const nextIsLiked = !isLiked;
-    setOptimisticIsLiked(nextIsLiked);
-
-    try {
-      if (nextIsLiked) {
-        await createLikeMutation.mutateAsync(numericPostId);
-      } else {
-        await deleteLikeMutation.mutateAsync(numericPostId);
-      }
-    } catch {
-      setOptimisticIsLiked(null);
-    }
-  };
-
-  const handleSubmitComment = async () => {
-    const trimmedComment = commentInput.trim();
-
-    if (!isValidPostId || !trimmedComment || createCommentMutation.isPending) {
-      return;
-    }
-
-    try {
-      await createCommentMutation.mutateAsync({
-        postId: numericPostId,
-        payload: {
-          content: trimmedComment,
-        },
-      });
-      setCommentInput('');
-    } catch {
-      // 댓글 입력값을 유지해서 다시 시도할 수 있도록 둡니다.
-    }
-  };
-
-  const handleStartEditComment = (comment: Comment) => {
-    setEditingCommentId(comment.id);
-    setEditingCommentInput(comment.content);
-  };
-
-  const handleCancelEditComment = () => {
-    setEditingCommentId(null);
-    setEditingCommentInput('');
-  };
-
-  const handleSubmitEditComment = async () => {
-    const trimmedComment = editingCommentInput.trim();
-
-    if (
-      !isValidPostId ||
-      editingCommentId == null ||
-      !trimmedComment ||
-      updateCommentMutation.isPending ||
-      isEditingCommentMissing
-    ) {
-      return;
-    }
-
-    try {
-      await updateCommentMutation.mutateAsync({
-        postId: numericPostId,
-        commentId: editingCommentId,
-        payload: {
-          content: trimmedComment,
-        },
-      });
-      handleCancelEditComment();
-    } catch {
-      // 수정 입력값을 유지해서 다시 시도할 수 있도록 둡니다.
-    }
-  };
-
-  const handleDeleteComment = async (commentId: number) => {
-    if (!isValidPostId || deleteCommentMutation.isPending || typeof window === 'undefined') {
-      return;
-    }
-
-    const shouldDelete = window.confirm('댓글을 삭제할까요?');
-    if (!shouldDelete) {
-      return;
-    }
-
-    try {
-      await deleteCommentMutation.mutateAsync({
-        postId: numericPostId,
-        commentId,
-      });
-
-      if (editingCommentId === commentId) {
-        handleCancelEditComment();
-      }
-    } catch {
-      // 삭제 실패 시 현재 화면을 유지합니다.
-    }
-  };
-
-  const handleShareClick = async () => {
-    if (!data || typeof window === 'undefined') {
-      return;
-    }
-
-    try {
-      const shareData = {
-        title: data.title,
-        text: `${data.author.name}님의 소소톡 게시글`,
-        url: window.location.href,
-      };
-
-      if (navigator.share) {
-        await navigator.share(shareData);
-        return;
-      }
-
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(window.location.href);
-      }
-    } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') {
-        return;
-      }
-    }
-  };
-
-  const handleDeleteClick = async () => {
-    if (!isValidPostId || deletePostMutation.isPending || typeof window === 'undefined') {
-      return;
-    }
-
-    const shouldDelete = window.confirm('게시글을 삭제할까요?');
-    if (!shouldDelete) {
-      return;
-    }
-
-    try {
-      await deletePostMutation.mutateAsync({ postId: numericPostId });
-      router.push('/sosotalk');
-    } catch {
-      // 삭제 실패 시 현재 화면을 유지합니다.
-    }
-  };
-
-  const handleEditClick = () => {
-    if (!isValidPostId) {
-      return;
-    }
-
-    router.push(`/sosotalk/write?postId=${numericPostId}`);
-  };
+  const {
+    commentSectionRef,
+    currentUser,
+    data,
+    comments,
+    commentCount,
+    commentInput,
+    editingCommentId,
+    editingCommentInput,
+    isEditPending,
+    displayedLikeCount,
+    isError,
+    isLikePending,
+    isLiked,
+    isLoading,
+    isValidPostId,
+    setCommentInput,
+    setEditingCommentInput,
+    handleCancelEditComment,
+    handleCommentClick,
+    handleDeleteClick,
+    handleDeleteComment,
+    handleEditClick,
+    handleLikeClick,
+    handleShareClick,
+    handleStartEditComment,
+    handleSubmitComment,
+    handleSubmitEditComment,
+  } = useSosoTalkPostDetailPage(postId);
 
   if (!isValidPostId) {
     return (
@@ -246,7 +74,7 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
 
   return (
     <SosoTalkPostDetailPageLayout>
-      <div className="flex flex-col gap-5 md:gap-6">
+      <div className="flex w-full flex-col gap-5 md:gap-6">
         <SosoTalkPostDetail
           title={data.title}
           contentHtml={data.content}
@@ -272,7 +100,7 @@ export function SosoTalkPostDetailPage({ postId }: SosoTalkPostDetailPageProps) 
               currentUserId: currentUser?.id,
               editingCommentId,
               editingCommentInput,
-              isEditPending: updateCommentMutation.isPending,
+              isEditPending,
               onEditClick: () => handleStartEditComment(comment),
               onDeleteClick: () => void handleDeleteComment(comment.id),
               onEditValueChange: setEditingCommentInput,
@@ -298,7 +126,9 @@ function SosoTalkPostDetailPageLayout({ children }: { children: ReactNode }) {
   return (
     <div className="bg-sosoeat-gray-100 flex min-h-screen flex-col">
       <main className="flex-1 px-4 py-8 md:px-6 md:py-10">
-        <div className="mx-auto w-full max-w-[1280px]">{children}</div>
+        <div className="mx-auto w-full max-w-[1280px]">
+          <div className="mx-auto w-full max-w-[860px] xl:max-w-[960px]">{children}</div>
+        </div>
       </main>
     </div>
   );
@@ -310,70 +140,4 @@ function StatusMessage({ message }: { message: string }) {
       <p className="text-sosoeat-gray-500 text-sm md:text-base">{message}</p>
     </div>
   );
-}
-
-interface MapCommentToCommentItemDataOptions {
-  currentUserId?: number;
-  editingCommentId: number | null;
-  editingCommentInput: string;
-  isEditPending: boolean;
-  onEditClick: () => void;
-  onDeleteClick: () => void;
-  onEditValueChange: (value: string) => void;
-  onEditSubmit: () => void;
-  onEditCancel: () => void;
-}
-
-function mapCommentToCommentItemData(
-  comment: Comment,
-  {
-    currentUserId,
-    editingCommentId,
-    editingCommentInput,
-    isEditPending,
-    onEditClick,
-    onDeleteClick,
-    onEditValueChange,
-    onEditSubmit,
-    onEditCancel,
-  }: MapCommentToCommentItemDataOptions
-): CommentItemData {
-  return {
-    id: String(comment.id),
-    authorName: comment.author.name,
-    authorImageUrl: comment.author.image || SOSOTALK_AUTHOR_IMAGE_FALLBACK,
-    createdAt: format(comment.createdAt, 'M월 d일 HH:mm', { locale: ko }),
-    relativeTime: formatSosoTalkRelativeTime(comment.createdAt),
-    content: comment.content,
-    isAuthorComment: currentUserId === comment.author.id,
-    isEditing: editingCommentId === comment.id,
-    editValue: editingCommentId === comment.id ? editingCommentInput : comment.content,
-    isEditPending,
-    onEditClick,
-    onDeleteClick,
-    onEditValueChange,
-    onEditSubmit,
-    onEditCancel,
-  };
-}
-
-function formatSosoTalkRelativeTime(createdAt: Date, now: Date = new Date()): string {
-  const diffMs = now.getTime() - createdAt.getTime();
-
-  if (diffMs < 60_000) {
-    return '방금 전';
-  }
-
-  const diffMinutes = Math.floor(diffMs / 60_000);
-  if (diffMinutes < 60) {
-    return `${diffMinutes}분 전`;
-  }
-
-  const diffHours = Math.floor(diffMs / 3_600_000);
-  if (diffHours < 24) {
-    return `${diffHours}시간 전`;
-  }
-
-  const diffDays = Math.floor(diffMs / 86_400_000);
-  return `${diffDays}일 전`;
 }


### PR DESCRIPTION
### PR 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 변경 사항 (Changes)

- #255 소소톡 상세 페이지에 몰려 있던 상태/핸들러/유틸 로직을 역할별로 분리했습니다.
- `sosotalk-post-detail-page.tsx`를 화면 조합 중심으로 얇게 정리했습니다.
- `model` 폴더를 추가하고 다음 단위로 구조를 정리했습니다.
  - `use-sosotalk-post-detail-page`
  - `use-sosotalk-post-detail-comment-actions`
  - `use-sosotalk-post-detail-post-actions`
  - `sosotalk-post-detail-page.utils`
  - `model/index.ts`
- 댓글 액션, 게시글 액션, 포맷/매핑/파생 상태 계산 책임을 나눴습니다.
- 로딩/에러/잘못된 `postId` 상태도 성공 상태와 동일한 max-width 구조를 사용하도록 레이아웃을 정리했습니다.

### 테스트 방법 (How to Test)

1. `npm run test -- src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx --runInBand` 실행
2. `/sosotalk/[id]` 진입 후 댓글 버튼 클릭 시 댓글 섹션으로 스크롤되는지 확인
3. 좋아요 클릭 후 상태가 정상 반영되는지 확인
4. 댓글 작성/수정/삭제, 수정 페이지 이동, 삭제 후 목록 이동이 기존과 동일하게 동작하는지 확인
5. 잘못된 `postId`, 로딩/에러 상태에서도 레이아웃 폭이 일관되게 보이는지 확인

### 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
상세 페이지 한 파일에 몰려 있던 책임을 `page -> model -> action hooks/utils` 구조로 나눈 부분을 중점적으로 봐주시면 좋습니다.

- [x] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
현재 전체 `type-check`는 이번 PR과 무관한 기존 `profile-edit` 영역의 `react-easy-crop` 타입 이슈로 실패합니다.  
소소톡 상세 페이지 관련 테스트는 별도로 통과 확인했습니다.
