### PR TITLE
[Feat]: 소소톡 페이지 구조 정리 및 write 흐름 테스트 보강

### DIFF
--- a/src/features/sosotalk-write/model/index.ts
+++ b/src/features/sosotalk-write/model/index.ts
@@ -24,3 +24,4 @@ export {
 } from './sosotalk-post-editor.utils';
 export { useSosoTalkPostEditor } from './use-sosotalk-post-editor';
 export { useSosoTalkPostEditorImage } from './use-sosotalk-post-editor-image';
+export { useSosoTalkWritePage } from './use-sosotalk-write-page';

--- a/src/features/sosotalk-write/model/use-sosotalk-write-page.test.ts
+++ b/src/features/sosotalk-write/model/use-sosotalk-write-page.test.ts
@@ -1,0 +1,191 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useSosoTalkWritePage } from './use-sosotalk-write-page';
+
+const mockPush = jest.fn();
+const mockToastError = jest.fn();
+const mockUploadSosoTalkPostImage = jest.fn();
+const mockCreateMutateAsync = jest.fn();
+const mockUpdateMutateAsync = jest.fn();
+const mockUseGetSosoTalkPostDetail = jest.fn();
+const mockUseCreateSosoTalkPost = jest.fn();
+const mockUseUpdateSosoTalkPost = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+jest.mock('@/entities/post', () => ({
+  uploadSosoTalkPostImage: (...args: unknown[]) => mockUploadSosoTalkPostImage(...args),
+  useCreateSosoTalkPost: () => mockUseCreateSosoTalkPost(),
+  useGetSosoTalkPostDetail: (...args: unknown[]) => mockUseGetSosoTalkPostDetail(...args),
+  useUpdateSosoTalkPost: () => mockUseUpdateSosoTalkPost(),
+}));
+
+describe('useSosoTalkWritePage', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockToastError.mockReset();
+    mockUploadSosoTalkPostImage.mockReset();
+    mockCreateMutateAsync.mockReset();
+    mockUpdateMutateAsync.mockReset();
+    mockUseGetSosoTalkPostDetail.mockReset();
+    mockUseCreateSosoTalkPost.mockReset();
+    mockUseUpdateSosoTalkPost.mockReset();
+
+    mockUseGetSosoTalkPostDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+
+    mockUseCreateSosoTalkPost.mockReturnValue({
+      mutateAsync: mockCreateMutateAsync,
+      isPending: false,
+    });
+
+    mockUseUpdateSosoTalkPost.mockReturnValue({
+      mutateAsync: mockUpdateMutateAsync,
+      isPending: false,
+    });
+  });
+
+  it('작성 성공 시 이미지를 업로드하고 상세 페이지로 이동한다', async () => {
+    const imageFile = new File(['image'], 'meal.png', { type: 'image/png' });
+    mockUploadSosoTalkPostImage.mockResolvedValue('https://example.com/uploaded.png');
+    mockCreateMutateAsync.mockResolvedValue({ id: 123 });
+
+    const { result } = renderHook(() => useSosoTalkWritePage({}));
+
+    await act(async () => {
+      await result.current.handleCreateSubmit({
+        title: '점심 메이트 구해요',
+        contentHtml: '<p>같이 드실 분?</p>',
+        contentText: '같이 드실 분?',
+        imageFile,
+        displayImageUrl: '',
+      });
+    });
+
+    expect(mockUploadSosoTalkPostImage).toHaveBeenCalledWith(imageFile);
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+      payload: {
+        title: '점심 메이트 구해요',
+        content: '<p>같이 드실 분?</p>',
+        image: 'https://example.com/uploaded.png',
+      },
+    });
+    expect(mockPush).toHaveBeenCalledWith('/sosotalk/123');
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('작성 실패 시 에러 토스트를 보여주고 submitting 상태를 해제한다', async () => {
+    mockCreateMutateAsync.mockRejectedValue(new Error('create failed'));
+
+    const { result } = renderHook(() => useSosoTalkWritePage({}));
+
+    await act(async () => {
+      await result.current.handleCreateSubmit({
+        title: '저녁 메이트',
+        contentHtml: '<p>저녁 같이 드실 분</p>',
+        contentText: '저녁 같이 드실 분',
+        imageFile: null,
+        displayImageUrl: '',
+      });
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith('게시글 등록에 실패했어요. 다시 시도해 주세요.');
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('수정 성공 시 기존 이미지 값을 포함해 수정 후 상세 페이지로 이동한다', async () => {
+    mockUseGetSosoTalkPostDetail.mockReturnValue({
+      data: {
+        id: 7,
+        title: '기존 제목',
+        content: '<p>기존 본문</p>',
+        image: 'https://example.com/original.png',
+      },
+      isLoading: false,
+      isError: false,
+    });
+    mockUpdateMutateAsync.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSosoTalkWritePage({ editPostId: 7 }));
+
+    await act(async () => {
+      await result.current.handleEditSubmit({
+        title: '수정된 제목',
+        contentHtml: '<p>수정된 본문</p>',
+        contentText: '수정된 본문',
+        imageFile: null,
+        displayImageUrl: 'https://example.com/original.png',
+      });
+    });
+
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+      postId: 7,
+      payload: {
+        title: '수정된 제목',
+        content: '<p>수정된 본문</p>',
+        image: 'https://example.com/original.png',
+      },
+    });
+    expect(mockPush).toHaveBeenCalledWith('/sosotalk/7');
+  });
+
+  it('수정 실패 시 에러 토스트를 보여준다', async () => {
+    mockUseGetSosoTalkPostDetail.mockReturnValue({
+      data: {
+        id: 9,
+        title: '기존 제목',
+        content: '<p>기존 본문</p>',
+        image: '',
+      },
+      isLoading: false,
+      isError: false,
+    });
+    mockUpdateMutateAsync.mockRejectedValue(new Error('update failed'));
+
+    const { result } = renderHook(() => useSosoTalkWritePage({ editPostId: 9 }));
+
+    await act(async () => {
+      await result.current.handleEditSubmit({
+        title: '수정 제목',
+        contentHtml: '<p>수정 본문</p>',
+        contentText: '수정 본문',
+        imageFile: null,
+        displayImageUrl: '',
+      });
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith('게시글 수정에 실패했어요. 다시 시도해 주세요.');
+    expect(mockPush).not.toHaveBeenCalledWith('/sosotalk/9');
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('수정 모드에서는 상세 조회 상태를 그대로 노출한다', async () => {
+    mockUseGetSosoTalkPostDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useSosoTalkWritePage({ editPostId: 11 }));
+
+    await waitFor(() => {
+      expect(result.current.isEditMode).toBe(true);
+      expect(result.current.isLoading).toBe(true);
+      expect(mockUseGetSosoTalkPostDetail).toHaveBeenCalledWith(11);
+    });
+  });
+});

--- a/src/features/sosotalk-write/model/use-sosotalk-write-page.ts
+++ b/src/features/sosotalk-write/model/use-sosotalk-write-page.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import {
+  uploadSosoTalkPostImage,
+  useCreateSosoTalkPost,
+  useGetSosoTalkPostDetail,
+  useUpdateSosoTalkPost,
+} from '@/entities/post';
+
+import type { SosoTalkPostSubmitPayload } from './sosotalk-post-editor.types';
+
+interface UseSosoTalkWritePageParams {
+  editPostId?: number;
+}
+
+export function useSosoTalkWritePage({ editPostId }: UseSosoTalkWritePageParams) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isEditMode = editPostId != null;
+  const { data, isLoading, isError } = useGetSosoTalkPostDetail(editPostId);
+  const createPostMutation = useCreateSosoTalkPost();
+  const updatePostMutation = useUpdateSosoTalkPost();
+
+  const resolveCreateImageUrl = async (
+    payload: SosoTalkPostSubmitPayload
+  ): Promise<string | undefined> => {
+    if (payload.imageFile) {
+      return uploadSosoTalkPostImage(payload.imageFile);
+    }
+
+    return payload.displayImageUrl || undefined;
+  };
+
+  const resolveUpdateImageValue = async (payload: SosoTalkPostSubmitPayload): Promise<string> => {
+    if (payload.imageFile) {
+      return uploadSosoTalkPostImage(payload.imageFile);
+    }
+
+    return payload.displayImageUrl;
+  };
+
+  const handleCreateSubmit = async (payload: SosoTalkPostSubmitPayload) => {
+    if (isSubmitting || createPostMutation.isPending) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const image = await resolveCreateImageUrl(payload);
+      const createdPost = await createPostMutation.mutateAsync({
+        payload: {
+          title: payload.title,
+          content: payload.contentHtml,
+          image,
+        },
+      });
+
+      router.push(`/sosotalk/${createdPost.id}`);
+    } catch {
+      toast.error('게시글 등록에 실패했어요. 다시 시도해 주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleEditSubmit = async (payload: SosoTalkPostSubmitPayload) => {
+    if (editPostId == null || editPostId <= 0 || isSubmitting || updatePostMutation.isPending) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const image = await resolveUpdateImageValue(payload);
+
+      await updatePostMutation.mutateAsync({
+        postId: editPostId,
+        payload: {
+          title: payload.title,
+          content: payload.contentHtml,
+          image,
+        },
+      });
+
+      router.push(`/sosotalk/${editPostId}`);
+    } catch {
+      toast.error('게시글 수정에 실패했어요. 다시 시도해 주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    data,
+    isEditMode,
+    isError,
+    isLoading,
+    isSubmitting,
+    handleCreateSubmit,
+    handleEditSubmit,
+  };
+}

--- a/src/features/sosotalk-write/model/use-sosotalk-write-page.ts
+++ b/src/features/sosotalk-write/model/use-sosotalk-write-page.ts
@@ -18,6 +18,24 @@ interface UseSosoTalkWritePageParams {
   editPostId?: number;
 }
 
+const resolveCreateImageUrl = async (
+  payload: SosoTalkPostSubmitPayload
+): Promise<string | undefined> => {
+  if (payload.imageFile) {
+    return uploadSosoTalkPostImage(payload.imageFile);
+  }
+
+  return payload.displayImageUrl || undefined;
+};
+
+const resolveUpdateImageValue = async (payload: SosoTalkPostSubmitPayload): Promise<string> => {
+  if (payload.imageFile) {
+    return uploadSosoTalkPostImage(payload.imageFile);
+  }
+
+  return payload.displayImageUrl;
+};
+
 export function useSosoTalkWritePage({ editPostId }: UseSosoTalkWritePageParams) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -25,24 +43,6 @@ export function useSosoTalkWritePage({ editPostId }: UseSosoTalkWritePageParams)
   const { data, isLoading, isError } = useGetSosoTalkPostDetail(editPostId);
   const createPostMutation = useCreateSosoTalkPost();
   const updatePostMutation = useUpdateSosoTalkPost();
-
-  const resolveCreateImageUrl = async (
-    payload: SosoTalkPostSubmitPayload
-  ): Promise<string | undefined> => {
-    if (payload.imageFile) {
-      return uploadSosoTalkPostImage(payload.imageFile);
-    }
-
-    return payload.displayImageUrl || undefined;
-  };
-
-  const resolveUpdateImageValue = async (payload: SosoTalkPostSubmitPayload): Promise<string> => {
-    if (payload.imageFile) {
-      return uploadSosoTalkPostImage(payload.imageFile);
-    }
-
-    return payload.displayImageUrl;
-  };
 
   const handleCreateSubmit = async (payload: SosoTalkPostSubmitPayload) => {
     if (isSubmitting || createPostMutation.isPending) {

--- a/src/features/sosotalk-write/ui/sosotalk-write-page-client.test.tsx
+++ b/src/features/sosotalk-write/ui/sosotalk-write-page-client.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SosoTalkWritePageClient } from './sosotalk-write-page-client';
+
+const mockUseSosoTalkWritePage = jest.fn();
+const mockEditor = jest.fn();
+
+jest.mock('../model', () => ({
+  useSosoTalkWritePage: (params: unknown) => mockUseSosoTalkWritePage(params),
+}));
+
+jest.mock('./sosotalk-post-editor', () => ({
+  SosoTalkPostEditor: (props: Record<string, unknown>) => {
+    mockEditor(props);
+
+    return <div data-testid="sosotalk-post-editor">editor</div>;
+  },
+}));
+
+describe('SosoTalkWritePageClient', () => {
+  beforeEach(() => {
+    mockUseSosoTalkWritePage.mockReturnValue({
+      data: undefined,
+      isEditMode: false,
+      isError: false,
+      isLoading: false,
+      isSubmitting: false,
+      handleCreateSubmit: jest.fn(),
+      handleEditSubmit: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('작성 모드에서는 생성 전용 editor를 렌더링한다', async () => {
+    const user = userEvent.setup();
+    const handleCreateSubmit = jest.fn();
+
+    mockUseSosoTalkWritePage.mockReturnValue({
+      data: undefined,
+      isEditMode: false,
+      isError: false,
+      isLoading: false,
+      isSubmitting: true,
+      handleCreateSubmit,
+      handleEditSubmit: jest.fn(),
+    });
+
+    render(<SosoTalkWritePageClient />);
+
+    expect(screen.getByTestId('sosotalk-post-editor')).toBeInTheDocument();
+    expect(mockEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isSubmitting: true,
+        onSubmit: expect.any(Function),
+      })
+    );
+
+    const submittedPayload = {
+      title: '제목',
+      contentHtml: '<p>본문</p>',
+      contentText: '본문',
+      imageFile: null,
+      displayImageUrl: '',
+    };
+
+    await mockEditor.mock.calls.at(-1)?.[0].onSubmit(submittedPayload);
+
+    expect(handleCreateSubmit).toHaveBeenCalledWith(submittedPayload);
+    expect(mockUseSosoTalkWritePage).toHaveBeenCalledWith({ editPostId: undefined });
+    expect(user).toBeDefined();
+  });
+
+  it('수정 모드 로딩 중에는 로딩 문구를 보여준다', () => {
+    mockUseSosoTalkWritePage.mockReturnValue({
+      data: undefined,
+      isEditMode: true,
+      isError: false,
+      isLoading: true,
+      isSubmitting: false,
+      handleCreateSubmit: jest.fn(),
+      handleEditSubmit: jest.fn(),
+    });
+
+    render(<SosoTalkWritePageClient editPostId={3} />);
+
+    expect(screen.getByText('게시글 정보를 불러오는 중이에요.')).toBeInTheDocument();
+    expect(screen.queryByTestId('sosotalk-post-editor')).not.toBeInTheDocument();
+  });
+
+  it('수정 모드에서 조회에 실패하면 에러 문구를 보여준다', () => {
+    mockUseSosoTalkWritePage.mockReturnValue({
+      data: undefined,
+      isEditMode: true,
+      isError: true,
+      isLoading: false,
+      isSubmitting: false,
+      handleCreateSubmit: jest.fn(),
+      handleEditSubmit: jest.fn(),
+    });
+
+    render(<SosoTalkWritePageClient editPostId={3} />);
+
+    expect(screen.getByText('수정할 게시글 정보를 불러오지 못했어요.')).toBeInTheDocument();
+  });
+
+  it('수정 모드에서는 기존 값을 editor에 전달하고 수정 submit을 연결한다', async () => {
+    const handleEditSubmit = jest.fn();
+    const data = {
+      title: '기존 제목',
+      content: '<p>기존 본문</p>',
+      image: 'https://example.com/image.jpg',
+    };
+
+    mockUseSosoTalkWritePage.mockReturnValue({
+      data,
+      isEditMode: true,
+      isError: false,
+      isLoading: false,
+      isSubmitting: false,
+      handleCreateSubmit: jest.fn(),
+      handleEditSubmit,
+    });
+
+    render(<SosoTalkWritePageClient editPostId={3} />);
+
+    expect(mockEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialTitle: '기존 제목',
+        initialContent: '<p>기존 본문</p>',
+        initialImageUrl: 'https://example.com/image.jpg',
+        submitLabel: '수정',
+        onSubmit: expect.any(Function),
+      })
+    );
+
+    const submittedPayload = {
+      title: '수정 제목',
+      contentHtml: '<p>수정 본문</p>',
+      contentText: '수정 본문',
+      imageFile: null,
+      displayImageUrl: 'https://example.com/image.jpg',
+    };
+
+    await mockEditor.mock.calls.at(-1)?.[0].onSubmit(submittedPayload);
+
+    expect(handleEditSubmit).toHaveBeenCalledWith(submittedPayload);
+  });
+});

--- a/src/features/sosotalk-write/ui/sosotalk-write-page-client.tsx
+++ b/src/features/sosotalk-write/ui/sosotalk-write-page-client.tsx
@@ -1,17 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-
-import { useRouter } from 'next/navigation';
-
-import {
-  uploadSosoTalkPostImage,
-  useCreateSosoTalkPost,
-  useGetSosoTalkPostDetail,
-  useUpdateSosoTalkPost,
-} from '@/entities/post';
-
-import type { SosoTalkPostSubmitPayload } from '../model';
+import { useSosoTalkWritePage } from '../model';
 
 import { SosoTalkPostEditor } from './sosotalk-post-editor';
 
@@ -20,84 +9,17 @@ interface SosoTalkWritePageClientProps {
 }
 
 export function SosoTalkWritePageClient({ editPostId }: SosoTalkWritePageClientProps) {
-  const router = useRouter();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const isEditMode = editPostId != null;
-  const { data, isLoading, isError } = useGetSosoTalkPostDetail(editPostId);
-  const createPostMutation = useCreateSosoTalkPost();
-  const updatePostMutation = useUpdateSosoTalkPost();
-
-  const resolveCreateImageUrl = async (
-    payload: SosoTalkPostSubmitPayload
-  ): Promise<string | undefined> => {
-    if (payload.imageFile) {
-      return uploadSosoTalkPostImage(payload.imageFile);
-    }
-
-    return payload.displayImageUrl || undefined;
-  };
-
-  const resolveUpdateImageValue = async (payload: SosoTalkPostSubmitPayload): Promise<string> => {
-    if (payload.imageFile) {
-      return uploadSosoTalkPostImage(payload.imageFile);
-    }
-
-    // Keep the explicit empty string so the server can distinguish
-    // "remove image" from "field omitted".
-    return payload.displayImageUrl;
-  };
-
-  const handleCreateSubmit = async (payload: SosoTalkPostSubmitPayload) => {
-    if (isSubmitting || createPostMutation.isPending) {
-      return;
-    }
-
-    setIsSubmitting(true);
-
-    try {
-      const image = await resolveCreateImageUrl(payload);
-      const createdPost = await createPostMutation.mutateAsync({
-        payload: {
-          title: payload.title,
-          content: payload.contentHtml,
-          image,
-        },
-      });
-
-      router.push(`/sosotalk/${createdPost.id}`);
-    } catch {
-      // 작성 실패 시 입력한 값을 유지한 채 다시 시도할 수 있도록 둡니다.
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleEditSubmit = async (payload: SosoTalkPostSubmitPayload) => {
-    if (editPostId == null || editPostId <= 0 || isSubmitting || updatePostMutation.isPending) {
-      return;
-    }
-
-    setIsSubmitting(true);
-
-    try {
-      const image = await resolveUpdateImageValue(payload);
-
-      await updatePostMutation.mutateAsync({
-        postId: editPostId,
-        payload: {
-          title: payload.title,
-          content: payload.contentHtml,
-          image,
-        },
-      });
-
-      router.push(`/sosotalk/${editPostId}`);
-    } catch {
-      // 수정 실패 시 입력한 값을 유지한 채 다시 시도할 수 있도록 둡니다.
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  const {
+    data,
+    isEditMode,
+    isError,
+    isLoading,
+    isSubmitting,
+    handleCreateSubmit,
+    handleEditSubmit,
+  } = useSosoTalkWritePage({
+    editPostId,
+  });
 
   if (!isEditMode) {
     return (

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/index.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/index.ts
@@ -1,0 +1,2 @@
+export { createSosoTalkMainPageQueryParams } from './sosotalk-main-page.utils';
+export { useSosoTalkMainPage } from './use-sosotalk-main-page';

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts
@@ -1,0 +1,21 @@
+import { createSosoTalkMainPageQueryParams } from './sosotalk-main-page.utils';
+
+describe('createSosoTalkMainPageQueryParams', () => {
+  it('인기 탭과 댓글 정렬 조합을 목록 쿼리 파라미터로 변환한다', () => {
+    expect(createSosoTalkMainPageQueryParams('popular', 'comments')).toEqual({
+      type: 'best',
+      sortBy: 'commentCount',
+      sortOrder: 'desc',
+      size: 10,
+    });
+  });
+
+  it('전체 탭과 최신 정렬 조합을 목록 쿼리 파라미터로 변환한다', () => {
+    expect(createSosoTalkMainPageQueryParams('all', 'latest')).toEqual({
+      type: 'all',
+      sortBy: 'createdAt',
+      sortOrder: 'desc',
+      size: 10,
+    });
+  });
+});

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
@@ -2,18 +2,19 @@ import type { GetSosoTalkPostListParams } from '@/entities/post';
 
 import type { SosoTalkSortValue, SosoTalkTabValue } from '../sosotalk-filter-bar';
 
+const SORT_BY_MAP: Record<SosoTalkSortValue, GetSosoTalkPostListParams['sortBy']> = {
+  comments: 'commentCount',
+  latest: 'createdAt',
+  likes: 'likeCount',
+};
+
 export function createSosoTalkMainPageQueryParams(
   activeTab: SosoTalkTabValue,
   activeSort: SosoTalkSortValue
 ): GetSosoTalkPostListParams {
   return {
     type: activeTab === 'popular' ? 'best' : 'all',
-    sortBy:
-      activeSort === 'comments'
-        ? 'commentCount'
-        : activeSort === 'likes'
-          ? 'likeCount'
-          : 'createdAt',
+    sortBy: SORT_BY_MAP[activeSort] ?? 'createdAt',
     sortOrder: 'desc',
     size: 10,
   };

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
@@ -1,0 +1,20 @@
+import type { GetSosoTalkPostListParams } from '@/entities/post';
+
+import type { SosoTalkSortValue, SosoTalkTabValue } from '../sosotalk-filter-bar';
+
+export function createSosoTalkMainPageQueryParams(
+  activeTab: SosoTalkTabValue,
+  activeSort: SosoTalkSortValue
+): GetSosoTalkPostListParams {
+  return {
+    type: activeTab === 'popular' ? 'best' : 'all',
+    sortBy:
+      activeSort === 'comments'
+        ? 'commentCount'
+        : activeSort === 'likes'
+          ? 'likeCount'
+          : 'createdAt',
+    sortOrder: 'desc',
+    size: 10,
+  };
+}

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { mapPostToSosoTalkCardItem, useGetSosoTalkPostList } from '@/entities/post';
+
+import type { SosoTalkSortValue, SosoTalkTabValue } from '../sosotalk-filter-bar';
+
+import { createSosoTalkMainPageQueryParams } from './sosotalk-main-page.utils';
+
+export function useSosoTalkMainPage() {
+  const [activeTab, setActiveTab] = useState<SosoTalkTabValue>('all');
+  const [activeSort, setActiveSort] = useState<SosoTalkSortValue>('latest');
+
+  const queryParams = useMemo(
+    () => createSosoTalkMainPageQueryParams(activeTab, activeSort),
+    [activeSort, activeTab]
+  );
+  const { data, isLoading, isError } = useGetSosoTalkPostList(queryParams);
+  const posts = useMemo(() => data?.data.map(mapPostToSosoTalkCardItem) ?? [], [data]);
+
+  return {
+    activeSort,
+    activeTab,
+    isError,
+    isLoading,
+    posts,
+    setActiveSort,
+    setActiveTab,
+  };
+}

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
@@ -1,22 +1,17 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-
 import Link from 'next/link';
 
 import { Plus } from 'lucide-react';
 
-import type { GetSosoTalkPostListParams } from '@/entities/post';
-import { mapPostToSosoTalkCardItem, useGetSosoTalkPostList } from '@/entities/post';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 
+import { useSosoTalkMainPage } from './model';
 import { SosoTalkBanner } from '../sosotalk-banner';
 import { SosoTalkCard } from '../sosotalk-card';
 import {
   SosoTalkFilterBar,
-  type SosoTalkSortValue,
-  type SosoTalkTabValue,
 } from '../sosotalk-filter-bar';
 
 interface SosoTalkMainPageProps {
@@ -27,27 +22,8 @@ const SOSOTALK_BANNER_IMAGE =
   'https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=1600&auto=format&fit=crop';
 
 export const SosoTalkMainPage = ({ className }: SosoTalkMainPageProps) => {
-  const [activeTab, setActiveTab] = useState<SosoTalkTabValue>('all');
-  const [activeSort, setActiveSort] = useState<SosoTalkSortValue>('latest');
-
-  const queryParams = useMemo<GetSosoTalkPostListParams>(
-    () => ({
-      type: activeTab === 'popular' ? 'best' : 'all',
-      sortBy:
-        activeSort === 'comments'
-          ? 'commentCount'
-          : activeSort === 'likes'
-            ? 'likeCount'
-            : 'createdAt',
-      sortOrder: 'desc' as const,
-      size: 10,
-    }),
-    [activeSort, activeTab]
-  );
-
-  const { data, isLoading, isError } = useGetSosoTalkPostList(queryParams);
-
-  const posts = useMemo(() => data?.data.map(mapPostToSosoTalkCardItem) ?? [], [data]);
+  const { activeSort, activeTab, isError, isLoading, posts, setActiveSort, setActiveTab } =
+    useSosoTalkMainPage();
 
   return (
     <div className={cn('bg-background min-h-screen w-full bg-[#f9f9f9] pb-24 md:pb-28', className)}>


### PR DESCRIPTION
## PR 제목: [Refactor]: 소소톡 페이지 구조 정리 및 write 흐름 테스트 보강

### PR 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 변경 사항 (Changes)

- #260 소소톡 메인/상세/작성 페이지 구조를 전반적으로 정리했습니다.
- 메인 페이지에서 탭/정렬 상태와 목록 쿼리 파라미터 매핑 로직을 `model`로 분리했습니다.
- `sosotalk-main-page.tsx`를 화면 조합 중심으로 정리하고, 메인 페이지 query 매핑 유틸 테스트를 추가했습니다.
- 작성/수정 페이지의 컨테이너 로직을 `useSosoTalkWritePage`로 분리해 `sosotalk-write-page-client.tsx`를 얇게 정리했습니다.
- write 페이지 컨테이너 테스트와 `useSosoTalkWritePage` 훅 테스트를 추가해 생성/수정 성공, 실패, 로딩/에러 분기까지 검증했습니다.
- 기존 상세 페이지 구조 정리 이후 회귀 테스트도 함께 확인했습니다.

### 테스트 방법 (How to Test)

1. `npm run test -- src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts --runInBand`
2. `npm run test -- src/features/sosotalk-write/model/use-sosotalk-write-page.test.ts --runInBand`
3. `npm run test -- src/features/sosotalk-write/ui/sosotalk-write-page-client.test.tsx --runInBand`
4. `npm run test -- src/features/sosotalk-write/ui/sosotalk-post-editor/sosotalk-post-editor.test.tsx --runInBand`
5. `npm run test -- src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx --runInBand`
6. `/sosotalk`에서 탭/정렬 변경 시 목록이 정상 반영되는지 확인
7. `/sosotalk/write`에서 게시글 생성 후 상세 페이지로 이동하는지 확인
8. `/sosotalk/write?postId={id}`에서 기존 값이 채워지고 수정 후 상세 페이지로 이동하는지 확인

### 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
소소톡 메인/작성 페이지의 컨테이너 로직을 `model`로 이동하면서 페이지 컴포넌트를 얇게 정리한 부분과, write 흐름 테스트 범위를 중점적으로 봐주시면 좋습니다.

- [x] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
현재 전체 `type-check`는 이번 PR과 무관한 기존 `profile-edit` 영역의 `react-easy-crop` 타입 이슈로 실패합니다.
소소톡 관련 테스트는 별도로 통과 확인했습니다.
