### PR TITLE
[Feat]: ProfileEdit - api/model 세그먼트 추가 및 FSD 구조 정리

### DIFF
--- a/src/features/profile-edit/api/profile-edit.api.ts
+++ b/src/features/profile-edit/api/profile-edit.api.ts
@@ -1,8 +1,10 @@
 import { fetchClient } from '@/shared/api/fetch-client';
 import type { UpdateUserRequest, User } from '@/shared/types/generated-client';
 
-export const patchMe = async (body: UpdateUserRequest): Promise<User | null> => {
+export const patchMe = async (body: UpdateUserRequest): Promise<User> => {
   const res = await fetchClient.patch('/users/me', body);
-  if (!res.ok) return null;
+  if (!res.ok) {
+    throw new Error('프로필 수정에 실패했습니다.');
+  }
   return res.json();
 };

--- a/src/features/profile-edit/api/profile-edit.api.ts
+++ b/src/features/profile-edit/api/profile-edit.api.ts
@@ -1,0 +1,8 @@
+import { fetchClient } from '@/shared/api/fetch-client';
+import type { UpdateUserRequest, User } from '@/shared/types/generated-client';
+
+export const patchMe = async (body: UpdateUserRequest): Promise<User | null> => {
+  const res = await fetchClient.patch('/users/me', body);
+  if (!res.ok) return null;
+  return res.json();
+};

--- a/src/features/profile-edit/index.ts
+++ b/src/features/profile-edit/index.ts
@@ -1,1 +1,2 @@
+export { useUpdateProfile } from './model/profile-edit.mutations';
 export { EditProfileModal } from './ui/edit-profile-modal/edit-profile-modal';

--- a/src/features/profile-edit/model/profile-edit.mutations.ts
+++ b/src/features/profile-edit/model/profile-edit.mutations.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { useAuthStore } from '@/entities/auth';
+import type { User } from '@/shared/types/generated-client';
+
+import { patchMe } from '../api/profile-edit.api';
+
+export const useUpdateProfile = (onSuccess?: (user: User) => void) => {
+  const login = useAuthStore((s) => s.login);
+
+  return useMutation({
+    mutationFn: patchMe,
+    onSuccess: (data) => {
+      if (!data) return;
+      login({
+        id: data.id,
+        email: data.email,
+        name: data.name,
+        teamId: data.teamId,
+        companyName: data.companyName,
+        image: data.image,
+      });
+      onSuccess?.(data);
+    },
+  });
+};

--- a/src/features/profile-edit/model/use-profile-image-editor.ts
+++ b/src/features/profile-edit/model/use-profile-image-editor.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import type { Area } from 'react-easy-crop';
+
+import { useUploadImage } from '@/entities/image';
+import { getCroppedImg } from '@/shared/lib/image-crop';
+import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
+
+export function useProfileImageEditor(onChange: (url: string) => void) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { mutateAsync, isPending } = useUploadImage(PresignedUrlRequestFolderEnum.Users);
+
+  const [rawSrc, setRawSrc] = useState<string | null>(null);
+  const [cropModalOpen, setCropModalOpen] = useState(false);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+
+  const openFileDialog = () => inputRef.current?.click();
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setRawSrc(URL.createObjectURL(file));
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+    setCropModalOpen(true);
+    e.target.value = '';
+  };
+
+  const handleCropConfirm = async () => {
+    if (!rawSrc || !croppedAreaPixels) return;
+    try {
+      const blob = await getCroppedImg(rawSrc, croppedAreaPixels);
+      const file = new File([blob], 'profile.jpg', { type: 'image/jpeg' });
+      const publicUrl = await mutateAsync(file);
+      if (publicUrl) onChange(publicUrl);
+      setCropModalOpen(false);
+    } catch (error) {
+      console.error('프로필 이미지 처리 중 오류가 발생했습니다:', error);
+    } finally {
+      URL.revokeObjectURL(rawSrc);
+      setRawSrc(null);
+    }
+  };
+
+  const handleCropCancel = () => {
+    if (rawSrc) URL.revokeObjectURL(rawSrc);
+    setRawSrc(null);
+    setCropModalOpen(false);
+  };
+
+  return {
+    inputRef,
+    isPending,
+    rawSrc,
+    cropModalOpen,
+    crop,
+    zoom,
+    openFileDialog,
+    handleFileChange,
+    handleCropConfirm,
+    handleCropCancel,
+    setCrop,
+    setZoom,
+    setCroppedAreaPixels,
+  };
+}

--- a/src/features/profile-edit/model/use-profile-image-editor.ts
+++ b/src/features/profile-edit/model/use-profile-image-editor.ts
@@ -22,6 +22,7 @@ export function useProfileImageEditor(onChange: (url: string) => void) {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (rawSrc) URL.revokeObjectURL(rawSrc);
     setRawSrc(URL.createObjectURL(file));
     setCrop({ x: 0, y: 0 });
     setZoom(1);

--- a/src/features/profile-edit/ui/edit-profile-modal/_components/profile-field.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/_components/profile-field.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Field, FieldContent, FieldLabel } from '@/shared/ui/field';
+import { Input } from '@/shared/ui/input';
+
+import type { ProfileFieldProps } from '../edit-profile-modal.types';
+
+const inputClassName =
+  'focus:border-sosoeat-gray-700 border border-transparent focus:ring-0 focus:outline-none';
+const fieldLabelClassName = 'text-sm font-semibold';
+
+export function ProfileField({ id, label, type = 'text', value, onChange }: ProfileFieldProps) {
+  return (
+    <Field orientation="vertical" className="gap-2">
+      <FieldLabel htmlFor={id} className={fieldLabelClassName}>
+        {label}
+      </FieldLabel>
+      <FieldContent>
+        <Input id={id} type={type} value={value} onChange={onChange} className={inputClassName} />
+      </FieldContent>
+    </Field>
+  );
+}

--- a/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import Cropper from 'react-easy-crop';
+
+import Image from 'next/image';
+
+import { Loader2, Pencil, XIcon } from 'lucide-react';
+
+import { Button } from '@/shared/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+
+import { useProfileImageEditor } from '../../../model/use-profile-image-editor';
+import type { ProfileImageEditorProps } from '../edit-profile-modal.types';
+
+const actionButtonClassName =
+  'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold';
+
+export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorProps) {
+  const {
+    inputRef,
+    isPending,
+    rawSrc,
+    cropModalOpen,
+    crop,
+    zoom,
+    openFileDialog,
+    handleFileChange,
+    handleCropConfirm,
+    handleCropCancel,
+    setCrop,
+    setZoom,
+    setCroppedAreaPixels,
+  } = useProfileImageEditor(onChange);
+
+  return (
+    <div className="flex justify-center">
+      <div className="relative h-[116px] w-[116px]">
+        <Image
+          src={imageUrl || '/images/basic-profile.svg'}
+          alt="프로필 이미지"
+          fill
+          className="ring-sosoeat-gray-300 rounded-full object-cover ring-1"
+        />
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        <Button
+          type="button"
+          size="icon"
+          disabled={isPending}
+          onClick={openFileDialog}
+          className="border-sosoeat-gray-300 absolute right-1 bottom-1 cursor-pointer rounded-full border bg-white text-gray-600 md:right-1 md:bottom-0"
+        >
+          {isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Pencil className="h-6 w-6" />
+          )}
+        </Button>
+      </div>
+
+      <Dialog open={cropModalOpen} onOpenChange={(open) => !open && handleCropCancel()}>
+        <DialogContent
+          showCloseButton={false}
+          className="w-85.75 max-w-none rounded-4xl bg-white p-9 shadow-xl sm:max-w-none md:w-136"
+        >
+          <DialogHeader className="flex w-full flex-row items-center justify-between">
+            <DialogTitle className="text-xl font-semibold text-gray-900">미리 보기</DialogTitle>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-8 shrink-0 cursor-pointer text-[#737373] hover:bg-transparent hover:text-[#737373]"
+              aria-label="닫기"
+              onClick={handleCropCancel}
+            >
+              <XIcon className="size-6" strokeWidth={1.8} />
+            </Button>
+          </DialogHeader>
+
+          <div className="relative h-72 w-full overflow-hidden rounded-2xl bg-white">
+            {rawSrc && (
+              <Cropper
+                image={rawSrc}
+                crop={crop}
+                zoom={zoom}
+                aspect={1}
+                cropShape="round"
+                showGrid={false}
+                onCropChange={setCrop}
+                onZoomChange={setZoom}
+                onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
+              />
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <span className="text-sm text-gray-500">확대/축소</span>
+            <input
+              type="range"
+              min={1}
+              max={3}
+              step={0.01}
+              value={zoom}
+              onChange={(e) => setZoom(Number(e.target.value))}
+              className="h-1 w-full cursor-pointer accent-orange-500"
+            />
+          </div>
+
+          <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
+            <Button
+              className={`${actionButtonClassName} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
+              onClick={handleCropCancel}
+            >
+              취소
+            </Button>
+            <Button
+              disabled={isPending}
+              onClick={handleCropConfirm}
+              className={`${actionButtonClassName} bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 cursor-pointer text-white`}
+            >
+              {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : '적용하기'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
@@ -1,15 +1,9 @@
 'use client';
 
-import { useRef, useState } from 'react';
-import type { Area } from 'react-easy-crop';
-import Cropper from 'react-easy-crop';
+import { useState } from 'react';
 
-import Image from 'next/image';
+import { PencilLine, XIcon } from 'lucide-react';
 
-import { Loader2, Pencil, PencilLine, XIcon } from 'lucide-react';
-
-import { useUploadImage } from '@/entities/image';
-import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
 import { Button } from '@/shared/ui/button';
 import {
   Dialog,
@@ -20,218 +14,22 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/shared/ui/dialog';
-import { Field, FieldContent, FieldGroup, FieldLabel } from '@/shared/ui/field';
-import { Input } from '@/shared/ui/input';
+import { FieldGroup } from '@/shared/ui/field';
 
-import type {
-  EditProfileModalProps,
-  ProfileFieldProps,
-  ProfileImageEditorProps,
-} from './edit-profile-modal.types';
+import { useUpdateProfile } from '../../model/profile-edit.mutations';
 
-const styles = {
-  input: 'focus:border-sosoeat-gray-700 border border-transparent focus:ring-0 focus:outline-none',
-  fieldLabel: 'text-sm font-semibold',
-  actionButton:
-    'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold',
-} as const;
+import { ProfileField } from './_components/profile-field';
+import { ProfileImageEditor } from './_components/profile-image-editor';
+import type { EditProfileModalProps } from './edit-profile-modal.types';
 
-function createImage(url: string): Promise<HTMLImageElement> {
-  return new Promise((resolve, reject) => {
-    const image = new window.Image();
-    image.addEventListener('load', () => resolve(image));
-    image.addEventListener('error', reject);
-    image.crossOrigin = 'anonymous';
-    image.src = url;
-  });
-}
-
-async function getCroppedImg(imageSrc: string, pixelCrop: Area): Promise<Blob> {
-  const image = await createImage(imageSrc);
-  const canvas = document.createElement('canvas');
-  canvas.width = pixelCrop.width;
-  canvas.height = pixelCrop.height;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) throw new Error('Canvas 2D context를 가져올 수 없습니다.');
-  ctx.drawImage(
-    image,
-    pixelCrop.x,
-    pixelCrop.y,
-    pixelCrop.width,
-    pixelCrop.height,
-    0,
-    0,
-    pixelCrop.width,
-    pixelCrop.height
-  );
-  return new Promise((resolve, reject) => {
-    canvas.toBlob((blob) => {
-      if (blob) resolve(blob);
-      else reject(new Error('Canvas is empty'));
-    }, 'image/jpeg');
-  });
-}
-
-function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const { mutateAsync, isPending } = useUploadImage(PresignedUrlRequestFolderEnum.Users);
-
-  const [rawSrc, setRawSrc] = useState<string | null>(null);
-  const [cropModalOpen, setCropModalOpen] = useState(false);
-  const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setRawSrc(URL.createObjectURL(file));
-    setCrop({ x: 0, y: 0 });
-    setZoom(1);
-    setCropModalOpen(true);
-    e.target.value = '';
-  };
-
-  const handleCropConfirm = async () => {
-    if (!rawSrc || !croppedAreaPixels) return;
-    try {
-      const blob = await getCroppedImg(rawSrc, croppedAreaPixels);
-      const file = new File([blob], 'profile.jpg', { type: 'image/jpeg' });
-      const publicUrl = await mutateAsync(file);
-      if (publicUrl) onChange(publicUrl);
-      setCropModalOpen(false);
-    } catch (error) {
-      console.error('프로필 이미지 처리 중 오류가 발생했습니다:', error);
-    } finally {
-      URL.revokeObjectURL(rawSrc);
-      setRawSrc(null);
-    }
-  };
-
-  const handleCropCancel = () => {
-    if (rawSrc) URL.revokeObjectURL(rawSrc);
-    setRawSrc(null);
-    setCropModalOpen(false);
-  };
-
-  return (
-    <div className="flex justify-center">
-      <div className="relative h-[116px] w-[116px]">
-        <Image
-          src={imageUrl || '/images/basic-profile.svg'}
-          alt="프로필 이미지"
-          fill
-          className="ring-sosoeat-gray-300 rounded-full object-cover ring-1"
-        />
-        <input
-          ref={inputRef}
-          type="file"
-          accept="image/jpeg,image/png,image/webp,image/gif"
-          className="hidden"
-          onChange={handleFileChange}
-        />
-        <Button
-          type="button"
-          size="icon"
-          disabled={isPending}
-          onClick={() => inputRef.current?.click()}
-          className="border-sosoeat-gray-300 absolute right-1 bottom-1 cursor-pointer rounded-full border bg-white text-gray-600 md:right-1 md:bottom-0"
-        >
-          {isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Pencil className="h-6 w-6" />
-          )}
-        </Button>
-      </div>
-
-      <Dialog open={cropModalOpen} onOpenChange={(open) => !open && handleCropCancel()}>
-        <DialogContent
-          showCloseButton={false}
-          className="w-85.75 max-w-none rounded-4xl bg-white p-9 shadow-xl sm:max-w-none md:w-136"
-        >
-          <DialogHeader className="flex w-full flex-row items-center justify-between">
-            <DialogTitle className="text-xl font-semibold text-gray-900">미리 보기</DialogTitle>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              className="size-8 shrink-0 cursor-pointer text-[#737373] hover:bg-transparent hover:text-[#737373]"
-              aria-label="닫기"
-              onClick={handleCropCancel}
-            >
-              <XIcon className="size-6" strokeWidth={1.8} />
-            </Button>
-          </DialogHeader>
-
-          <div className="relative h-72 w-full overflow-hidden rounded-2xl bg-white">
-            {rawSrc && (
-              <Cropper
-                image={rawSrc}
-                crop={crop}
-                zoom={zoom}
-                aspect={1}
-                cropShape="round"
-                showGrid={false}
-                onCropChange={setCrop}
-                onZoomChange={setZoom}
-                onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
-              />
-            )}
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <span className="text-sm text-gray-500">확대/축소</span>
-            <input
-              type="range"
-              min={1}
-              max={3}
-              step={0.01}
-              value={zoom}
-              onChange={(e) => setZoom(Number(e.target.value))}
-              className="h-1 w-full cursor-pointer accent-orange-500"
-            />
-          </div>
-
-          <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
-            <Button
-              className={`${styles.actionButton} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
-              onClick={handleCropCancel}
-            >
-              취소
-            </Button>
-            <Button
-              disabled={isPending}
-              onClick={handleCropConfirm}
-              className={`${styles.actionButton} bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 cursor-pointer text-white`}
-            >
-              {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : '적용하기'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
-  );
-}
-
-function ProfileField({ id, label, type = 'text', value, onChange }: ProfileFieldProps) {
-  return (
-    <Field orientation="vertical" className="gap-2">
-      <FieldLabel htmlFor={id} className={styles.fieldLabel}>
-        {label}
-      </FieldLabel>
-      <FieldContent>
-        <Input id={id} type={type} value={value} onChange={onChange} className={styles.input} />
-      </FieldContent>
-    </Field>
-  );
-}
+const actionButtonClassName =
+  'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold';
 
 export function EditProfileModal({
   initialName = '',
   initialEmail = '',
   initialImageUrl = '',
-  onSubmit,
+  onSuccess,
   open: externalOpen,
   onOpenChange: externalOnOpenChange,
 }: EditProfileModalProps) {
@@ -243,8 +41,10 @@ export function EditProfileModal({
   const open = externalOpen ?? internalOpen;
   const setOpen = externalOnOpenChange ?? setInternalOpen;
 
+  const { mutate, isPending } = useUpdateProfile(onSuccess);
+
   const handleSubmit = () => {
-    onSubmit?.({ name, email, imageUrl });
+    mutate({ name, email, image: imageUrl || undefined });
     setOpen(false);
   };
 
@@ -296,14 +96,15 @@ export function EditProfileModal({
         <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
           <DialogClose asChild>
             <Button
-              className={`${styles.actionButton} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
+              className={`${actionButtonClassName} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
             >
               취소
             </Button>
           </DialogClose>
           <Button
+            disabled={isPending}
             onClick={handleSubmit}
-            className={`${styles.actionButton} bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 cursor-pointer text-white`}
+            className={`${actionButtonClassName} bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 cursor-pointer text-white`}
           >
             수정하기
           </Button>

--- a/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
@@ -44,8 +44,7 @@ export function EditProfileModal({
   const { mutate, isPending } = useUpdateProfile(onSuccess);
 
   const handleSubmit = () => {
-    mutate({ name, email, image: imageUrl || undefined });
-    setOpen(false);
+    mutate({ name, email, image: imageUrl || undefined }, { onSuccess: () => setOpen(false) });
   };
 
   return (

--- a/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.types.ts
+++ b/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.types.ts
@@ -1,12 +1,14 @@
 import type { ChangeEvent } from 'react';
 
+import type { User } from '@/shared/types/generated-client';
+
 export interface EditProfileModalProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   initialName?: string;
   initialEmail?: string;
   initialImageUrl?: string;
-  onSubmit?: (data: { name: string; email: string; imageUrl?: string }) => void;
+  onSuccess?: (user: User) => void;
 }
 
 export interface ProfileFieldProps {
@@ -15,11 +17,6 @@ export interface ProfileFieldProps {
   type?: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-}
-
-export interface ModalActionButtonsProps {
-  onCancel: () => void;
-  onSubmit: () => void;
 }
 
 export interface ProfileImageEditorProps {

--- a/src/shared/lib/image-crop.ts
+++ b/src/shared/lib/image-crop.ts
@@ -1,0 +1,37 @@
+import type { Area } from 'react-easy-crop';
+
+export function createImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new window.Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', reject);
+    image.crossOrigin = 'anonymous';
+    image.src = url;
+  });
+}
+
+export async function getCroppedImg(imageSrc: string, pixelCrop: Area): Promise<Blob> {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  canvas.width = pixelCrop.width;
+  canvas.height = pixelCrop.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context를 가져올 수 없습니다.');
+  ctx.drawImage(
+    image,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height
+  );
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('Canvas is empty'));
+    }, 'image/jpeg');
+  });
+}

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -1,6 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-
-import { UpdateUserRequest } from '@/shared/types/generated-client';
+import { useQuery } from '@tanstack/react-query';
 
 import { mypageRepository } from './mypage.repository';
 
@@ -30,9 +28,4 @@ export const useFavoriteMeetings = (enabled = true) =>
     queryFn: mypageRepository.fetchFavoriteMeetings,
     enabled,
     refetchOnMount: 'always',
-  });
-
-export const usePatchMe = () =>
-  useMutation({
-    mutationFn: (body: UpdateUserRequest) => mypageRepository.patchMe(body),
   });

--- a/src/widgets/mypage/model/mypage.repository.ts
+++ b/src/widgets/mypage/model/mypage.repository.ts
@@ -1,18 +1,7 @@
 import { fetchClient } from '@/shared/api/fetch-client';
-import {
-  FavoriteList,
-  UpdateUserRequest,
-  User,
-  UserMeetingsResponse,
-} from '@/shared/types/generated-client';
+import { FavoriteList, UserMeetingsResponse } from '@/shared/types/generated-client';
 
 export const mypageRepository = {
-  patchMe: async (body: UpdateUserRequest): Promise<User | null> => {
-    const res = await fetchClient.patch('/users/me', body);
-    if (!res.ok) return null;
-    return res.json();
-  },
-
   fetchJoinedMeetings: async (): Promise<UserMeetingsResponse> => {
     const res = await fetchClient.get('/users/me/meetings?type=joined');
     if (!res.ok) return { data: [], nextCursor: '', hasMore: false };

--- a/src/widgets/mypage/ui/user-card/user-card.tsx
+++ b/src/widgets/mypage/ui/user-card/user-card.tsx
@@ -10,8 +10,6 @@ import { cn } from '@/shared/lib/utils';
 import { Avatar, AvatarImage } from '@/shared/ui/avatar';
 import { Card, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
 
-import { mypageRepository } from '../../model/mypage.repository';
-
 import { UserCardProps } from './user-card.types';
 
 export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCardProps) {
@@ -20,17 +18,10 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
   const [localEmail, setLocalEmail] = useState(email);
   const [localImageUrl, setLocalImageUrl] = useState(imageUrl);
 
-  const handleProfileUpdate = async (data: { name: string; email: string; imageUrl?: string }) => {
-    const updated = await mypageRepository.patchMe({
-      name: data.name,
-      email: data.email,
-      image: data.imageUrl,
-    });
-    if (updated) {
-      setLocalName(updated.name);
-      setLocalEmail(updated.email);
-      setLocalImageUrl(updated.image);
-    }
+  const handleProfileSuccess = (user: { name: string; email: string; image?: string }) => {
+    setLocalName(user.name);
+    setLocalEmail(user.email);
+    setLocalImageUrl(user.image);
   };
 
   return (
@@ -97,7 +88,7 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
           initialEmail={localEmail}
           initialName={localName}
           initialImageUrl={localImageUrl}
-          onSubmit={handleProfileUpdate}
+          onSuccess={handleProfileSuccess}
         />
       </div>
     </div>


### PR DESCRIPTION
## [Feat]: ProfileEdit - api/model 세그먼트 추가 및 FSD 구조 정리

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- `features/profile-edit` 슬라이스에 `api/`, `model/` 세그먼트가 없어 프로필 수정 API 호출이 `widgets/mypage`에 누수되어 있던 문제를 해결합니다.

- `shared/lib/image-crop.ts` 생성 — 이미지 크롭 유틸(`createImage`, `getCroppedImg`)을 다른 곳에서도 재사용할 수 있도록 shared로 이동
- `features/profile-edit/api/profile-edit.api.ts` 생성 — `PATCH /users/me` 호출 함수를 feature 내부로 이동
- `features/profile-edit/model/profile-edit.mutations.ts` 생성 — `useUpdateProfile` 훅 추가, 수정 성공 시 `useAuthStore` 업데이트로 네비게이션 바 즉시 반영
- `features/profile-edit/model/use-profile-image-editor.ts` 생성 — `ProfileImageEditor` 내부 크롭/줌 상태 로직 추출
- `ui/edit-profile-modal/_components/` — `ProfileField`, `ProfileImageEditor`를 내부 컴포넌트로 분리
- `EditProfileModal`의 `onSubmit` prop을 `onSuccess(data: User) => void`로 교체, 모달 내부에서 API 직접 호출
- `widgets/mypage`에서 `patchMe`, `usePatchMe` 제거 — widget 레이어 책임 분리
- **[Fix]** 프로필 이미지 없는 계정에서 `image: ''` 빈 문자열 전송으로 발생하던 400 에러 수정 (`imageUrl || undefined`)


### 🧪 테스트 방법 (How to Test)

**프로필 수정 기본 동작**
1. 로컬 환경에서 앱을 실행합니다.
2. 마이페이지 → 프로필 수정 모달을 열어 이름/이메일을 변경 후 수정하기를 클릭합니다.
3. 마이페이지 유저 카드의 이름/이메일이 즉시 반영되는지 확인합니다.
4. 네비게이션 바의 프로필 이미지/이름이 즉시 반영되는지 확인합니다.

**프로필 이미지 없는 계정 버그 픽스**
1. 기본 프로필(이미지 미설정) 계정으로 로그인합니다.
2. 프로필 수정 모달에서 이름만 변경 후 수정하기를 클릭합니다.
3. 400 에러 없이 정상적으로 이름이 수정되는지 확인합니다.

**프로필 이미지 변경**
1. 프로필 수정 모달에서 이미지를 변경합니다.
2. 크롭 모달에서 적용하기를 클릭합니다.
3. 수정하기 클릭 후 마이페이지와 네비게이션 바의 프로필 이미지가 즉시 반영되는지 확인합니다.


### 🚨 기타 참고 사항 (Notes)

- [ ] widgets/mypage 세그먼트 구조 정리(api/, lib/ 분리)는 별도 이슈로 분리
