### PR TITLE
[feat]: 소소톡 최종 QA 엣지 케이스 보강

### DIFF
--- a/src/app/sosotalk/write/page.tsx
+++ b/src/app/sosotalk/write/page.tsx
@@ -12,10 +12,7 @@ export default async function SosoTalkWritePage({ searchParams }: SosoTalkWriteP
   const hasEditPostIdParam = editPostIdParam != null;
   const parsedEditPostId =
     editPostIdParam && /^\d+$/.test(editPostIdParam) ? Number(editPostIdParam) : undefined;
-  const editPostId =
-    parsedEditPostId != null && Number.isInteger(parsedEditPostId) && parsedEditPostId > 0
-      ? parsedEditPostId
-      : undefined;
+  const editPostId = parsedEditPostId != null && parsedEditPostId > 0 ? parsedEditPostId : undefined;
   const isInvalidEditPostId = hasEditPostIdParam && editPostId == null;
 
   return (

--- a/src/app/sosotalk/write/page.tsx
+++ b/src/app/sosotalk/write/page.tsx
@@ -9,18 +9,23 @@ interface SosoTalkWritePageProps {
 export default async function SosoTalkWritePage({ searchParams }: SosoTalkWritePageProps) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const editPostIdParam = resolvedSearchParams?.postId;
+  const hasEditPostIdParam = editPostIdParam != null;
   const parsedEditPostId =
     editPostIdParam && /^\d+$/.test(editPostIdParam) ? Number(editPostIdParam) : undefined;
   const editPostId =
     parsedEditPostId != null && Number.isInteger(parsedEditPostId) && parsedEditPostId > 0
       ? parsedEditPostId
       : undefined;
+  const isInvalidEditPostId = hasEditPostIdParam && editPostId == null;
 
   return (
     <main className="min-h-screen bg-[#f9f9f9] px-4 py-8 md:px-6 md:py-10">
       <div className="mx-auto w-full max-w-[1280px]">
         <div className="mx-auto w-full max-w-[860px]">
-          <SosoTalkWritePageClient editPostId={editPostId} />
+          <SosoTalkWritePageClient
+            editPostId={editPostId}
+            isInvalidEditPostId={isInvalidEditPostId}
+          />
         </div>
       </div>
     </main>

--- a/src/features/sosotalk-write/model/use-sosotalk-write-page.edge.test.ts
+++ b/src/features/sosotalk-write/model/use-sosotalk-write-page.edge.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useSosoTalkWritePage } from './use-sosotalk-write-page';
+
+const mockPush = jest.fn();
+const mockUploadSosoTalkPostImage = jest.fn();
+const mockCreateMutateAsync = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/entities/post', () => ({
+  uploadSosoTalkPostImage: (...args: unknown[]) => mockUploadSosoTalkPostImage(...args),
+  useCreateSosoTalkPost: () => ({
+    mutateAsync: mockCreateMutateAsync,
+    isPending: false,
+  }),
+  useGetSosoTalkPostDetail: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  }),
+  useUpdateSosoTalkPost: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
+
+describe('useSosoTalkWritePage edge cases', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockUploadSosoTalkPostImage.mockReset();
+    mockCreateMutateAsync.mockReset();
+  });
+
+  it('이미지를 제거한 뒤 작성하면 image 없이 등록된다', async () => {
+    mockCreateMutateAsync.mockResolvedValue({ id: 456 });
+
+    const { result } = renderHook(() => useSosoTalkWritePage({}));
+
+    await act(async () => {
+      await result.current.handleCreateSubmit({
+        title: '이미지 없이 작성',
+        contentHtml: '<p>본문</p>',
+        contentText: '본문',
+        imageFile: null,
+        displayImageUrl: '',
+      });
+    });
+
+    expect(mockUploadSosoTalkPostImage).not.toHaveBeenCalled();
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+      payload: {
+        title: '이미지 없이 작성',
+        content: '<p>본문</p>',
+        image: undefined,
+      },
+    });
+    expect(mockPush).toHaveBeenCalledWith('/sosotalk/456');
+  });
+});

--- a/src/features/sosotalk-write/ui/sosotalk-write-page-client.edge.test.tsx
+++ b/src/features/sosotalk-write/ui/sosotalk-write-page-client.edge.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+
+import { SosoTalkWritePageClient } from './sosotalk-write-page-client';
+
+jest.mock('../model', () => ({
+  useSosoTalkWritePage: () => ({
+    data: undefined,
+    isEditMode: false,
+    isError: false,
+    isLoading: false,
+    isSubmitting: false,
+    handleCreateSubmit: jest.fn(),
+    handleEditSubmit: jest.fn(),
+  }),
+}));
+
+jest.mock('./sosotalk-post-editor', () => ({
+  SosoTalkPostEditor: () => <div data-testid="sosotalk-post-editor">editor</div>,
+}));
+
+describe('SosoTalkWritePageClient edge cases', () => {
+  it('잘못된 postId로 수정 페이지에 들어오면 안내 문구를 보여준다', () => {
+    render(<SosoTalkWritePageClient isInvalidEditPostId />);
+
+    expect(screen.getByText('올바르지 않은 게시글입니다.')).toBeInTheDocument();
+    expect(screen.queryByTestId('sosotalk-post-editor')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/sosotalk-write/ui/sosotalk-write-page-client.tsx
+++ b/src/features/sosotalk-write/ui/sosotalk-write-page-client.tsx
@@ -6,9 +6,13 @@ import { SosoTalkPostEditor } from './sosotalk-post-editor';
 
 interface SosoTalkWritePageClientProps {
   editPostId?: number;
+  isInvalidEditPostId?: boolean;
 }
 
-export function SosoTalkWritePageClient({ editPostId }: SosoTalkWritePageClientProps) {
+export function SosoTalkWritePageClient({
+  editPostId,
+  isInvalidEditPostId = false,
+}: SosoTalkWritePageClientProps) {
   const {
     data,
     isEditMode,
@@ -20,6 +24,10 @@ export function SosoTalkWritePageClient({ editPostId }: SosoTalkWritePageClientP
   } = useSosoTalkWritePage({
     editPostId,
   });
+
+  if (isInvalidEditPostId) {
+    return <div className="py-20 text-center text-sm text-gray-500">올바르지 않은 게시글입니다.</div>;
+  }
 
   if (!isEditMode) {
     return (

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
@@ -1,6 +1,9 @@
 import type { GetSosoTalkPostListParams } from '@/entities/post';
 
-import type { SosoTalkSortValue, SosoTalkTabValue } from '../sosotalk-filter-bar';
+import type {
+  SosoTalkSortValue,
+  SosoTalkTabValue,
+} from '../../sosotalk-filter-bar/sosotalk-filter-bar.types';
 
 const SORT_BY_MAP: Record<SosoTalkSortValue, GetSosoTalkPostListParams['sortBy']> = {
   comments: 'commentCount',

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
@@ -4,7 +4,10 @@ import { useMemo, useState } from 'react';
 
 import { mapPostToSosoTalkCardItem, useGetSosoTalkPostList } from '@/entities/post';
 
-import type { SosoTalkSortValue, SosoTalkTabValue } from '../sosotalk-filter-bar';
+import type {
+  SosoTalkSortValue,
+  SosoTalkTabValue,
+} from '../../sosotalk-filter-bar/sosotalk-filter-bar.types';
 
 import { createSosoTalkMainPageQueryParams } from './sosotalk-main-page.utils';
 

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+
+import { SosoTalkMainPage } from './sosotalk-main-page';
+
+const mockUseSosoTalkMainPage = jest.fn();
+const mockFilterBar = jest.fn();
+
+jest.mock('./model', () => ({
+  useSosoTalkMainPage: () => mockUseSosoTalkMainPage(),
+}));
+
+jest.mock('../sosotalk-banner', () => ({
+  SosoTalkBanner: (props: Record<string, unknown>) => (
+    <div data-testid="sosotalk-banner">{String(props.alt)}</div>
+  ),
+}));
+
+jest.mock('../sosotalk-card', () => ({
+  SosoTalkCard: (props: Record<string, unknown>) => (
+    <div data-testid="sosotalk-card">{String(props.title)}</div>
+  ),
+}));
+
+jest.mock('../sosotalk-filter-bar', () => ({
+  SosoTalkFilterBar: (props: Record<string, unknown>) => {
+    mockFilterBar(props);
+
+    return <div data-testid="sosotalk-filter-bar">filter</div>;
+  },
+}));
+
+describe('SosoTalkMainPage', () => {
+  beforeEach(() => {
+    mockUseSosoTalkMainPage.mockReturnValue({
+      activeSort: 'latest',
+      activeTab: 'all',
+      isError: false,
+      isLoading: false,
+      posts: [],
+      setActiveSort: jest.fn(),
+      setActiveTab: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('로딩 중에는 로딩 문구를 보여준다', () => {
+    mockUseSosoTalkMainPage.mockReturnValue({
+      activeSort: 'latest',
+      activeTab: 'all',
+      isError: false,
+      isLoading: true,
+      posts: [],
+      setActiveSort: jest.fn(),
+      setActiveTab: jest.fn(),
+    });
+
+    render(<SosoTalkMainPage />);
+
+    expect(screen.getByText('게시글을 불러오는 중이에요.')).toBeInTheDocument();
+  });
+
+  it('조회에 실패하면 에러 문구를 보여준다', () => {
+    mockUseSosoTalkMainPage.mockReturnValue({
+      activeSort: 'latest',
+      activeTab: 'all',
+      isError: true,
+      isLoading: false,
+      posts: [],
+      setActiveSort: jest.fn(),
+      setActiveTab: jest.fn(),
+    });
+
+    render(<SosoTalkMainPage />);
+
+    expect(
+      screen.getByText('게시글 목록을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.')
+    ).toBeInTheDocument();
+  });
+
+  it('게시글이 없으면 빈 상태 문구를 보여준다', () => {
+    render(<SosoTalkMainPage />);
+
+    expect(screen.getByText('아직 등록된 게시글이 없어요.')).toBeInTheDocument();
+  });
+
+  it('게시글이 있으면 카드 목록과 작성 링크를 보여준다', () => {
+    mockUseSosoTalkMainPage.mockReturnValue({
+      activeSort: 'likes',
+      activeTab: 'popular',
+      isError: false,
+      isLoading: false,
+      posts: [
+        { id: 1, title: '첫 번째 글' },
+        { id: 2, title: '두 번째 글' },
+      ],
+      setActiveSort: jest.fn(),
+      setActiveTab: jest.fn(),
+    });
+
+    render(<SosoTalkMainPage />);
+
+    expect(screen.getAllByTestId('sosotalk-card')).toHaveLength(2);
+    expect(screen.getByRole('link', { name: '게시글 작성' })).toHaveAttribute(
+      'href',
+      '/sosotalk/write'
+    );
+    expect(mockFilterBar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeSort: 'likes',
+        activeTab: 'popular',
+      })
+    );
+  });
+});

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.edge.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.edge.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+
+import { SosoTalkPostDetailPage } from './sosotalk-post-detail-page';
+
+jest.mock('./model', () => ({
+  SOSOTALK_AUTHOR_IMAGE_FALLBACK: '/fallback-profile.png',
+  formatSosoTalkRelativeTime: jest.fn(),
+  mapCommentToCommentItemData: jest.fn(),
+  useSosoTalkPostDetailPage: jest.fn(),
+}));
+
+jest.mock('./sosotalk-post-detail/sosotalk-post-detail', () => ({
+  SosoTalkPostDetail: () => <div>detail</div>,
+}));
+
+const { useSosoTalkPostDetailPage } = jest.requireMock('./model') as {
+  useSosoTalkPostDetailPage: jest.Mock;
+};
+
+const createBaseState = () => ({
+  commentSectionRef: { current: null },
+  currentUser: null,
+  data: undefined,
+  comments: [],
+  commentCount: 0,
+  commentInput: '',
+  editingCommentId: null,
+  editingCommentInput: '',
+  isEditPending: false,
+  displayedLikeCount: 0,
+  isError: false,
+  isLikePending: false,
+  isLiked: false,
+  isLoading: false,
+  isValidPostId: true,
+  setCommentInput: jest.fn(),
+  setEditingCommentInput: jest.fn(),
+  handleCancelEditComment: jest.fn(),
+  handleCommentClick: jest.fn(),
+  handleDeleteClick: jest.fn(),
+  handleDeleteComment: jest.fn(),
+  handleEditClick: jest.fn(),
+  handleLikeClick: jest.fn(),
+  handleShareClick: jest.fn(),
+  handleStartEditComment: jest.fn(),
+  handleSubmitComment: jest.fn(),
+  handleSubmitEditComment: jest.fn(),
+});
+
+describe('SosoTalkPostDetailPage edge cases', () => {
+  beforeEach(() => {
+    useSosoTalkPostDetailPage.mockReturnValue(createBaseState());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('잘못된 postId면 안내 문구를 보여준다', () => {
+    useSosoTalkPostDetailPage.mockReturnValue({
+      ...createBaseState(),
+      isValidPostId: false,
+    });
+
+    render(<SosoTalkPostDetailPage postId="invalid-id" />);
+
+    expect(screen.getByText('올바르지 않은 게시글입니다.')).toBeInTheDocument();
+    expect(useSosoTalkPostDetailPage).toHaveBeenCalledWith('invalid-id');
+  });
+
+  it('조회에 실패하면 에러 문구를 보여준다', () => {
+    useSosoTalkPostDetailPage.mockReturnValue({
+      ...createBaseState(),
+      isError: true,
+      data: undefined,
+    });
+
+    render(<SosoTalkPostDetailPage postId="1" />);
+
+    expect(
+      screen.getByText('게시글을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### PR 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [x] **Test (테스트):** 테스트 추가/수정 및 QA 보강
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 변경 사항 (Changes)

- #267 소소톡 최종 QA 단계에서 필요한 엣지 케이스를 보강했습니다.
- 메인 페이지의 로딩/에러/빈 상태 및 작성 링크 노출을 검증하는 테스트를 추가했습니다.
- 상세 페이지에서 잘못된 `postId`, 조회 실패 상태를 검증하는 엣지 테스트를 추가했습니다.
- 작성/수정 페이지에서 잘못된 `postId`로 수정 진입 시 안내 문구를 보여주도록 보완했습니다.
- 작성 페이지에서 이미지를 제거한 뒤 등록하는 케이스를 테스트로 보강했습니다.
- 소소톡 최종 QA 체크리스트 기준으로 자동 검증 가능한 흐름을 다시 정리했습니다.

### 테스트 방법 (How to Test)

1. `npm run test -- src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx --runInBand`
2. `npm run test -- src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.edge.test.tsx --runInBand`
3. `npm run test -- src/features/sosotalk-write/ui/sosotalk-write-page-client.edge.test.tsx --runInBand`
4. `npm run test -- src/features/sosotalk-write/model/use-sosotalk-write-page.edge.test.ts --runInBand`
5. `/sosotalk/write?postId=abc` 진입 시 `올바르지 않은 게시글입니다.` 문구가 표시되는지 확인
6. 메인 페이지 로딩/에러/빈 상태와 작성 버튼 이동이 자연스럽게 보이는지 확인
7. 상세 페이지에서 잘못된 `postId`와 조회 실패 상태 문구가 정상 노출되는지 확인

### 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
수정 페이지에서 잘못된 `postId` 파라미터를 새 글 작성 모드로 넘기지 않고 안내 문구로 처리한 부분과, QA 성격의 엣지 케이스 테스트 추가 범위를 중점적으로 봐주시면 좋습니다.

- [x] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
소소톡 관련 엣지 테스트는 모두 통과했고, 현재 로컬 `npm run build`도 통과 확인했습니다.
