### PR TITLE
[Refactor]: 모임 상세 페이지 이미지 최적화

### DIFF
--- a/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
@@ -83,6 +83,8 @@ export function MeetingHeroSection({ meeting: initialMeeting }: MeetingHeroSecti
             src={meeting.image}
             alt={meeting.name}
             fill
+            priority
+            sizes="(max-width: 768px) 670px, 654px"
             draggable={false}
             className="object-cover"
           />

--- a/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.tsx
@@ -36,7 +36,13 @@ export default function RecommendedMeetingCard({ meeting, onClick }: Recommended
         {/* ── 썸네일 ── */}
         <div className="pb-[14px]">
           <div className="relative h-[160px] w-full overflow-hidden rounded-3xl">
-            <Image src={meeting.image} alt={meeting.name} fill className="object-cover" />
+            <Image
+              src={meeting.image}
+              alt={meeting.name}
+              fill
+              sizes="302px"
+              className="object-cover"
+            />
             <div
               className="absolute right-5 bottom-5 cursor-pointer"
               onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
  ## 📋 요약      
                                                                                                                    
  모임 상세 페이지 Hero 이미지와 추천 모임 카드 이미지에 next/image 최적화 속성이 누락되어 있어 추가함.             
  sizes 미설정 시 브라우저가 100vw 기준으로 불필요하게 큰 이미지를 다운로드하는 문제 개선.                          
                                                                                                                    
  ---                                                                                                               
                                                                                                                    
  ## 🎯 목표      

  - Hero 이미지 LCP 개선 (priority로 preload 삽입)                                                                  
  - 실제 렌더링 크기에 맞는 이미지 다운로드 (sizes 명시)
                                                                                                                    
  ---             
                                                                                                                    
  ## ✅ 변경 사항 

  - `meeting-hero-section.tsx` — priority, sizes="(max-width: 768px) 670px, 654px" 추가                             
  - `meeting-recommended-card.tsx` — sizes="302px" 추가
                                                                                                                    
  ---                                                                                                               
   
  ## 📎 관련 이슈                                                                                                   
                  
  closes #275