### PR TITLE
[Feat]:  마이페이지  폴더 구조 변경 및 '게시글 작성' 수 api 연동

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -17,7 +17,7 @@ export default async function MyPage() {
   const [meetingCount, favoriteCount, postCount] = await Promise.all([
     fetchMeetingCountServer(),
     fetchFavoriteCountServer(),
-    user ? fetchPostCountServer(user.id) : Promise.resolve(0),
+    fetchPostCountServer(),
   ]);
 
   return (

--- a/src/widgets/mypage/api/mypage.api.server.ts
+++ b/src/widgets/mypage/api/mypage.api.server.ts
@@ -7,7 +7,6 @@ export const fetchMeServer = async (): Promise<User | null> => {
   return res.json();
 };
 
-// TODO: Replace with a dedicated count endpoint when the API supports it
 const MAX_MEETING_FETCH_SIZE = 9999;
 
 export const fetchMeetingCountServer = async (): Promise<number> => {
@@ -26,9 +25,9 @@ export const fetchFavoriteCountServer = async (): Promise<number> => {
   return data.count;
 };
 
-export const fetchPostCountServer = async (userId: number): Promise<number> => {
-  const res = await apiServer.get(`/articles?authorId=${userId}`, { cache: 'no-store' });
+export const fetchPostCountServer = async (): Promise<number> => {
+  const res = await apiServer.get('/users/me/posts', { cache: 'no-store' });
   if (!res.ok) return 0;
   const data = await res.json();
-  return data.totalCount ?? 0;
+  return data.data?.length ?? 0;
 };

--- a/src/widgets/mypage/api/mypage.api.server.ts
+++ b/src/widgets/mypage/api/mypage.api.server.ts
@@ -7,10 +7,10 @@ export const fetchMeServer = async (): Promise<User | null> => {
   return res.json();
 };
 
-const MAX_MEETING_FETCH_SIZE = 9999;
+const MAX_FETCH_SIZE = 100;
 
 export const fetchMeetingCountServer = async (): Promise<number> => {
-  const res = await apiServer.get(`/users/me/meetings?size=${MAX_MEETING_FETCH_SIZE}`, {
+  const res = await apiServer.get(`/users/me/meetings?size=${MAX_FETCH_SIZE}`, {
     cache: 'no-store',
   });
   if (!res.ok) return 0;
@@ -26,7 +26,9 @@ export const fetchFavoriteCountServer = async (): Promise<number> => {
 };
 
 export const fetchPostCountServer = async (): Promise<number> => {
-  const res = await apiServer.get('/users/me/posts', { cache: 'no-store' });
+  const res = await apiServer.get(`/users/me/posts?size=${MAX_FETCH_SIZE}`, {
+    cache: 'no-store',
+  });
   if (!res.ok) return 0;
   const data = await res.json();
   return data.data?.length ?? 0;

--- a/src/widgets/mypage/api/mypage.api.ts
+++ b/src/widgets/mypage/api/mypage.api.ts
@@ -1,7 +1,7 @@
 import { fetchClient } from '@/shared/api/fetch-client';
 import { FavoriteList, UserMeetingsResponse } from '@/shared/types/generated-client';
 
-export const mypageRepository = {
+export const mypageApi = {
   fetchJoinedMeetings: async (): Promise<UserMeetingsResponse> => {
     const res = await fetchClient.get('/users/me/meetings?type=joined');
     if (!res.ok) return { data: [], nextCursor: '', hasMore: false };

--- a/src/widgets/mypage/index.ts
+++ b/src/widgets/mypage/index.ts
@@ -3,7 +3,7 @@ export {
   fetchMeetingCountServer,
   fetchMeServer,
   fetchPostCountServer,
-} from './model/mypage.repository.server';
+} from './api/mypage.api.server';
 export { CountCard } from './ui/count-card';
 export { MeetingTabs } from './ui/meeting-tabs';
 export { UserCard } from './ui/user-card';

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { mypageRepository } from './mypage.repository';
+import { mypageApi } from '../api/mypage.api';
 
 export const mypageQueryKeys = {
   joinedMeetings: ['mypage-joined-meetings'] as const,
@@ -11,21 +11,21 @@ export const mypageQueryKeys = {
 export const useJoinedMeetings = (enabled = true) =>
   useQuery({
     queryKey: mypageQueryKeys.joinedMeetings,
-    queryFn: mypageRepository.fetchJoinedMeetings,
+    queryFn: mypageApi.fetchJoinedMeetings,
     enabled,
   });
 
 export const useCreatedMeetings = (enabled = true) =>
   useQuery({
     queryKey: mypageQueryKeys.createdMeetings,
-    queryFn: mypageRepository.fetchCreatedMeetings,
+    queryFn: mypageApi.fetchCreatedMeetings,
     enabled,
   });
 
 export const useFavoriteMeetings = (enabled = true) =>
   useQuery({
     queryKey: mypageQueryKeys.favoriteMeetings,
-    queryFn: mypageRepository.fetchFavoriteMeetings,
+    queryFn: mypageApi.fetchFavoriteMeetings,
     enabled,
     refetchOnMount: 'always',
   });


### PR DESCRIPTION
## [Feat]:  마이페이지  폴더 구조 변경 및 '게시글 작성' 수 api 연동

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- `widgets/mypage/model/mypage.repository.*` 파일이 FSD 컨벤션상 `api/` 세그먼트에 있어야 할 API 호출 로직을 `model/`에 보관하고 있었습니다.
  - `model/mypage.repository.ts` → `api/mypage.api.ts`
  - `model/mypage.repository.server.ts` → `api/mypage.api.server.ts`
  - `index.ts` 및 내부 import 경로 업데이트

- 마이페이지 카운트 카드 '게시글 작성' 수가 항상 0으로 표시되는 문제를 수정했습니다.
  - 기존 `/articles?authorId={userId}` → 존재하지 않는 엔드포인트 사용
  - `/users/me/posts` 로 변경, `userId` 파라미터 제거 (세션 기반 인증으로 대체)
  - 응답에 `totalCount` 필드가 없어 `data.data?.length` 로 카운트 산출

### 🧪 테스트 방법 (How to Test)

1. 소소톡에서 게시글을 1개 이상 작성합니다.
2. 마이페이지(`/mypage`)로 이동합니다.
3. 카운트 카드 '게시글 작성' 수가 실제 작성한 게시글 수와 일치하는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|  <img width="1146" height="353" alt="image" src="https://github.com/user-attachments/assets/a6e24417-492e-411b-887d-bd93e83cf4f6" /> |  <img width="1128" height="356" alt="image" src="https://github.com/user-attachments/assets/c5f9bcb4-611d-47eb-9633-1693809b0cef" />   |
