### PR TITLE
refactor: 댓글 도메인 경계 정리

### DIFF
--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -18,5 +18,3 @@ export {
 } from './model/comment.queries';
 export type { CommentInputProps } from './ui/comment-input';
 export { CommentInput } from './ui/comment-input';
-export type { CommentItemData, CommentItemProps } from './ui/comment-item';
-export { CommentItem } from './ui/comment-item';

--- a/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-item.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-item.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { MoreHorizontal } from 'lucide-react';
+
+import { CommentInput } from '@/entities/comment';
+import { cn } from '@/shared/lib/utils';
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui/dropdown';
+
+import type { SosoTalkCommentItemProps } from './sosotalk-comment-section.types';
+
+export function SosoTalkCommentItem({
+  authorName,
+  authorImageUrl,
+  createdAt,
+  relativeTime,
+  content,
+  isAuthorComment = false,
+  isEditing = false,
+  editValue = '',
+  isEditPending = false,
+  onEditClick,
+  onDeleteClick,
+  onEditValueChange,
+  onEditSubmit,
+  onEditCancel,
+  className,
+}: SosoTalkCommentItemProps) {
+  return (
+    <article
+      className={cn(
+        'flex items-start gap-3 rounded-[20px] px-4 py-4 sm:gap-4 sm:px-5 sm:py-5',
+        isAuthorComment && 'bg-sosoeat-orange-100/70',
+        className
+      )}
+    >
+      <Avatar size="default" className="h-[54px] w-[54px] shrink-0">
+        <AvatarImage src={authorImageUrl} alt={authorName} />
+        <AvatarFallback className="text-sm font-semibold">{authorName.slice(0, 1)}</AvatarFallback>
+      </Avatar>
+
+      <div className="min-w-0 flex-1 pt-1">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="text-sosoeat-gray-900 text-base leading-5 font-bold">
+                {authorName}
+              </span>
+              <div className="text-sosoeat-gray-500 flex items-center gap-1 text-xs leading-4 font-semibold">
+                <time>{createdAt}</time>
+                {relativeTime ? (
+                  <>
+                    <span aria-hidden="true">·</span>
+                    <span>{relativeTime}</span>
+                  </>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          {isAuthorComment && !isEditing ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="text-sosoeat-gray-500 hover:text-sosoeat-gray-700 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors"
+                  aria-label="댓글 메뉴"
+                >
+                  <MoreHorizontal className="h-5 w-5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[120px]">
+                <DropdownMenuItem onClick={onEditClick}>수정하기</DropdownMenuItem>
+                <DropdownMenuItem variant="destructive" onClick={onDeleteClick}>
+                  삭제하기
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </div>
+
+        {isEditing ? (
+          <div className="mt-3 space-y-3">
+            <CommentInput
+              value={editValue}
+              onChange={onEditValueChange}
+              onSubmit={onEditSubmit}
+              disabled={isEditPending}
+              submitLabel="댓글 수정"
+              currentUserName={authorName}
+              currentUserImageUrl={authorImageUrl}
+              showAvatar={false}
+            />
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onEditCancel}
+                disabled={isEditPending}
+                className="border-input bg-background ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring inline-flex h-10 items-center justify-center rounded-md border px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sosoeat-gray-900 mt-1 text-base leading-6 font-normal break-words whitespace-pre-wrap">
+            {content}
+          </p>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-item.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-item.tsx
@@ -5,6 +5,7 @@ import { MoreHorizontal } from 'lucide-react';
 import { CommentInput } from '@/entities/comment';
 import { cn } from '@/shared/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import { Button } from '@/shared/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -97,14 +98,14 @@ export function SosoTalkCommentItem({
               showAvatar={false}
             />
             <div className="flex justify-end">
-              <button
+              <Button
                 type="button"
+                variant="outline"
                 onClick={onEditCancel}
                 disabled={isEditPending}
-                className="border-input bg-background ring-offset-background hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring inline-flex h-10 items-center justify-center rounded-md border px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
               >
                 취소
-              </button>
+              </Button>
             </div>
           </div>
         ) : (

--- a/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-section.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-section.tsx
@@ -2,10 +2,11 @@
 
 import { MessageSquareText } from 'lucide-react';
 
-import { CommentInput, CommentItem } from '@/entities/comment';
+import { CommentInput } from '@/entities/comment';
 import { cn } from '@/shared/lib/utils';
 import { CountingBadge } from '@/shared/ui/counting-badge/counting-badge';
 
+import { SosoTalkCommentItem } from './sosotalk-comment-item';
 import type { SosoTalkCommentSectionProps } from './sosotalk-comment-section.types';
 
 export function SosoTalkCommentSection({
@@ -36,7 +37,7 @@ export function SosoTalkCommentSection({
 
       <div className="mt-6 space-y-2">
         {comments.map((comment) => (
-          <CommentItem
+          <SosoTalkCommentItem
             key={comment.id}
             authorName={comment.authorName}
             authorImageUrl={comment.authorImageUrl}

--- a/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-section.types.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-section.types.ts
@@ -1,7 +1,27 @@
-import type { CommentItemData } from '@/entities/comment';
+export interface SosoTalkCommentItemData {
+  id: string;
+  authorName: string;
+  authorImageUrl?: string;
+  createdAt: string;
+  relativeTime?: string;
+  content: string;
+  isAuthorComment?: boolean;
+  isEditing?: boolean;
+  editValue?: string;
+  isEditPending?: boolean;
+  onEditClick?: () => void;
+  onDeleteClick?: () => void;
+  onEditValueChange?: (value: string) => void;
+  onEditSubmit?: () => void;
+  onEditCancel?: () => void;
+}
+
+export interface SosoTalkCommentItemProps extends Omit<SosoTalkCommentItemData, 'id'> {
+  className?: string;
+}
 
 export interface SosoTalkCommentSectionProps {
-  comments: CommentItemData[];
+  comments: SosoTalkCommentItemData[];
   commentCount?: number;
   inputValue?: string;
   inputPlaceholder?: string;

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/sosotalk-post-detail-page.utils.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/sosotalk-post-detail-page.utils.ts
@@ -1,9 +1,9 @@
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
-import type { CommentItemData } from '@/entities/comment';
 import type { GetSosoTalkPostDetailResponse } from '@/entities/post';
 import type { Comment } from '@/shared/types/generated-client/models/Comment';
+import type { SosoTalkCommentItemData } from '../../sosotalk-comment-section/sosotalk-comment-section.types';
 
 const SOSOTALK_AUTHOR_IMAGE_FALLBACK =
   'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?q=80&w=300&auto=format&fit=crop';
@@ -33,7 +33,7 @@ export function mapCommentToCommentItemData(
     onEditSubmit,
     onEditCancel,
   }: MapCommentToCommentItemDataOptions
-): CommentItemData {
+): SosoTalkCommentItemData {
   return {
     id: String(comment.id),
     authorName: comment.author.name,

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.types.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail.types.ts
@@ -1,4 +1,4 @@
-import type { CommentItemData } from '@/entities/comment';
+import type { SosoTalkCommentItemData } from '../../sosotalk-comment-section/sosotalk-comment-section.types';
 
 export interface SosoTalkPostDetailProps {
   title: string;
@@ -21,7 +21,7 @@ export interface SosoTalkPostDetailProps {
   onLikeClick?: () => void;
   onCommentClick?: () => void;
   onShareClick?: () => void | Promise<void>;
-  comments?: CommentItemData[];
+  comments?: SosoTalkCommentItemData[];
   inputValue?: string;
   inputPlaceholder?: string;
   onChangeInput?: (value: string) => void;


### PR DESCRIPTION
### PR 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Test (테스트):** 테스트 추가/수정 및 QA 보강
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 변경 사항 (Changes)

- #280 모임 상세 댓글과 소소톡 댓글의 도메인 경계를 더 명확히 정리했습니다.
- 소소톡 댓글이 `@/entities/comment`의 `CommentItem`, `CommentItemData`에 직접 의존하던 구조를 제거했습니다.
- 소소톡 댓글 전용 `SosoTalkCommentItem` 컴포넌트와 관련 타입을 `sosotalk-comment-section` 내부로 이동했습니다.
- 소소톡 상세 페이지에서 사용하는 댓글 타입도 소소톡 로컬 타입 기준으로 정리했습니다.
- `entities/comment` public API에서는 더 이상 소소톡 댓글 아이템 UI를 노출하지 않도록 `CommentItem` export를 제거했습니다.
- `CommentInput`은 입력창 UI 성격이 강해 공용 컴포넌트로 유지했습니다.

### 테스트 방법 (How to Test)

1. `npm run test -- src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail-page.test.tsx --runInBand`
2. `npm run test -- src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.test.tsx --runInBand`
3. `/sosotalk/[id]`에서 댓글 작성/수정/삭제가 기존과 동일하게 동작하는지 확인
4. `/meetings/[id]`에서 모임 상세 댓글 입력/작성 흐름이 기존과 동일하게 동작하는지 확인

### 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
이번 작업은 댓글 공용화를 진행한 것이 아니라, 소소톡 댓글이 모임 댓글 도메인의 댓글 아이템 UI에 의존하던 부분만 분리해 경계를 명확히 한 작업입니다. `CommentInput`은 공용 UI로 유지하고, `CommentItem`만 소소톡 전용으로 분리한 방향을 중점적으로 봐주시면 좋습니다.

- [x] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
소소톡 상세 댓글 테스트와 모임 댓글 섹션 테스트는 모두 통과 확인했습니다.
