### PR TITLE
[Fix]: 마이페이지 탭 전환 지연 및 UI 무반응 개선

### DIFF
--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -8,23 +8,25 @@ export const mypageQueryKeys = {
   favoriteMeetings: ['mypage-favorite-meetings'] as const,
 };
 
+const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
+
 export const useJoinedMeetings = () =>
   useQuery({
     queryKey: mypageQueryKeys.joinedMeetings,
     queryFn: mypageApi.fetchJoinedMeetings,
-    staleTime: 1000 * 60 * 5,
+    staleTime: FIVE_MINUTES_IN_MS,
   });
 
 export const useCreatedMeetings = () =>
   useQuery({
     queryKey: mypageQueryKeys.createdMeetings,
     queryFn: mypageApi.fetchCreatedMeetings,
-    staleTime: 1000 * 60 * 5,
+    staleTime: FIVE_MINUTES_IN_MS,
   });
 
 export const useFavoriteMeetings = () =>
   useQuery({
     queryKey: mypageQueryKeys.favoriteMeetings,
     queryFn: mypageApi.fetchFavoriteMeetings,
-    staleTime: 1000 * 60 * 5,
+    staleTime: FIVE_MINUTES_IN_MS,
   });

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -8,24 +8,23 @@ export const mypageQueryKeys = {
   favoriteMeetings: ['mypage-favorite-meetings'] as const,
 };
 
-export const useJoinedMeetings = (enabled = true) =>
+export const useJoinedMeetings = () =>
   useQuery({
     queryKey: mypageQueryKeys.joinedMeetings,
     queryFn: mypageApi.fetchJoinedMeetings,
-    enabled,
+    staleTime: 1000 * 60 * 5,
   });
 
-export const useCreatedMeetings = (enabled = true) =>
+export const useCreatedMeetings = () =>
   useQuery({
     queryKey: mypageQueryKeys.createdMeetings,
     queryFn: mypageApi.fetchCreatedMeetings,
-    enabled,
+    staleTime: 1000 * 60 * 5,
   });
 
-export const useFavoriteMeetings = (enabled = true) =>
+export const useFavoriteMeetings = () =>
   useQuery({
     queryKey: mypageQueryKeys.favoriteMeetings,
     queryFn: mypageApi.fetchFavoriteMeetings,
-    enabled,
-    refetchOnMount: 'always',
+    staleTime: 1000 * 60 * 5,
   });

--- a/src/widgets/mypage/model/use-meeting-tabs.ts
+++ b/src/widgets/mypage/model/use-meeting-tabs.ts
@@ -8,9 +8,9 @@ import { useCreatedMeetings, useFavoriteMeetings, useJoinedMeetings } from './my
 import { toFavoriteMeetingCards, toUserMeetingCards } from './mypage.service';
 
 export function useMeetingTabs(activeTab: TabValue) {
-  const joinedQuery = useJoinedMeetings(activeTab === 'all');
-  const createdQuery = useCreatedMeetings(activeTab === 'created');
-  const favoriteQuery = useFavoriteMeetings(activeTab === 'favorite');
+  const joinedQuery = useJoinedMeetings();
+  const createdQuery = useCreatedMeetings();
+  const favoriteQuery = useFavoriteMeetings();
 
   const cards = useMemo(() => {
     if (activeTab === 'all' && joinedQuery.data) {

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -27,6 +27,10 @@ export function MeetingTabs() {
   const urlTab: TabValue = TAB_PARAM_MAP[tabParam] ?? 'all';
   const [optimisticTab, setOptimisticTab] = useState<TabValue>(urlTab);
   const activeTab = isPending ? optimisticTab : urlTab;
+
+  useEffect(() => {
+    setOptimisticTab(urlTab);
+  }, [urlTab]);
 
   const setActiveTab = (value: TabValue) => {
     setOptimisticTab(value);

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useState, useTransition } from 'react';
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -22,15 +22,18 @@ const TAB_PARAM_MAP: Record<string, TabValue> = {
 export function MeetingTabs() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const [isPending, startTransition] = useTransition();
   const tabParam = searchParams?.get('tab') ?? 'all';
-  const activeTab: TabValue = TAB_PARAM_MAP[tabParam] ?? 'all';
+  const urlTab: TabValue = TAB_PARAM_MAP[tabParam] ?? 'all';
+  const [optimisticTab, setOptimisticTab] = useState<TabValue>(urlTab);
+  const activeTab = isPending ? optimisticTab : urlTab;
 
-  const setActiveTab = useCallback(
-    (value: TabValue) => {
-      router.push(`/mypage?tab=${value}`);
-    },
-    [router]
-  );
+  const setActiveTab = (value: TabValue) => {
+    setOptimisticTab(value);
+    startTransition(() => {
+      router.replace(`/mypage?tab=${value}`);
+    });
+  };
 
   const { cards: fetchedCards, isLoading } = useMeetingTabs(activeTab);
 


### PR DESCRIPTION
## [Fix]: 마이페이지 탭 전환 지연 및 UI 무반응 개선

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 마이페이지 탭 클릭 시 router.push() 기반 네비게이션으로 인해 UI가 즉시 반응하지 않아 중복 클릭을 유발하는 문제가 있었습니다.
- startTransition + router.replace() + optimisticTab 상태를 적용하여 클릭 즉시 탭이 전환되도록 변경했습니다.
- 탭별 enabled 조건을 제거하여 페이지 진입 시 전체 탭 데이터를 병렬 프리패치하도록 변경했습니다.
- staleTime: 5분 설정으로 불필요한 refetch를 제거하고 refetchOnMount: 'always'를 제거했습니다.

### 🧪 테스트 방법 (How to Test)

1. 마이페이지(/mypage)에 진입합니다.
2. Network 탭을 열어 joined, created, favorites API가 동시에 호출되는지 확인합니다.
3. 나의 모임 → 내가 만든 → 찜한 모임 순서로 탭을 클릭하며 아래를 확인합니다.
    - 클릭 즉시 탭이 전환되어야 합니다. (딜레이 없음)
    - 이미 방문한 탭은 로딩 없이 바로 표시되어야 합니다.
4. 탭 전환 후 브라우저 뒤로가기를 눌러 히스토리가 쌓이지 않음을 확인합니다.