### PR TITLE
[Refactor]: comment 도메인을 meeting-comment / sosotalk-comment로 분리

### DIFF
--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -5,7 +5,11 @@ import { useInView } from 'react-intersection-observer';
 
 import { MainPageCard } from '@/entities/meeting';
 import { HeartButton } from '@/features/favorites';
-import { MeetingCreateModal, useCreateMeeting , useMeetingCreateTrigger } from '@/features/meeting-create';
+import {
+  MeetingCreateModal,
+  useCreateMeeting,
+  useMeetingCreateTrigger,
+} from '@/features/meeting-create';
 import { useModal } from '@/shared/lib/use-modal';
 
 import useSearchPage from '../../model/use-search-page';

--- a/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-item.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-comment-section/sosotalk-comment-item.tsx
@@ -2,18 +2,17 @@
 
 import { MoreHorizontal } from 'lucide-react';
 
-import { CommentInput } from '@/entities/comment';
+import type { SosoTalkCommentItemProps } from '@/entities/sosotalk-comment';
 import { cn } from '@/shared/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 import { Button } from '@/shared/ui/button';
+import { CommentInput } from '@/shared/ui/comment-input';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/shared/ui/dropdown';
-
-import type { SosoTalkCommentItemProps } from './sosotalk-comment-section.types';
 
 export function SosoTalkCommentItem({
   authorName,

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/sosotalk-post-detail-page.utils.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/sosotalk-post-detail-page.utils.ts
@@ -4,7 +4,6 @@ import { ko } from 'date-fns/locale';
 import type { GetSosoTalkPostDetailResponse } from '@/entities/post';
 import type { SosoTalkCommentItemData } from '@/entities/sosotalk-comment';
 import type { Comment } from '@/shared/types/generated-client/models/Comment';
-import type { SosoTalkCommentItemData } from '../../sosotalk-comment-section/sosotalk-comment-section.types';
 
 const SOSOTALK_AUTHOR_IMAGE_FALLBACK =
   'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?q=80&w=300&auto=format&fit=crop';


### PR DESCRIPTION
### 📌 유형 (Type)                                                                                       
                                                                                                           
  - [ ] **Feat (기능):** 새로운 기능 추가                                                                  
  - [ ] **Fix (버그 수정):** 버그 수정                                                                     
  - [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)                                           
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)                                                  
  - [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등                                        
                                                            
  ### 📝 변경 사항 (Changes)                                                                               
                                                            
  - **문제:** `entities/comment`에 모임 댓글과 소소토크 댓글 로직이 혼재되어 있었습니다. 두 도메인의       
  요구사항이 달라(모임: tree 구조/대댓글/좋아요/수정삭제, 소소토크: flat/단순) 명확한 분리가 필요했습니다.
  (closes #262)                                                                                            
  - `entities/comment` 제거 — 애매한 통합 폴더 삭제         
  - `entities/meeting-comment` 생성 — 모임 댓글 API, 타입, query 훅, query key                             
  - `entities/sosotalk-comment` 생성 — 소소토크 댓글 아이템 UI, 타입
  - `features/meeting-comment` 생성 — 모임 댓글 mutation 훅 5개 (create/update/delete/like/sync)           
  - `shared/ui/comment-input` 이동 — 두 도메인 공용 입력 컴포넌트                                          
  - `widgets/meeting-detail/model/use-meeting-comment-item` 분리 — 훅 조합 로직을 widget model로 이동      
                                                                                                           
  ### 🧪 테스트 방법 (How to Test)                          
                                                                                                           
  1. `npm run type-check` — 타입 에러 없음 확인             
  2. `npm run test` — 관련 테스트 통과 확인
  3. 모임 상세 페이지에서 댓글 작성 / 수정 / 삭제 / 좋아요 / 대댓글 동작 확인                              
  4. 소소토크 게시글 상세 페이지에서 댓글 목록 렌더링 확인                                                 
                                                                                                           
  ### 📸 스크린샷 또는 영상 (Optional)                                                                     
                                                            
  UI 변경 없음                                                                                             
                                                            
  ### 🚨 기타 참고 사항 (Notes)

- [x] **소소토크 담당 팀원이 추가한 `sosotalk-post-detail-page.utils.ts`의 `CommentItemData` 타입을      
  `SosoTalkCommentItemData`로 교체함 — 도메인 분리 과정에서 소소토크 전용 타입임을 명확히 하기 위해 이름   
  변경**