### PR TITLE
[Style]: 프로필 수정 모달 이메일 필드 제거 및 이미지 에디터 UI 수정

### DIFF
--- a/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
@@ -34,7 +34,7 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
 
   return (
     <div className="flex justify-center">
-      <div className="relative h-[116px] w-[116px]">
+      <div className="relative h-32.5 w-32.5 md:h-50 md:w-50">
         <Image
           src={imageUrl || '/images/basic-profile.svg'}
           alt="프로필 이미지"
@@ -53,7 +53,7 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
           size="icon"
           disabled={isPending}
           onClick={openFileDialog}
-          className="border-sosoeat-gray-300 absolute right-1 bottom-1 cursor-pointer rounded-full border bg-white text-gray-600 md:right-1 md:bottom-0"
+          className="border-sosoeat-gray-300 absolute right-2 bottom-0 cursor-pointer rounded-full border bg-white text-gray-600 md:right-5 md:bottom-0"
         >
           {isPending ? (
             <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
@@ -53,7 +53,7 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
           size="icon"
           disabled={isPending}
           onClick={openFileDialog}
-          className="border-sosoeat-gray-300 absolute right-2 bottom-0 cursor-pointer rounded-full border bg-white text-gray-600 md:right-5 md:bottom-0"
+          className="border-sosoeat-gray-300 absolute right-2 bottom-0 cursor-pointer rounded-full border bg-white text-gray-600 md:right-5"
         >
           {isPending ? (
             <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.stories.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.stories.tsx
@@ -18,6 +18,5 @@ export const Default: Story = {
   name: '반응형',
   args: {
     initialName: '김민준',
-    initialEmail: 'sosoeat@codeit.com',
   },
 };

--- a/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
@@ -27,14 +27,12 @@ const actionButtonClassName =
 
 export function EditProfileModal({
   initialName = '',
-  initialEmail = '',
   initialImageUrl = '',
   onSuccess,
   open: externalOpen,
   onOpenChange: externalOnOpenChange,
 }: EditProfileModalProps) {
   const [name, setName] = useState(initialName);
-  const [email, setEmail] = useState(initialEmail);
   const [imageUrl, setImageUrl] = useState(initialImageUrl);
   const [internalOpen, setInternalOpen] = useState(false);
 
@@ -44,13 +42,13 @@ export function EditProfileModal({
   const { mutate, isPending } = useUpdateProfile(onSuccess);
 
   const handleSubmit = () => {
-    mutate({ name, email, image: imageUrl || undefined }, { onSuccess: () => setOpen(false) });
+    mutate({ name, image: imageUrl || undefined }, { onSuccess: () => setOpen(false) });
   };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-300 hidden h-[34.45px] w-[104.04px] cursor-pointer flex-row items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1 md:flex">
+        <button className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-500 hidden h-[34.45px] w-[104.04px] cursor-pointer flex-row items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1 md:flex">
           <PencilLine className="h-[12.99px] w-[12.99px]" />
           프로필 수정
         </button>
@@ -82,13 +80,6 @@ export function EditProfileModal({
             label="이름"
             value={name}
             onChange={(e) => setName(e.target.value)}
-          />
-          <ProfileField
-            id="email"
-            label="이메일"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
           />
         </FieldGroup>
 

--- a/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.tsx
@@ -48,7 +48,7 @@ export function EditProfileModal({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-500 hidden h-[34.45px] w-[104.04px] cursor-pointer flex-row items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1 md:flex">
+        <button className="bg-sosoeat-gray-200 text-sosoeat-gray-700 ring-sosoeat-gray-500 hidden h-[34.45px] w-[104.04px] cursor-pointer items-center justify-center gap-1 rounded-xl text-xs font-bold ring-1 md:flex">
           <PencilLine className="h-[12.99px] w-[12.99px]" />
           프로필 수정
         </button>

--- a/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.types.ts
+++ b/src/features/profile-edit/ui/edit-profile-modal/edit-profile-modal.types.ts
@@ -6,7 +6,7 @@ export interface EditProfileModalProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   initialName?: string;
-  initialEmail?: string;
+
   initialImageUrl?: string;
   onSuccess?: (user: User) => void;
 }

--- a/src/widgets/mypage/ui/user-card/user-card.tsx
+++ b/src/widgets/mypage/ui/user-card/user-card.tsx
@@ -83,6 +83,7 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
 
       <div className="absolute top-4 right-0 p-5">
         <EditProfileModal
+          key={String(isOpen)}
           open={isOpen}
           onOpenChange={(val) => (val ? open() : close())}
           initialName={localName}

--- a/src/widgets/mypage/ui/user-card/user-card.tsx
+++ b/src/widgets/mypage/ui/user-card/user-card.tsx
@@ -35,7 +35,7 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
       >
         <CardHeader>
           <div className="flex items-center gap-6 md:hidden">
-            <Avatar className="h-[83px] w-[83px] shrink-0 border-2 border-white">
+            <Avatar className="h-20.75 w-20.75 shrink-0 border-2 border-white">
               <AvatarImage src={localImageUrl || '/images/basic-profile.svg'} />
             </Avatar>
             <div className="flex flex-col gap-1">
@@ -85,7 +85,6 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
         <EditProfileModal
           open={isOpen}
           onOpenChange={(val) => (val ? open() : close())}
-          initialEmail={localEmail}
           initialName={localName}
           initialImageUrl={localImageUrl}
           onSuccess={handleProfileSuccess}


### PR DESCRIPTION
## [Style]: 프로필 수정 모달 이메일 필드 제거 및 이미지 에디터 UI 수정

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 사용하지 않는 이메일 관련 코드를 제거했습니다.
  - EditProfileModal에서 initialEmail prop, email state 및 mutate 호출의 email 제거
  - 주석 처리되어 있던 이메일 ProfileField 블록 제거
  - EditProfileModalProps에서 initialEmail?: string 제거
  - user-card.tsx에서 initialEmail prop 전달 제거
  - stories의 initialEmail args 제거
  
- 프로필 이미지 에디터 UI를 수정했습니다.
  - 이미지 컨테이너 크기를 반응형 기준에 맞게 조정 (h/w-[116px] → h/w-[130px] md:h/w-[200px])
  - 편집 아이콘 버튼 위치 조정 (right-1 bottom-1 → right-2 bottom-0 md:right-5)
  - "프로필 수정" 트리거 버튼 ring 색상 토큰 수정 (ring-sosoeat-gray-300 → ring-sosoeat-gray-500)

### 🧪 테스트 방법 (How to Test)

변경 사항을 확인하기 위해 **테스트해야 할 단계나 시나리오**를 상세히 설명해주세요.

1.  로컬 환경에서 앱을 실행합니다.
2. 마이페이지로 이동하여 "프로필 수정" 버튼을 클릭합니다.
3. 프로필 수정 모달에 이메일 입력 필드가 노출되지 않는지 확인합니다.
4. 이름·이미지 수정 후 "수정하기"를 클릭하여 정상 동작하는지 확인합니다.
5. 모바일/데스크톱 뷰에서 프로필 이미지 크기와 편집 버튼 위치가 올바르게 노출되는지 확인합니다.


### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
| <img width="96" height="43" alt="image" src="https://github.com/user-attachments/assets/312fa6b4-2b30-4245-b608-2d74943dc7e7" /> | <img width="110" height="45" alt="image" src="https://github.com/user-attachments/assets/726e9598-6de4-448f-a63e-f10e35dd661c" /> | 

<img width="568" height="639" alt="image" src="https://github.com/user-attachments/assets/598c0777-c875-4a8c-80ab-e5f07030a713" />


