### PR TITLE
[Feat]: 모임 상세 페이지 스켈레톤 UI 및 Suspense 스트리밍 적용

### DIFF
--- a/src/app/meetings/[id]/_components/meeting-comment-fetcher.tsx
+++ b/src/app/meetings/[id]/_components/meeting-comment-fetcher.tsx
@@ -1,0 +1,32 @@
+import { MeetingCommentSection } from '@/widgets/meeting-detail';
+import {
+  fetchMeetingCommentCountForPage,
+  fetchMeetingCommentsForPage,
+  getMeetingById,
+} from '@/widgets/meeting-detail/index.server';
+
+interface Props {
+  meetingId: number;
+}
+
+export async function MeetingCommentFetcher({ meetingId }: Props) {
+  const meeting = await getMeetingById(meetingId);
+
+  const [initialComments, initialCommentCount] = await Promise.all([
+    fetchMeetingCommentsForPage(meetingId, meeting),
+    fetchMeetingCommentCountForPage(meetingId),
+  ]);
+
+  return (
+    <MeetingCommentSection
+      meetingId={meetingId}
+      initialComments={initialComments}
+      initialCommentCount={initialCommentCount}
+      commentSync={{
+        id: meeting.id,
+        hostId: meeting.hostId,
+        teamId: meeting.teamId,
+      }}
+    />
+  );
+}

--- a/src/app/meetings/[id]/_components/meeting-hero-fetcher.tsx
+++ b/src/app/meetings/[id]/_components/meeting-hero-fetcher.tsx
@@ -1,0 +1,26 @@
+import {
+  MeetingDescriptionSection,
+  MeetingHeroSection,
+  MeetingLocationSection,
+} from '@/widgets/meeting-detail';
+import { getMeetingById } from '@/widgets/meeting-detail/index.server';
+
+interface Props {
+  meetingId: number;
+}
+
+export async function MeetingHeroFetcher({ meetingId }: Props) {
+  const meeting = await getMeetingById(meetingId);
+
+  return (
+    <>
+      <MeetingHeroSection key={`${meeting.id}-${meeting.updatedAt}`} meeting={meeting} />
+      <MeetingDescriptionSection description={meeting.description} />
+      <MeetingLocationSection
+        address={meeting.address}
+        latitude={meeting.latitude}
+        longitude={meeting.longitude}
+      />
+    </>
+  );
+}

--- a/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
@@ -1,0 +1,22 @@
+import type { Meeting } from '@/entities/meeting';
+import { getMeetings } from '@/entities/meeting/index.server';
+import { MeetingRecommendedSection } from '@/widgets/meeting-detail';
+import { getMeetingById } from '@/widgets/meeting-detail/index.server';
+
+interface Props {
+  meetingId: number;
+}
+
+export async function MeetingRecommendedFetcher({ meetingId }: Props) {
+  const meeting = await getMeetingById(meetingId);
+  const meetingList = await getMeetings({ region: meeting.region, size: 4 }).catch(() => ({
+    data: [],
+  }));
+
+  return (
+    <MeetingRecommendedSection
+      meetings={meetingList.data as unknown as Meeting[]}
+      currentMeetingId={meetingId}
+    />
+  );
+}

--- a/src/app/meetings/[id]/loading.tsx
+++ b/src/app/meetings/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { MeetingDetailPageSkeleton } from '@/widgets/meeting-detail';
+
+export default function Loading() {
+  return <MeetingDetailPageSkeleton />;
+}

--- a/src/app/meetings/[id]/page.tsx
+++ b/src/app/meetings/[id]/page.tsx
@@ -1,70 +1,60 @@
-import type { Meeting } from '@/entities/meeting';
-import { getMeetings } from '@/entities/meeting/index.server';
-import {
-  MeetingCommentSection,
-  MeetingHeroSection,
-  MeetingLocationSection,
-  MeetingRecommendedSection,
-} from '@/widgets/meeting-detail';
-import {
-  fetchMeetingCommentCountForPage,
-  fetchMeetingCommentsForPage,
-  getMeetingById,
-} from '@/widgets/meeting-detail/index.server';
+import { Suspense } from 'react';
 
-// ─── Page ────────────────────────────────────────────────────
+import type { Metadata } from 'next';
+
+import {
+  MeetingCommentSkeleton,
+  MeetingHeroSkeleton,
+  MeetingRecommendedSkeleton,
+} from '@/widgets/meeting-detail';
+import { getMeetingById } from '@/widgets/meeting-detail/index.server';
+
+import { MeetingCommentFetcher } from './_components/meeting-comment-fetcher';
+import { MeetingHeroFetcher } from './_components/meeting-hero-fetcher';
+import { MeetingRecommendedFetcher } from './_components/meeting-recommended-fetcher';
+
+// ─── Metadata ────────────────────────────────────────────────
 
 type Props = {
   params: Promise<{ id: string }>;
 };
 
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const meeting = await getMeetingById(Number(id)).catch(() => null);
+
+  if (!meeting) return {};
+
+  return {
+    title: meeting.name,
+    description: meeting.description,
+    openGraph: {
+      title: meeting.name,
+      description: meeting.description,
+      images: [{ url: meeting.image }],
+    },
+  };
+}
+
+// ─── Page ────────────────────────────────────────────────────
+
 export default async function MeetingDetailPage({ params }: Props) {
   const { id } = await params;
   const meetingId = Number(id);
 
-  const meetingData = await getMeetingById(meetingId);
-
-  const [meetingList, initialComments, initialCommentCount] = await Promise.all([
-    getMeetings({ region: meetingData.region, size: 4 }).catch(() => ({ data: [] })),
-    fetchMeetingCommentsForPage(meetingId, meetingData),
-    fetchMeetingCommentCountForPage(meetingId),
-  ]);
-
   return (
     <main className="space-y-[30px] py-10">
-      <MeetingHeroSection
-        key={`${meetingData.id}-${meetingData.updatedAt}`}
-        meeting={meetingData}
-      />
+      <Suspense fallback={<MeetingHeroSkeleton />}>
+        <MeetingHeroFetcher meetingId={meetingId} />
+      </Suspense>
 
-      <section>
-        <h2 className="text-sosoeat-gray-900 mb-3 text-2xl font-semibold">모임 설명</h2>
-        <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-12 py-10">
-          <p className="text-sosoeat-gray-800 text-lg font-normal whitespace-pre-line">
-            {meetingData.description}
-          </p>
-        </div>
-      </section>
+      <Suspense fallback={<MeetingCommentSkeleton />}>
+        <MeetingCommentFetcher meetingId={meetingId} />
+      </Suspense>
 
-      <MeetingLocationSection
-        address={meetingData.address}
-        latitude={meetingData.latitude}
-        longitude={meetingData.longitude}
-      />
-      <MeetingCommentSection
-        meetingId={meetingId}
-        initialComments={initialComments}
-        initialCommentCount={initialCommentCount}
-        commentSync={{
-          id: meetingData.id,
-          hostId: meetingData.hostId,
-          teamId: meetingData.teamId,
-        }}
-      />
-      <MeetingRecommendedSection
-        meetings={meetingList.data as unknown as Meeting[]}
-        currentMeetingId={meetingId}
-      />
+      <Suspense fallback={<MeetingRecommendedSkeleton />}>
+        <MeetingRecommendedFetcher meetingId={meetingId} />
+      </Suspense>
     </main>
   );
 }

--- a/src/widgets/meeting-detail/index.ts
+++ b/src/widgets/meeting-detail/index.ts
@@ -1,5 +1,10 @@
 export { MeetingCommentSection } from './ui/meeting-comment-section/meeting-comment-section';
+export { MeetingDescriptionSection } from './ui/meeting-description-section/meeting-description-section';
 export { MeetingDetailCard } from './ui/meeting-detail-card/meeting-detail-card';
 export { MeetingHeroSection } from './ui/meeting-hero-section/meeting-hero-section';
 export { MeetingLocationSection } from './ui/meeting-location-section/meeting-location-section';
 export { MeetingRecommendedSection } from './ui/meeting-recommended-section/meeting-recommended-section';
+export { MeetingCommentSkeleton } from './ui/skeletons/meeting-comment-skeleton';
+export { MeetingDetailPageSkeleton } from './ui/skeletons/meeting-detail-page-skeleton';
+export { MeetingHeroSkeleton } from './ui/skeletons/meeting-hero-skeleton';
+export { MeetingRecommendedSkeleton } from './ui/skeletons/meeting-recommended-skeleton';

--- a/src/widgets/meeting-detail/model/meeting-detail.server.ts
+++ b/src/widgets/meeting-detail/model/meeting-detail.server.ts
@@ -1,11 +1,14 @@
+import { cache } from 'react';
+
 import type { Meeting } from '@/entities/meeting';
 import { apiServer } from '@/shared/api/api-server';
 
 /**
  * 모임 단건 조회 (서버 컴포넌트 전용)
  * GET /meetings/:id
+ * React.cache로 같은 렌더 트리 내 동일 id 중복 요청 방지
  */
-export async function getMeetingById(id: number): Promise<Meeting> {
+export const getMeetingById = cache(async (id: number): Promise<Meeting> => {
   const response = await apiServer.get(`/meetings/${id}`);
 
   if (!response.ok) {
@@ -14,4 +17,4 @@ export async function getMeetingById(id: number): Promise<Meeting> {
   }
 
   return response.json();
-}
+});

--- a/src/widgets/meeting-detail/ui/meeting-description-section/meeting-description-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-description-section/meeting-description-section.tsx
@@ -1,0 +1,16 @@
+interface MeetingDescriptionSectionProps {
+  description: string;
+}
+
+export function MeetingDescriptionSection({ description }: MeetingDescriptionSectionProps) {
+  return (
+    <section>
+      <h2 className="text-sosoeat-gray-900 mb-3 text-2xl font-semibold">모임 설명</h2>
+      <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-12 py-10">
+        <p className="text-sosoeat-gray-800 text-lg font-normal whitespace-pre-line">
+          {description}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 import { useQueryClient } from '@tanstack/react-query';
 
 import type { Meeting } from '@/entities/meeting';
-import { MeetingEditModal, toMeetingEditFormData } from '@/features/meeting-edit';
+import { toMeetingEditFormData } from '@/features/meeting-edit';
 import { useModal } from '@/shared/lib/use-modal';
 
 import {
@@ -20,6 +21,10 @@ import {
 import { MeetingDetailCard } from '../meeting-detail-card';
 
 import { useMeetingRole } from './hooks/use-meeting-role';
+
+const MeetingEditModal = dynamic(() =>
+  import('@/features/meeting-edit').then((m) => m.MeetingEditModal)
+);
 
 interface MeetingHeroSectionProps {
   meeting: Meeting;

--- a/src/widgets/meeting-detail/ui/skeletons/meeting-comment-skeleton.tsx
+++ b/src/widgets/meeting-detail/ui/skeletons/meeting-comment-skeleton.tsx
@@ -1,0 +1,28 @@
+import { MessageSquareText } from 'lucide-react';
+
+import { Skeleton } from '@/shared/ui/skeleton/skeleton';
+
+export function MeetingCommentSkeleton() {
+  return (
+    <section className="border-sosoeat-gray-200 w-full rounded-[24px] border bg-white px-6 py-4">
+      <div className="flex items-center gap-2">
+        <MessageSquareText className="text-sosoeat-orange-600 size-5" />
+        <Skeleton className="h-5 w-12" />
+        <Skeleton className="h-5 w-8 rounded-full" />
+      </div>
+
+      <div className="mt-4 space-y-4 pr-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex gap-3">
+            <Skeleton className="size-9 shrink-0 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/widgets/meeting-detail/ui/skeletons/meeting-detail-page-skeleton.tsx
+++ b/src/widgets/meeting-detail/ui/skeletons/meeting-detail-page-skeleton.tsx
@@ -1,0 +1,74 @@
+import { Skeleton } from '@/shared/ui/skeleton/skeleton';
+
+import { MeetingCommentSkeleton } from './meeting-comment-skeleton';
+import { MeetingRecommendedSkeleton } from './meeting-recommended-skeleton';
+
+export function MeetingDetailPageSkeleton() {
+  return (
+    <main className="space-y-[30px] py-10">
+      {/* Hero */}
+      <div className="flex flex-col gap-6 md:flex-row">
+        <Skeleton className="h-[241px] w-full rounded-[24px] md:h-auto md:min-w-0 md:flex-1" />
+        <div className="min-w-0 flex-1 rounded-[20px] bg-white p-4 md:p-6 lg:rounded-[32px]">
+          <div className="space-y-3">
+            <Skeleton className="h-5 w-28 rounded-full" />
+            <Skeleton className="h-8 w-3/4" />
+            <div className="space-y-3 pt-2">
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-9 shrink-0 rounded-full" />
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-16" />
+                  <Skeleton className="h-4 w-32" />
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-9 shrink-0 rounded-full" />
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-10" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-9 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-1">
+                  <Skeleton className="h-3 w-14" />
+                  <Skeleton className="h-3 w-full max-w-[500px]" />
+                </div>
+              </div>
+            </div>
+            <Skeleton className="mt-2 h-10 w-full lg:h-[62px]" />
+          </div>
+        </div>
+      </div>
+
+      {/* Description */}
+      <section>
+        <Skeleton className="mb-3 h-8 w-28" />
+        <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-12 py-10">
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-3/4" />
+          </div>
+        </div>
+      </section>
+
+      {/* Location */}
+      <section>
+        <Skeleton className="mb-3 h-8 w-24" />
+        <div className="border-sosoeat-gray-200 mt-5 overflow-hidden rounded-[16px] border">
+          <Skeleton className="h-[240px] w-full rounded-none md:h-[320px] lg:h-[352px]" />
+          <div className="px-6 py-4">
+            <Skeleton className="h-5 w-48" />
+          </div>
+        </div>
+      </section>
+
+      {/* Comment */}
+      <MeetingCommentSkeleton />
+
+      {/* Recommended */}
+      <MeetingRecommendedSkeleton />
+    </main>
+  );
+}

--- a/src/widgets/meeting-detail/ui/skeletons/meeting-hero-skeleton.tsx
+++ b/src/widgets/meeting-detail/ui/skeletons/meeting-hero-skeleton.tsx
@@ -1,0 +1,65 @@
+import { Skeleton } from '@/shared/ui/skeleton/skeleton';
+
+export function MeetingHeroSkeleton() {
+  return (
+    <>
+      {/* Hero */}
+      <div className="flex flex-col gap-6 md:flex-row">
+        <Skeleton className="h-[241px] w-full rounded-[24px] md:h-auto md:min-w-0 md:flex-1" />
+        <div className="min-w-0 flex-1 rounded-[20px] bg-white p-4 md:p-6 lg:rounded-[32px]">
+          <div className="space-y-3">
+            <Skeleton className="h-5 w-28 rounded-full" />
+            <Skeleton className="h-8 w-3/4" />
+            <div className="space-y-3 pt-2">
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-9 shrink-0 rounded-full" />
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-16" />
+                  <Skeleton className="h-4 w-32" />
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-9 shrink-0 rounded-full" />
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-10" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-9 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-1">
+                  <Skeleton className="h-3 w-14" />
+                  <Skeleton className="h-3 w-full max-w-[500px]" />
+                </div>
+              </div>
+            </div>
+            <Skeleton className="mt-2 h-10 w-full lg:h-[62px]" />
+          </div>
+        </div>
+      </div>
+
+      {/* Description */}
+      <section>
+        <Skeleton className="mb-3 h-8 w-28" />
+        <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-12 py-10">
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-3/4" />
+          </div>
+        </div>
+      </section>
+
+      {/* Location */}
+      <section>
+        <Skeleton className="mb-3 h-8 w-24" />
+        <div className="border-sosoeat-gray-200 mt-5 overflow-hidden rounded-[16px] border">
+          <Skeleton className="h-[240px] w-full rounded-none md:h-[320px] lg:h-[352px]" />
+          <div className="px-6 py-4">
+            <Skeleton className="h-5 w-48" />
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/widgets/meeting-detail/ui/skeletons/meeting-recommended-skeleton.tsx
+++ b/src/widgets/meeting-detail/ui/skeletons/meeting-recommended-skeleton.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from '@/shared/ui/skeleton/skeleton';
+
+export function MeetingRecommendedSkeleton() {
+  return (
+    <section>
+      <Skeleton className="mb-4 h-8 w-52" />
+      <div className="mt-5 flex gap-6 overflow-hidden pb-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="w-[302px] shrink-0">
+            <Skeleton className="h-[160px] w-full rounded-3xl" />
+            <div className="mt-[14px] space-y-3 px-1">
+              <div className="flex gap-1">
+                <Skeleton className="h-5 w-16 rounded-full" />
+                <Skeleton className="h-5 w-12 rounded-full" />
+              </div>
+              <Skeleton className="h-6 w-full" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### 📌 유형 (Type)                                                                                                        
                                                                                                                            
  - [x] **Feat (기능):** 새로운 기능 추가                                                                                   
                                                                                                                            
  ---                                                                                                                       
                                                                                                                            
  ### 📝 변경 사항 (Changes)

  closes #279

  **스켈레톤 컴포넌트 추가**                                                                                                
  - `MeetingHeroSkeleton`, `MeetingCommentSkeleton`, `MeetingRecommendedSkeleton` 신규 추가
  - 각 섹션의 레이아웃에 맞는 shimmer 애니메이션 적용                                                                       
                                                                                                                            
  **Suspense 스트리밍 적용**
  - `page.tsx`에서 Hero / 댓글 / 추천 모임 섹션을 각각 `<Suspense>` 경계로 분리                                             
  - 서버 컴포넌트(`MeetingHeroFetcher`, `MeetingCommentFetcher`, `MeetingRecommendedFetcher`)가 독립적으로 스트리밍되어 가장
   빠른 섹션부터 순차적으로 표시                                                                                            
  - 기존 모든 데이터가 준비될 때까지 블로킹하던 방식 제거                                                                   
                                                                                                                            
  **수정 모달 코드 스플리팅**                                                                                               
  - `MeetingEditModal`을 `dynamic import`로 전환해 초기 번들 크기 감소
                                                                                                                            
  ---             

  ### 🧪 테스트 방법 (How to Test)

  1. 로컬에서 `npm run dev` 실행                                                                                            
  2. `/meetings/:id` 페이지 진입
  3. 각 섹션(Hero, 댓글, 추천 모임)이 스켈레톤을 먼저 보여주다가 순차적으로 실제 데이터로 교체되는지 확인                   
  4. Network 탭에서 응답이 청크로 나뉘어 streaming되는지 확인                                                               
                                                                                                                            
  ---                                                                                                                       
                                                                                                                            
  ### 🚨 기타 참고 사항 (Notes)

  - [ ] 이후 PR(#295 )에서 `prefetchQuery + HydrationBoundary` 패턴을 추가 적용할 예정입니다.                                