### PR TITLE
[Fix]: 로그인·회원가입 폼 UX 개선 및 에러 처리 리팩토링

### DIFF
--- a/src/features/auth/model/auth.mutations.ts
+++ b/src/features/auth/model/auth.mutations.ts
@@ -25,9 +25,6 @@ export const useLoginMutation = (callbackUrl?: string | null) => {
       toast.success('로그인에 성공했습니다.');
       router.push(getSafeCallbackUrl(callbackUrl, '/home'));
     },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : '로그인에 실패했습니다.');
-    },
   });
 };
 

--- a/src/features/auth/model/login-form.schema.ts
+++ b/src/features/auth/model/login-form.schema.ts
@@ -3,25 +3,8 @@ import { z } from 'zod';
 export const loginSchema = z.object({
   email: z
     .string()
+    .trim()
     .min(1, '이메일을 입력해주세요.')
-    .superRefine((val, ctx) => {
-      if (!val.trim()) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: '이메일을 입력해주세요.' });
-        return;
-      }
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val)) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: '올바른 이메일 형식이 아닙니다.' });
-      }
-    }),
-  password: z
-    .string()
-    .min(1, '비밀번호를 입력해주세요.')
-    .superRefine((val, ctx) => {
-      if (val && val.length < 8) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: '비밀번호가 8자 이상이 되도록 해 주세요.',
-        });
-      }
-    }),
+    .refine((val) => /^[^\n\s@]+@[^\s@]+\.[^\s@]+$/.test(val), '올바른 이메일 형식이 아닙니다.'),
+  password: z.string().min(1, '비밀번호를 입력해주세요.'),
 });

--- a/src/features/auth/model/login-form.schema.ts
+++ b/src/features/auth/model/login-form.schema.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 export const loginSchema = z.object({
   email: z
     .string()
-    .min(1, ' ')
+    .min(1, '이메일을 입력해주세요.')
     .superRefine((val, ctx) => {
       if (!val.trim()) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: ' ' });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: '이메일을 입력해주세요.' });
         return;
       }
       if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val)) {
@@ -15,7 +15,7 @@ export const loginSchema = z.object({
     }),
   password: z
     .string()
-    .min(1, ' ')
+    .min(1, '비밀번호를 입력해주세요.')
     .superRefine((val, ctx) => {
       if (val && val.length < 8) {
         ctx.addIssue({

--- a/src/features/auth/model/use-login-form.ts
+++ b/src/features/auth/model/use-login-form.ts
@@ -42,7 +42,8 @@ export const useLoginForm = ({ defaultValues }: LoginFormProps) => {
   const {
     register,
     handleSubmit,
-    formState: { isValid, errors, touchedFields },
+    setError,
+    formState: { errors, touchedFields, isSubmitted },
   } = useForm<LoginRequest>({
     resolver: zodResolver(loginSchema),
     mode: 'onSubmit',
@@ -50,23 +51,30 @@ export const useLoginForm = ({ defaultValues }: LoginFormProps) => {
   });
 
   const handleFormSubmit = handleSubmit((data: LoginRequest) => {
-    login(data);
+    login(data, {
+      onError: (error) => {
+        setError('root', {
+          message: error instanceof Error ? error.message : '로그인에 실패했습니다.',
+        });
+      },
+    });
   });
 
   const toggleShowPassword = () => setShowPassword((prev) => !prev);
 
-  const emailError = touchedFields.email ? errors.email : undefined;
-  const passwordError = touchedFields.password ? errors.password : undefined;
+  const emailError = touchedFields.email || isSubmitted ? errors.email : undefined;
+  const passwordError = touchedFields.password || isSubmitted ? errors.password : undefined;
 
   return {
     register,
     handleFormSubmit,
     emailError,
     passwordError,
+    rootError: errors.root,
     showPassword,
     toggleShowPassword,
     isPending,
-    isButtonActive: isValid,
+
     hasEmailError: !!emailError?.message?.trim(),
     hasPasswordError: !!passwordError?.message?.trim(),
   };

--- a/src/features/auth/ui/auth-submit-button/auth-submit-button.tsx
+++ b/src/features/auth/ui/auth-submit-button/auth-submit-button.tsx
@@ -1,4 +1,5 @@
 import { type VariantProps } from 'class-variance-authority';
+import { Loader2 } from 'lucide-react';
 
 import { cn } from '@/shared/lib/utils';
 import { Button, buttonVariants } from '@/shared/ui/button';
@@ -7,14 +8,12 @@ interface AuthSubmitButtonProps
   extends React.ComponentProps<'button'>, VariantProps<typeof buttonVariants> {
   isActive: boolean;
   isLoading?: boolean;
-  loadingText?: string;
   label: string;
 }
 
 export const AuthSubmitButton = ({
   isActive,
   isLoading = false,
-  loadingText,
   label,
   className,
   ...props
@@ -32,7 +31,7 @@ export const AuthSubmitButton = ({
       )}
       {...props}
     >
-      {isLoading ? (loadingText ?? `${label} 중...`) : label}
+      {isLoading ? <Loader2 className="size-5 animate-spin" /> : label}
     </Button>
   );
 };

--- a/src/features/auth/ui/auth-submit-button/auth-submit-button.tsx
+++ b/src/features/auth/ui/auth-submit-button/auth-submit-button.tsx
@@ -6,13 +6,13 @@ import { Button, buttonVariants } from '@/shared/ui/button';
 
 interface AuthSubmitButtonProps
   extends React.ComponentProps<'button'>, VariantProps<typeof buttonVariants> {
-  isActive: boolean;
+  isActive?: boolean;
   isLoading?: boolean;
   label: string;
 }
 
 export const AuthSubmitButton = ({
-  isActive,
+  isActive = true,
   isLoading = false,
   label,
   className,

--- a/src/widgets/auth/login-form/ui/login-form.tsx
+++ b/src/widgets/auth/login-form/ui/login-form.tsx
@@ -89,7 +89,7 @@ const LoginFormContent = (props: LoginFormProps) => {
           </div>
         </div>
 
-        <AuthSubmitButton isActive={true} isLoading={isPending} label="로그인" />
+        <AuthSubmitButton isLoading={isPending} label="로그인" />
       </FieldGroup>
     </form>
   );

--- a/src/widgets/auth/login-form/ui/login-form.tsx
+++ b/src/widgets/auth/login-form/ui/login-form.tsx
@@ -21,9 +21,9 @@ const LoginFormContent = (props: LoginFormProps) => {
     showPassword,
     toggleShowPassword,
     isPending,
-    isButtonActive,
     emailError,
     passwordError,
+    rootError,
     hasEmailError,
     hasPasswordError,
   } = useLoginForm(props);
@@ -38,7 +38,7 @@ const LoginFormContent = (props: LoginFormProps) => {
           <FieldContent>
             <Input
               id="email"
-              type="text"
+              type="email"
               placeholder="이메일을 입력해주세요"
               disabled={isPending}
               className={getInputClasses(hasEmailError)}
@@ -83,12 +83,13 @@ const LoginFormContent = (props: LoginFormProps) => {
           </div>
         </Field>
 
-        <AuthSubmitButton
-          isActive={isButtonActive}
-          isLoading={isPending}
-          loadingText="로그인 중..."
-          label="로그인"
-        />
+        <div className={getErrorAnimationClasses(!!rootError?.message?.trim())}>
+          <div className="overflow-hidden">
+            <FieldError errors={[rootError]} className="pl-1 duration-200" />
+          </div>
+        </div>
+
+        <AuthSubmitButton isActive={true} isLoading={isPending} label="로그인" />
       </FieldGroup>
     </form>
   );

--- a/src/widgets/auth/login-layout/ui/login-layout.tsx
+++ b/src/widgets/auth/login-layout/ui/login-layout.tsx
@@ -72,7 +72,7 @@ export const LoginLayout = ({ children }: LoginLayoutProps) => {
         <div className="flex justify-center pt-10">
           <Link
             href="/signup"
-            className="group text-sm font-medium text-gray-400 transition-colors hover:text-gray-500 md:text-base"
+            className="group text-sm font-medium text-gray-700 transition-colors hover:text-gray-900 md:text-base"
           >
             <span className="duration-200">소소잇이 처음이신가요?</span>{' '}
             <span className="text-sosoeat-orange-600 font-bold duration-200 group-hover:underline">

--- a/src/widgets/auth/signup-form/ui/_components/email-step.tsx
+++ b/src/widgets/auth/signup-form/ui/_components/email-step.tsx
@@ -91,12 +91,7 @@ export const EmailStep = ({ onNext, defaultValues }: EmailStepProps) => {
         </Field>
       </div>
 
-      <AuthSubmitButton
-        label="다음"
-        isActive={true}
-        isLoading={isCheckingEmail}
-        className="mt-4 h-13"
-      />
+      <AuthSubmitButton label="다음" isLoading={isCheckingEmail} className="mt-4 h-13" />
     </form>
   );
 };

--- a/src/widgets/auth/signup-form/ui/_components/email-step.tsx
+++ b/src/widgets/auth/signup-form/ui/_components/email-step.tsx
@@ -35,7 +35,6 @@ export const EmailStep = ({ onNext, defaultValues }: EmailStepProps) => {
 
   const displayError =
     (touchedFields.email || isSubmitted) && errors.email ? errors.email : undefined;
-  const isDisabled = !!displayError?.message?.trim() || isCheckingEmail;
 
   const checkEmailDuplicate = async (email: string): Promise<boolean> => {
     try {
@@ -77,7 +76,7 @@ export const EmailStep = ({ onNext, defaultValues }: EmailStepProps) => {
           <FieldContent className="gap-1.5">
             <Input
               id="email"
-              type="text"
+              type="email"
               placeholder="example@email.com"
               className={getInputClasses(!!displayError?.message?.trim())}
               {...register('email')}
@@ -94,7 +93,7 @@ export const EmailStep = ({ onNext, defaultValues }: EmailStepProps) => {
 
       <AuthSubmitButton
         label="다음"
-        isActive={!isDisabled}
+        isActive={true}
         isLoading={isCheckingEmail}
         className="mt-4 h-13"
       />

--- a/src/widgets/auth/signup-form/ui/_components/name-step.tsx
+++ b/src/widgets/auth/signup-form/ui/_components/name-step.tsx
@@ -70,12 +70,7 @@ export const NameStep = ({
           <ChevronLeft className="h-6 w-6" />
           <span>이전</span>
         </Button>
-        <AuthSubmitButton
-          label="회원가입"
-          isActive={true}
-          isLoading={isLoading}
-          className="h-[52px] flex-1"
-        />
+        <AuthSubmitButton label="회원가입" isLoading={isLoading} className="h-[52px] flex-1" />
       </div>
     </form>
   );

--- a/src/widgets/auth/signup-form/ui/_components/name-step.tsx
+++ b/src/widgets/auth/signup-form/ui/_components/name-step.tsx
@@ -21,14 +21,14 @@ export const NameStep = ({
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors, touchedFields, isSubmitted },
   } = useForm<NameValues>({
     resolver: zodResolver(nameSchema),
     mode: 'onBlur',
     defaultValues,
   });
 
-  const nameError = errors.name;
+  const nameError = touchedFields.name || isSubmitted ? errors.name : undefined;
   const hasError = !!nameError?.message?.trim();
 
   const onSubmit = (data: NameValues) => {
@@ -72,7 +72,7 @@ export const NameStep = ({
         </Button>
         <AuthSubmitButton
           label="회원가입"
-          isActive={isValid}
+          isActive={true}
           isLoading={isLoading}
           className="h-[52px] flex-1"
         />

--- a/src/widgets/auth/signup-form/ui/_components/password-step.tsx
+++ b/src/widgets/auth/signup-form/ui/_components/password-step.tsx
@@ -16,6 +16,7 @@ import { Input } from '@/shared/ui/input';
 export const PasswordStep = ({
   onNext,
   onPrev,
+  isLoading,
   defaultValues,
 }: MiddleStepProps<PasswordValues>) => {
   const [showPassword, setShowPassword] = useState(false);
@@ -24,17 +25,18 @@ export const PasswordStep = ({
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors, touchedFields, isSubmitted },
   } = useForm<PasswordValues>({
     resolver: zodResolver(passwordSchema),
     mode: 'onBlur',
     defaultValues,
   });
 
-  const passwordError = errors.password;
+  const passwordError = touchedFields.password || isSubmitted ? errors.password : undefined;
   const hasPasswordError = !!passwordError?.message?.trim();
 
-  const confirmError = errors.passwordConfirm;
+  const confirmError =
+    touchedFields.passwordConfirm || isSubmitted ? errors.passwordConfirm : undefined;
   const hasConfirmError = !!confirmError?.message?.trim();
 
   const onSubmit = (data: PasswordValues) => {
@@ -114,12 +116,18 @@ export const PasswordStep = ({
           type="button"
           variant="outline"
           onClick={onPrev}
+          disabled={isLoading}
           className="bg-sosoeat-gray-100 mt-2 h-[52px] rounded-[16px] px-4 text-base font-semibold text-gray-500 shadow-sm transition-colors"
         >
           <ChevronLeft className="h-6 w-6" />
           <span>이전</span>
         </Button>
-        <AuthSubmitButton label="다음" isActive={isValid} className="h-[52px] flex-1" />
+        <AuthSubmitButton
+          label="다음"
+          isActive={true}
+          isLoading={isLoading}
+          className="h-[52px] flex-1"
+        />
       </div>
     </form>
   );

--- a/src/widgets/auth/signup-form/ui/_components/password-step.tsx
+++ b/src/widgets/auth/signup-form/ui/_components/password-step.tsx
@@ -16,7 +16,6 @@ import { Input } from '@/shared/ui/input';
 export const PasswordStep = ({
   onNext,
   onPrev,
-  isLoading,
   defaultValues,
 }: MiddleStepProps<PasswordValues>) => {
   const [showPassword, setShowPassword] = useState(false);
@@ -116,18 +115,12 @@ export const PasswordStep = ({
           type="button"
           variant="outline"
           onClick={onPrev}
-          disabled={isLoading}
           className="bg-sosoeat-gray-100 mt-2 h-[52px] rounded-[16px] px-4 text-base font-semibold text-gray-500 shadow-sm transition-colors"
         >
           <ChevronLeft className="h-6 w-6" />
           <span>이전</span>
         </Button>
-        <AuthSubmitButton
-          label="다음"
-          isActive={true}
-          isLoading={isLoading}
-          className="h-[52px] flex-1"
-        />
+        <AuthSubmitButton label="다음" className="h-[52px] flex-1" />
       </div>
     </form>
   );

--- a/src/widgets/auth/signup-form/ui/_components/signup-header.tsx
+++ b/src/widgets/auth/signup-form/ui/_components/signup-header.tsx
@@ -6,7 +6,7 @@ export const SignupHeader = () => {
       <div className="relative h-10 w-20 md:h-12 md:w-24">
         <Image src="/images/logo.svg" alt="소소잇 로고" fill className="object-contain" priority />
       </div>
-      <h1 className="text-lg font-bold text-gray-900 md:text-xl">모여요 가입하기</h1>
+      <h1 className="text-lg font-bold text-gray-900 md:text-xl">소소잇 가입하기</h1>
       <p className="text-xs font-medium text-gray-500 md:text-sm">
         1인 가구를 위한 식생활 모임에 합류하세요
       </p>

--- a/src/widgets/auth/signup-form/ui/signup-form.tsx
+++ b/src/widgets/auth/signup-form/ui/signup-form.tsx
@@ -52,6 +52,7 @@ export const SignupForm = ({ defaultStep = 'email' }: SignupFormProps) => {
               <PasswordStep
                 onNext={handlePasswordNext}
                 onPrev={handlePrev}
+                isLoading={isPending}
                 defaultValues={
                   formData.password
                     ? {

--- a/src/widgets/auth/signup-form/ui/signup-form.tsx
+++ b/src/widgets/auth/signup-form/ui/signup-form.tsx
@@ -52,7 +52,6 @@ export const SignupForm = ({ defaultStep = 'email' }: SignupFormProps) => {
               <PasswordStep
                 onNext={handlePasswordNext}
                 onPrev={handlePrev}
-                isLoading={isPending}
                 defaultValues={
                   formData.password
                     ? {


### PR DESCRIPTION
 ### 📌 유형 (Type)

  - [ ] **Feat (기능):** 새로운 기능 추가
  - [x] **Fix (버그 수정):** 버그 수정
  - [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
  - [ ] **Docs (문서):** 문서 관련 변경
  - [ ] **Style (스타일):** 코드 포맷 등
  - [ ] **Chore (기타):** 빌드, 설정 등

  ### 📝 변경 사항 (Changes)

  - 로그인 mutation의 `onError`를 제거하고, `useLoginForm`에서 `setError('root')`로 서버 에러를 폼 내부에
  표시하도록 변경
  - 에러 메시지를 공백 문자에서 구체적인 문구로 변경 (`'이메일을 입력해주세요.'` 등)
  - `isSubmitted` 조건 추가로 폼 제출 시도 후 즉시 에러 노출
  - 이메일 입력 필드 `type="email"` 적용 (모바일 키보드 UX 개선)
  - `AuthSubmitButton` 로딩 상태 표시를 텍스트에서 `Loader2` 스피너로 변경, `loadingText` 프롭 제거
  - 회원가입 `PasswordStep` 다음 버튼에 `isLoading` 누락 수정
  - 로그인 페이지 하단 링크 명암비 개선 (`text-gray-400` → `text-gray-700`)
  - 회원가입 헤더 텍스트 "소소잇 가입하기"로 수정

  ### 🧪 테스트 방법 (How to Test)

  1. `/login` 페이지에서 빈 폼 제출 시 에러 메시지 즉시 표시 확인
  2. 잘못된 이메일/비밀번호 입력 후 로그인 시 폼 하단에 서버 에러 메시지 표시 확인 (Toast 없음)
  3. `/signup` 이메일 단계 → 모바일에서 이메일 키보드 레이아웃 확인
  4. 회원가입 마지막 단계(이름 입력) 제출 중 "다음" 버튼에 스피너 표시 확인
  5. 회원가입 비밀번호 단계 제출 중 "이전" 버튼 비활성화 및 "다음" 버튼 스피너 확인

  ### 📸 스크린샷 또는 영상 (Optional)

  | 변경 전 (Before) | 변경 후 (After) |
  | :--------------: | :-------------: |
  |                  |                 |

  ### 🚨 기타 참고 사항 (Notes)
