### PR TITLE
[Refactor]: mypgae 모델 레이어 분리 및 쿼리키 컨벤션 적용

### DIFF
--- a/src/widgets/mypage/model/mypage.constants.ts
+++ b/src/widgets/mypage/model/mypage.constants.ts
@@ -1,0 +1,9 @@
+import type { TabList } from './mypage.types';
+
+export const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
+
+export const MYPAGE_TABS: TabList[] = [
+  { value: 'all', label: '나의 모임' },
+  { value: 'favorite', label: '찜한 모임' },
+  { value: 'created', label: '내가 만든 모임' },
+];

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -2,31 +2,31 @@ import { useQuery } from '@tanstack/react-query';
 
 import { mypageApi } from '../api/mypage.api';
 
-export const mypageQueryKeys = {
-  joinedMeetings: ['mypage-joined-meetings'] as const,
-  createdMeetings: ['mypage-created-meetings'] as const,
-  favoriteMeetings: ['mypage-favorite-meetings'] as const,
-};
+import { FIVE_MINUTES_IN_MS } from './mypage.constants';
 
-const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
+export const mypageKeys = {
+  joinedMeetings: () => ['users', 'me', 'joined-meetings'] as const,
+  createdMeetings: () => ['users', 'me', 'created-meetings'] as const,
+  favoriteMeetings: () => ['users', 'me', 'favorite-meetings'] as const,
+} as const;
 
 export const useJoinedMeetings = () =>
   useQuery({
-    queryKey: mypageQueryKeys.joinedMeetings,
+    queryKey: mypageKeys.joinedMeetings(),
     queryFn: mypageApi.fetchJoinedMeetings,
     staleTime: FIVE_MINUTES_IN_MS,
   });
 
 export const useCreatedMeetings = () =>
   useQuery({
-    queryKey: mypageQueryKeys.createdMeetings,
+    queryKey: mypageKeys.createdMeetings(),
     queryFn: mypageApi.fetchCreatedMeetings,
     staleTime: FIVE_MINUTES_IN_MS,
   });
 
 export const useFavoriteMeetings = () =>
   useQuery({
-    queryKey: mypageQueryKeys.favoriteMeetings,
+    queryKey: mypageKeys.favoriteMeetings(),
     queryFn: mypageApi.fetchFavoriteMeetings,
     staleTime: FIVE_MINUTES_IN_MS,
   });

--- a/src/widgets/mypage/model/mypage.types.ts
+++ b/src/widgets/mypage/model/mypage.types.ts
@@ -1,0 +1,6 @@
+export type TabValue = 'all' | 'favorite' | 'created';
+
+export interface TabList {
+  value: TabValue;
+  label: string;
+}

--- a/src/widgets/mypage/model/use-meeting-tabs.ts
+++ b/src/widgets/mypage/model/use-meeting-tabs.ts
@@ -2,10 +2,9 @@
 
 import { useMemo } from 'react';
 
-import { TabValue } from '../ui/meeting-tabs/meeting-tabs.types';
-
 import { useCreatedMeetings, useFavoriteMeetings, useJoinedMeetings } from './mypage.queries';
 import { toFavoriteMeetingCards, toUserMeetingCards } from './mypage.service';
+import { TabValue } from './mypage.types';
 
 export function useMeetingTabs(activeTab: TabValue) {
   const joinedQuery = useJoinedMeetings();

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.types.ts
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.types.ts
@@ -1,12 +1,2 @@
-export type TabValue = 'all' | 'favorite' | 'created';
-
-export interface TabList {
-  value: TabValue;
-  label: string;
-}
-
-export const MYPAGE_TABS: TabList[] = [
-  { value: 'all', label: '나의 모임' },
-  { value: 'favorite', label: '찜한 모임' },
-  { value: 'created', label: '내가 만든 모임' },
-];
+export { MYPAGE_TABS } from '../../model/mypage.constants';
+export type { TabList,TabValue } from '../../model/mypage.types';


### PR DESCRIPTION
## [Refactor]: mypgae 모델 레이어 분리 및 쿼리키 컨벤션 적용

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

widgets/mypage 모델 레이어의 타입·상수가 UI 레이어에 혼재되어 있었고, 쿼리키가 팀 컨벤션을 따르지 않는 문제를 개선했습니다.

- model/mypage.types.ts 신규 생성 — TabValue, TabList 타입을 UI 레이어에서 model 레이어로 이동
- model/mypage.constants.ts 신규 생성 — MYPAGE_TABS, FIVE_MINUTES_IN_MS 상수를 model 레이어로 이동
- use-meeting-tabs.ts의 UI 레이어 역방향 의존성 제거 (../ui/... → ./mypage.types)
- ui/meeting-tabs/meeting-tabs.types.ts는 model re-export로 변경하여 기존 import 경로 유지
- mypageQueryKeys → mypageKeys로 rename, raw 배열을 factory 함수 형태로 교체 (['mypage-joined-meetings'] → () => ['users', 'me', 'joined-meetings'])


### 🧪 테스트 방법 (How to Test)

1.  npm run type-check — 타입 에러 없는지 확인
2. npm run test — mypage.service.test.ts 통과 확인
3. 마이페이지(/mypage) 진입 후 나의 모임 / 찜한 모임 / 내가 만든 모임 탭 전환이 정상 동작하는지 확인


