### PR TITLE
[Style]: 모임 상세 페이지 UI 수정

### DIFF
--- a/src/app/meetings/[id]/page.tsx
+++ b/src/app/meetings/[id]/page.tsx
@@ -40,7 +40,7 @@ export default async function MeetingDetailPage({ params }: Props) {
       <section>
         <h2 className="text-sosoeat-gray-900 mb-3 text-2xl font-semibold">모임 설명</h2>
         <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-12 py-10">
-          <p className="text-sosoeat-gray-800 text-lg font-normal whitespace-pre-line">
+          <p className="text-sosoeat-gray-800 text-base font-normal whitespace-pre-line md:text-lg">
             {meetingData.description}
           </p>
         </div>

--- a/src/shared/ui/comment-input/comment-input.tsx
+++ b/src/shared/ui/comment-input/comment-input.tsx
@@ -79,7 +79,7 @@ export function CommentInput({
             event.preventDefault();
             handleSubmit();
           }}
-          className="text-sosoeat-gray-900 placeholder:text-sosoeat-gray-700 max-h-40 min-h-[23px] flex-1 resize-none border-0 bg-transparent px-0 pt-0 pb-1.5 text-base font-normal shadow-none focus-visible:ring-0 md:text-base"
+          className="text-sosoeat-gray-900 placeholder:text-sosoeat-gray-700 max-h-40 min-h-[23px] flex-1 resize-none border-0 bg-transparent px-0 py-1.5 text-base font-normal shadow-none focus-visible:ring-0 md:text-base"
         />
 
         <Button

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
@@ -78,12 +78,14 @@ describe('MeetingCommentItem', () => {
       expect(screen.getByRole('button', { name: '더보기' })).toBeInTheDocument();
     });
 
-    it('isMine이 false이면 더보기 버튼이 표시되지 않는다', () => {
+    it('isMine이 false이면 더보기 버튼이 invisible 처리된다', () => {
       render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
         wrapper: createWrapper(),
       });
 
-      expect(screen.queryByRole('button', { name: '더보기' })).not.toBeInTheDocument();
+      const button = screen.queryByRole('button', { name: '더보기' });
+      expect(button).toBeInTheDocument();
+      expect(button?.closest('.invisible')).toBeTruthy();
     });
 
     it('더보기 클릭 시 수정하기/삭제하기가 표시된다', async () => {

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -2,6 +2,7 @@
 
 import { Heart, MessageCircle, UserRound } from 'lucide-react';
 
+import { useAuthStore } from '@/entities/auth';
 import { cn } from '@/shared/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 
@@ -57,6 +58,7 @@ export function MeetingCommentItem({
   } = useMeetingCommentItem({ commentId: id, meetingId, content, isLiked, likeCount });
 
   const isPending = id < 0;
+  const { isAuthenticated } = useAuthStore();
 
   return (
     <div>
@@ -164,10 +166,13 @@ export function MeetingCommentItem({
             {isReplying && (
               <div className="mt-2 flex gap-2">
                 <textarea
-                  className="flex-1 resize-none rounded-lg border px-3 py-2 text-sm outline-none"
+                  className="flex-1 resize-none rounded-lg border px-3 py-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
                   rows={1}
-                  placeholder="답글을 입력하세요."
+                  placeholder={
+                    isAuthenticated ? '답글을 입력하세요.' : '로그인 후 댓글을 작성할 수 있습니다.'
+                  }
                   value={replyText}
+                  disabled={!isAuthenticated}
                   onChange={(e) => setReplyText(e.target.value)}
                 />
                 <div className="flex gap-1">
@@ -181,7 +186,8 @@ export function MeetingCommentItem({
                   <button
                     type="button"
                     onClick={handleReplySubmit}
-                    className="bg-sosoeat-orange-600 cursor-pointer rounded-lg px-3 py-1 text-sm text-white"
+                    disabled={!isAuthenticated}
+                    className="bg-sosoeat-orange-600 cursor-pointer rounded-lg px-3 py-1 text-sm text-white disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     저장
                   </button>

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -86,9 +86,9 @@ export function MeetingCommentItem({
                 <span className="text-sosoeat-gray-600 text-xs">
                   {formatCommentDate(createdAt)}
                 </span>
-                {isMine && !isDeleted && (
+                <div className={cn((!isMine || isDeleted) && 'pointer-events-none invisible')}>
                   <EllipsisMenu onEdit={() => setIsEditing(true)} onDelete={openDeleteModal} />
-                )}
+                </div>
               </div>
             </div>
 

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
@@ -20,7 +20,7 @@ export function ActionButton({ config, category, onClick, pending }: ActionButto
   if (config.variant === 'disabled') {
     return (
       <Button
-        className="text-sosoeat-gray-700 border-sosoeat-gray-300 bg-sosoeat-gray-200 h-full w-full cursor-not-allowed rounded-2xl border-2 text-sm md:text-base lg:text-xl"
+        className="text-sosoeat-gray-700 border-sosoeat-gray-300 bg-sosoeat-gray-200 h-full w-full cursor-not-allowed rounded-2xl border-2 text-sm md:text-xl"
         disabled
       >
         {config.label}

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
@@ -83,7 +83,7 @@ export const ACTION_BUTTON_CONFIGS: ActionButtonConfig[] = [
   {
     type: 'closed',
     match: ({ status, role, isJoined }) =>
-      status === 'closed' || (status === 'full' && !(role === 'participant' && isJoined)),
+      status === 'closed' || (status === 'full' && role !== 'host' && !isJoined),
     label: '모집 마감',
     variant: 'disabled',
   },

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
@@ -17,12 +17,12 @@ export const CATEGORY_LABEL: Record<MeetingCategory, string> = {
 
 /** 기본 액션 버튼 (참여하기 / 모임 확정하기) */
 export const actionButtonVariants = cva(
-  'h-full w-full rounded-2xl text-sm md:text-base lg:text-xl',
+  'h-full w-full rounded-2xl text-sm md:text-xl focus-visible:ring-0 focus-visible:border-transparent',
   {
     variants: {
       category: {
-        groupEat: 'bg-sosoeat-orange-600 text-white hover:bg-sosoeat-orange-700',
-        groupBuy: 'bg-sosoeat-blue-600 text-white hover:bg-sosoeat-blue-700',
+        groupEat: 'bg-sosoeat-orange-600 text-white hover:bg-sosoeat-orange-700 hover:text-white',
+        groupBuy: 'bg-sosoeat-blue-600 text-white hover:bg-sosoeat-blue-700 hover:text-white',
       },
     },
   }
@@ -30,12 +30,14 @@ export const actionButtonVariants = cva(
 
 /** 흰 버튼 (참여 취소하기 / 공유하기) */
 export const outlineButtonVariants = cva(
-  'ring-0 h-full w-full rounded-2xl bg-white text-normal md:text-sm lg:text-xl',
+  'ring-0 h-full w-full rounded-2xl bg-white text-normal md:text-xl focus-visible:ring-0 focus-visible:border-transparent',
   {
     variants: {
       category: {
-        groupEat: 'ring-1 text-sosoeat-orange-700 hover:bg-white',
-        groupBuy: 'ring-1 text-sosoeat-blue-700 hover:bg-white',
+        groupEat:
+          'ring-1 text-sosoeat-orange-700 hover:bg-sosoeat-orange-100 hover:text-sosoeat-orange-700',
+        groupBuy:
+          'ring-1 text-sosoeat-blue-700 hover:bg-sosoeat-blue-50 hover:text-sosoeat-blue-700',
       },
     },
   }

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
@@ -30,7 +30,7 @@ export const actionButtonVariants = cva(
 
 /** 흰 버튼 (참여 취소하기 / 공유하기) */
 export const outlineButtonVariants = cva(
-  'ring-0 h-full w-full rounded-2xl bg-white text-normal md:text-xl focus-visible:ring-0 focus-visible:border-transparent',
+  'ring-0 h-full w-full rounded-2xl bg-white text-normal md:text-xl shadow-inner focus-visible:ring-0 focus-visible:border-transparent',
   {
     variants: {
       category: {
@@ -82,7 +82,8 @@ export interface ActionButtonConfig {
 export const ACTION_BUTTON_CONFIGS: ActionButtonConfig[] = [
   {
     type: 'closed',
-    match: ({ status }) => status === 'closed' || status === 'full',
+    match: ({ status, role, isJoined }) =>
+      status === 'closed' || (status === 'full' && !(role === 'participant' && isJoined)),
     label: '모집 마감',
     variant: 'disabled',
   },

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
@@ -126,8 +126,7 @@ interface InfoSectionProps {
 
 function InfoSection({ meeting, category, fullDateLabel, className }: InfoSectionProps) {
   return (
-    // sm: gap-1 (4px) / md: gap-1.5 (6px) / lg: gap-2 (8px)
-    <div className={cn('flex flex-col gap-1 md:gap-1.5 lg:gap-2', className)}>
+    <div className={cn('flex flex-col gap-1 md:gap-2', className)}>
       <InfoRow icon={<CalendarIcon />} category={category} label="날짜 및 시간">
         <p className="text-sosoeat-gray-900 text-xs font-bold md:text-sm">{fullDateLabel}</p>
       </InfoRow>
@@ -162,7 +161,7 @@ interface ActionRowProps {
 function ActionRow({ actionButton, meetingId, isFavorited }: ActionRowProps) {
   return (
     <div className="flex items-center gap-2">
-      <div className="h-10 w-full lg:h-[62px]">{actionButton}</div>
+      <div className="h-10 w-full md:h-[62px]">{actionButton}</div>
       {/* sm·md: 40×40 */}
       <HeartButton
         meetingId={meetingId}
@@ -215,15 +214,7 @@ export function MeetingDetailCard(props: MeetingDetailCardProps) {
   );
 
   return (
-    <div
-      className={cn(
-        'flex flex-col rounded-[20px] bg-white lg:rounded-[32px]',
-        // sm: p-4(16px) / md·lg: p-6(24px)
-        'p-4 md:p-6',
-        // sm: gap-3(12px) / md: gap-[14px] / lg: gap-4(16px)
-        'gap-3 md:gap-[14px] lg:gap-4'
-      )}
-    >
+    <div className={cn('flex flex-col rounded-[32px] bg-white', 'p-4 md:p-6', 'gap-3 md:gap-4')}>
       {/* ════════════════════════════════════════
           sm 뱃지 섹션
           - hasSafetyBadge O: 상태 뱃지(첫 줄) + deadline(둘째 줄)
@@ -245,7 +236,11 @@ export function MeetingDetailCard(props: MeetingDetailCardProps) {
           </div>
         )}
         <div className={cn('flex items-center', !hasSafetyBadge && 'justify-between')}>
-          <DeadlineBadge registrationEnd={new Date(meeting.registrationEnd)} variant={category} />
+          <DeadlineBadge
+            registrationEnd={new Date(meeting.registrationEnd)}
+            variant={category}
+            className="min-w-0 flex-1"
+          />
           {!hasSafetyBadge && ellipsisMenu}
         </div>
       </div>
@@ -255,8 +250,12 @@ export function MeetingDetailCard(props: MeetingDetailCardProps) {
           - deadline + 상태 뱃지 한 줄
           ════════════════════════════════════════ */}
       <div className="hidden md:flex md:items-center md:justify-between">
-        <div className="flex items-center gap-1">
-          <DeadlineBadge registrationEnd={new Date(meeting.registrationEnd)} variant={category} />
+        <div className="flex min-w-0 items-center gap-1 overflow-hidden">
+          <DeadlineBadge
+            registrationEnd={new Date(meeting.registrationEnd)}
+            variant={category}
+            className="min-w-0 flex-1"
+          />
           {isConfirmed && (
             <EstablishmentStatusBadge
               confirmedAt={new Date(meeting.confirmedAt!)}
@@ -274,7 +273,7 @@ export function MeetingDetailCard(props: MeetingDetailCardProps) {
           md: text-2xl/bold
           lg: text-3xl/bold
           ════════════════════════════════════════ */}
-      <h2 className="line-clamp-2 text-xl leading-snug font-semibold md:text-2xl md:font-bold lg:line-clamp-none lg:text-3xl">
+      <h2 className="line-clamp-2 text-xl leading-snug font-semibold md:line-clamp-none md:text-2xl md:font-bold">
         {meeting.name}
       </h2>
 

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.utils.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.utils.ts
@@ -5,16 +5,11 @@ import type { Meeting } from '@/entities/meeting';
 
 import type { MeetingRole, MeetingStatus } from './meeting-detail-card.types';
 
-/**
- * 모임 상태 단일 정의 — 카드 액션 테이블·역할 훅과 동일 규칙을 씁니다.
- * (마감일 경과 또는 정원 만석은 모두 `closed` → 모집 마감 UI)
- */
 export const getMeetingStatus = (meeting: Meeting): MeetingStatus => {
   if (meeting.canceledAt != null) return 'closed';
   const now = new Date();
-  if (new Date(meeting.registrationEnd) < now || meeting.participantCount >= meeting.capacity) {
-    return 'closed';
-  }
+  if (new Date(meeting.registrationEnd) < now) return 'closed';
+  if (meeting.participantCount >= meeting.capacity) return 'full';
   if (meeting.confirmedAt != null) return 'confirmed';
   return 'open';
 };

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.utils.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.utils.ts
@@ -11,11 +11,11 @@ import type { MeetingRole, MeetingStatus } from './meeting-detail-card.types';
  */
 export const getMeetingStatus = (meeting: Meeting): MeetingStatus => {
   if (meeting.canceledAt != null) return 'closed';
-  if (meeting.confirmedAt != null) return 'confirmed';
   const now = new Date();
   if (new Date(meeting.registrationEnd) < now || meeting.participantCount >= meeting.capacity) {
     return 'closed';
   }
+  if (meeting.confirmedAt != null) return 'confirmed';
   return 'open';
 };
 

--- a/src/widgets/meeting-detail/ui/meeting-recommended-section/meeting-recommended-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-recommended-section/meeting-recommended-section.tsx
@@ -14,6 +14,8 @@ export function MeetingRecommendedSection({
 }: MeetingRecommendedSectionProps) {
   const recommendedMeetings = meetings.filter((m) => m.id !== currentMeetingId);
 
+  if (recommendedMeetings.length === 0) return null;
+
   return (
     <section>
       <h2 className="text-sosoeat-gray-900 mb-4 text-2xl font-semibold">이런 모임은 어때요?</h2>


### PR DESCRIPTION
 ### 📌 유형 (Type)                                                                                             
                                                                                                                 
  - [ ] **Feat (기능):** 새로운 기능 추가                                                                        
  - [x] **Fix (버그 수정):** 버그 수정                                                                           
  - [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)                                                 
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)                                                        
  - [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)                                  
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등                                              
                                                                                                                 
  ### 📝 변경 사항 (Changes)                                                                                     
                                                                                                                 
  closes #307                                               

  **버그 수정**                                                                                                  
  - 마감일이 지났거나 정원이 찼을 때 확정 모임에서 "모집 마감" 버튼이 표시되지 않던 문제 수정
  - 정원 초과(`full`) 상태를 마감일 경과(`closed`)와 분리 — 정원 초과 시 참여 중인 유저는 "참여 취소하기" 유지,  
  마감일 경과 시에는 참여자도 "모집 마감" 표시                                                                   
  - 비로그인 상태에서 대댓글 입력창이 활성화된 채로 노출되던 문제 수정                                           
  - `isMine=false`일 때 더보기 버튼을 조건부 렌더링 대신 `invisible` 처리하여 날짜 위치 일관성 유지              
  - 추천 모임 리스트가 비어있을 때 섹션이 노출되던 문제 수정                                                     
                                                                                                                 
  **UI/스타일 개선**                                                                                             
  - 댓글 입력창 커서 수직 중앙 정렬                                                                              
  - 모바일 모임 설명 텍스트 `text-lg` → `text-base md:text-lg`                                                   
  - 히어로 카드 뱃지 오버플로우 방지 (`min-w-0 overflow-hidden`)                                                 
  - 액션 버튼 높이 md/lg 통일 (`md:h-[62px]`), 텍스트 크기 md/lg 통일 (`md:text-xl`)                             
  - lg 브레이크포인트 레이아웃 점프 개선 (카드 border-radius, gap, 제목 폰트 크기 breakpoint 분기 정리)          
  - 흰 배경 버튼 hover 시 카테고리 색상 연한 배경 적용 및 `shadow-inner` 추가                                    
  - 색상 버튼 hover 시 검은 테두리 제거                                                                          
                                                                                                                 
  ### 🧪 테스트 방법 (How to Test)                                                                               
                                                                                                                 
  1. 마감일이 경과한 모임 상세 페이지 진입                                                                       
     - 참여자 포함 전원 "모집 마감" 버튼 표시 확인
  2. 정원이 꽉 찬 모임에 마지막으로 참여                                                                         
     - 참여자 본인은 "참여 취소하기" 버튼 표시 확인                                                              
     - 비참여자는 "모집 마감" 버튼 표시 확인                                                                     
  3. 비로그인 상태에서 답글 버튼 클릭                                                                            
     - 입력창 `disabled` 처리 및 안내 문구 확인                                                                  
  4. 추천 모임이 없는 상세 페이지 진입                                                                           
     - "이런 모임은 어때요?" 섹션 미노출 확인                                                                    
  5. 브라우저 창 리사이즈로 md/lg 경계 통과                                                                      
     - 레이아웃 점프 없이 자연스럽게 전환되는지 확인                                                 