### PR TITLE
[Feature] CountCard - 마이페이지 참여/찜 모임 count 실시간 반영

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -9,6 +9,7 @@ import {
   fetchMeetingCountServer,
   fetchMeServer,
   fetchPostCountServer,
+  MeetingCountCard,
   MeetingTabs,
   UserCard,
 } from '@/widgets/mypage';
@@ -34,7 +35,7 @@ export default async function MyPage() {
       </div>
 
       <div className="flex flex-row justify-center gap-5 md:p-5">
-        <CountCard variant="meeting" count={meetingCount} />
+        <MeetingCountCard initialCount={meetingCount} />
         <FavoriteCountCard initialCount={favoriteCount} />
         <CountCard variant="post" count={postCount} />
       </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -4,6 +4,7 @@ import { format } from 'date-fns';
 
 import {
   CountCard,
+  FavoriteCountCard,
   fetchFavoriteCountServer,
   fetchMeetingCountServer,
   fetchMeServer,
@@ -34,7 +35,7 @@ export default async function MyPage() {
 
       <div className="flex flex-row justify-center gap-5 md:p-5">
         <CountCard variant="meeting" count={meetingCount} />
-        <CountCard variant="favorite" count={favoriteCount} />
+        <FavoriteCountCard initialCount={favoriteCount} />
         <CountCard variant="post" count={postCount} />
       </div>
 

--- a/src/entities/meeting/index.ts
+++ b/src/entities/meeting/index.ts
@@ -1,5 +1,6 @@
 export { meetingsApi } from './api/meetings.api';
 export type { Meeting, MeetingCategory } from './model/meeting.types';
+export { mypageMeetingCountKey } from './model/meeting-keys';
 export { meetingsQueryOptions } from './model/meetings.options';
 export { useSearchInfiniteOption, useSearchInfiniteOptions } from './model/search.queries';
 export { useDetailRouter } from './model/use-detail-router';

--- a/src/entities/meeting/model/meeting-keys.ts
+++ b/src/entities/meeting/model/meeting-keys.ts
@@ -1,0 +1,1 @@
+export const mypageMeetingCountKey = ['users', 'me', 'meeting-count'] as const;

--- a/src/features/meeting-create/model/use-create-meeting.test.ts
+++ b/src/features/meeting-create/model/use-create-meeting.test.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { toast } from 'sonner';
 
-import { meetingsApi } from '@/entities/meeting';
+import { meetingsApi, mypageMeetingCountKey } from '@/entities/meeting';
 import { meetingCommentApi } from '@/entities/meeting-comment';
 import type { CreateMeeting } from '@/shared/types/generated-client/models/CreateMeeting';
 
@@ -14,6 +14,7 @@ jest.mock('@/entities/meeting', () => ({
   meetingsApi: {
     create: jest.fn(),
   },
+  mypageMeetingCountKey: ['users', 'me', 'meeting-count'],
 }));
 
 jest.mock('sonner', () => ({
@@ -32,11 +33,13 @@ jest.mock('@/entities/meeting-comment', () => ({
 const mockCreate = meetingsApi.create as jest.Mock;
 const mockSyncCreateMeeting = meetingCommentApi.syncCreateMeeting as jest.Mock;
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+const createWrapper = (queryClient: QueryClient) => {
   return ({ children }: { children: React.ReactNode }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 };
+
+const createQueryClient = () =>
+  new QueryClient({ defaultOptions: { mutations: { retry: false } } });
 
 /** 모달의 handleSubmit과 동일한 변환 로직 */
 const MOCK_PAYLOAD: CreateMeeting = {
@@ -62,7 +65,7 @@ describe('useCreateMeeting', () => {
     mockSyncCreateMeeting.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useCreateMeeting(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper(createQueryClient()),
     });
 
     result.current.mutate(MOCK_PAYLOAD);
@@ -77,11 +80,29 @@ describe('useCreateMeeting', () => {
     expect(toast.success).toHaveBeenCalled();
   });
 
+  it('모임 생성 성공 시 mypageMeetingCountKey를 invalidate한다', async () => {
+    const mockMeeting = { id: 1, hostId: 42, teamId: 'team-abc' };
+    mockCreate.mockResolvedValue(mockMeeting);
+    mockSyncCreateMeeting.mockResolvedValue(undefined);
+
+    const queryClient = createQueryClient();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateMeeting(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate(MOCK_PAYLOAD);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: mypageMeetingCountKey });
+  });
+
   it('모임 생성 실패 시 isError 상태가 되고 error toast를 띄운다', async () => {
     mockCreate.mockRejectedValue(new Error('모임 생성에 실패했습니다.'));
 
     const { result } = renderHook(() => useCreateMeeting(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper(createQueryClient()),
     });
 
     result.current.mutate(MOCK_PAYLOAD);

--- a/src/features/meeting-create/model/use-create-meeting.ts
+++ b/src/features/meeting-create/model/use-create-meeting.ts
@@ -1,12 +1,14 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { meetingsApi } from '@/entities/meeting';
+import { meetingsApi, mypageMeetingCountKey } from '@/entities/meeting';
 import { meetingCommentApi } from '@/entities/meeting-comment';
 import { CreateMeeting } from '@/shared/types/generated-client/models/CreateMeeting';
 
-export const useCreateMeeting = () =>
-  useMutation({
+export const useCreateMeeting = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
     mutationFn: (payload: CreateMeeting) => meetingsApi.create(payload),
     onSuccess: (meeting) => {
       meetingCommentApi
@@ -18,9 +20,11 @@ export const useCreateMeeting = () =>
         .catch((error: Error) => {
           console.error('[useCreateMeeting] comment sync failed:', error);
         });
+      void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       toast.success('모임이 생성되었습니다.');
     },
     onError: (error: Error) => {
       toast.error(error.message || '모임 생성 중 오류가 발생했습니다.');
     },
   });
+};

--- a/src/widgets/meeting-detail/model/meeting-detail.queries.test.ts
+++ b/src/widgets/meeting-detail/model/meeting-detail.queries.test.ts
@@ -1,0 +1,132 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
+
+import { meetingsApi, mypageMeetingCountKey } from '@/entities/meeting';
+
+import { useDeleteMeeting, useJoinMeeting, useLeaveMeeting } from './meeting-detail.queries';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/entities/meeting', () => ({
+  meetingsApi: {
+    join: jest.fn(),
+    leave: jest.fn(),
+    deleteMeeting: jest.fn(),
+  },
+  mypageMeetingCountKey: ['users', 'me', 'meeting-count'],
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockJoin = meetingsApi.join as jest.Mock;
+const mockLeave = meetingsApi.leave as jest.Mock;
+const mockDelete = meetingsApi.deleteMeeting as jest.Mock;
+
+const MEETING_ID = 1;
+
+const createWrapper = (queryClient: QueryClient) => {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useJoinMeeting', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('성공 시 mypageMeetingCountKey를 invalidate한다', async () => {
+    mockJoin.mockResolvedValue(undefined);
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useJoinMeeting(MEETING_ID), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: mypageMeetingCountKey });
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('실패 시 mypageMeetingCountKey를 invalidate하지 않는다', async () => {
+    mockJoin.mockRejectedValue(new Error('모임 참여에 실패했습니다.'));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useJoinMeeting(MEETING_ID), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: mypageMeetingCountKey });
+    expect(toast.error).toHaveBeenCalled();
+  });
+});
+
+describe('useLeaveMeeting', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('성공 시 mypageMeetingCountKey를 invalidate한다', async () => {
+    mockLeave.mockResolvedValue(undefined);
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useLeaveMeeting(MEETING_ID), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: mypageMeetingCountKey });
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('실패 시 mypageMeetingCountKey를 invalidate하지 않는다', async () => {
+    mockLeave.mockRejectedValue(new Error('모임 참여 취소에 실패했습니다.'));
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useLeaveMeeting(MEETING_ID), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: mypageMeetingCountKey });
+    expect(toast.error).toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteMeeting', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('성공 시 mypageMeetingCountKey를 invalidate한다', async () => {
+    mockDelete.mockResolvedValue(undefined);
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteMeeting(MEETING_ID), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: mypageMeetingCountKey });
+    expect(toast.success).toHaveBeenCalled();
+  });
+});

--- a/src/widgets/meeting-detail/model/meeting-detail.queries.ts
+++ b/src/widgets/meeting-detail/model/meeting-detail.queries.ts
@@ -6,7 +6,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import type { Meeting } from '@/entities/meeting';
-import { meetingsApi } from '@/entities/meeting';
+import { meetingsApi, mypageMeetingCountKey } from '@/entities/meeting';
 
 export const meetingDetailKeys = {
   detail: (id: number) => ['meetings', 'detail', id] as const,
@@ -59,10 +59,12 @@ export const useConfirmMeeting = (id: number) => {
 
 export const useDeleteMeeting = (id: number) => {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: () => meetingsApi.deleteMeeting(id),
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       toast.success('모임이 삭제되었습니다.');
       router.push('/meetings');
     },
@@ -104,6 +106,7 @@ export const useJoinMeeting = (id: number) => {
     onSettled: (_data, error) => {
       if (error == null) {
         void queryClient.invalidateQueries({ queryKey: meetingDetailKeys.detail(id) });
+        void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       }
     },
   });
@@ -141,6 +144,7 @@ export const useLeaveMeeting = (id: number) => {
     onSettled: (_data, error) => {
       if (error == null) {
         void queryClient.invalidateQueries({ queryKey: meetingDetailKeys.detail(id) });
+        void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       }
     },
   });

--- a/src/widgets/meeting-detail/model/meeting-detail.queries.ts
+++ b/src/widgets/meeting-detail/model/meeting-detail.queries.ts
@@ -101,12 +101,12 @@ export const useJoinMeeting = (id: number) => {
       toast.error(error.message || '모임 참여 중 오류가 발생했습니다.');
     },
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       toast.success('모임에 참여했습니다.');
     },
     onSettled: (_data, error) => {
       if (error == null) {
         void queryClient.invalidateQueries({ queryKey: meetingDetailKeys.detail(id) });
-        void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       }
     },
   });
@@ -139,12 +139,12 @@ export const useLeaveMeeting = (id: number) => {
       toast.error(error.message || '모임 참여 취소 중 오류가 발생했습니다.');
     },
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       toast.success('모임 참여를 취소했습니다.');
     },
     onSettled: (_data, error) => {
       if (error == null) {
         void queryClient.invalidateQueries({ queryKey: meetingDetailKeys.detail(id) });
-        void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       }
     },
   });

--- a/src/widgets/mypage/api/mypage.api.ts
+++ b/src/widgets/mypage/api/mypage.api.ts
@@ -1,6 +1,8 @@
 import { fetchClient } from '@/shared/api/fetch-client';
 import { FavoriteList, UserMeetingsResponse } from '@/shared/types/generated-client';
 
+const MAX_FETCH_SIZE = 100;
+
 export const mypageApi = {
   fetchJoinedMeetings: async (): Promise<UserMeetingsResponse> => {
     const res = await fetchClient.get('/users/me/meetings?type=joined');
@@ -18,5 +20,12 @@ export const mypageApi = {
     const res = await fetchClient.get('/favorites');
     if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
     return res.json();
+  },
+
+  fetchMeetingCount: async (): Promise<number> => {
+    const res = await fetchClient.get(`/users/me/meetings?size=${MAX_FETCH_SIZE}`);
+    if (!res.ok) return 0;
+    const data: UserMeetingsResponse = await res.json();
+    return data.data.length;
   },
 };

--- a/src/widgets/mypage/api/mypage.api.ts
+++ b/src/widgets/mypage/api/mypage.api.ts
@@ -23,7 +23,7 @@ export const mypageApi = {
   },
 
   fetchMeetingCount: async (): Promise<number> => {
-    const res = await fetchClient.get(`/users/me/meetings?size=${MAX_FETCH_SIZE}`);
+    const res = await fetchClient.get(`/users/me/meetings?type=joined&size=${MAX_FETCH_SIZE}`);
     if (!res.ok) return 0;
     const data: UserMeetingsResponse = await res.json();
     return data.data.length;

--- a/src/widgets/mypage/index.ts
+++ b/src/widgets/mypage/index.ts
@@ -4,6 +4,6 @@ export {
   fetchMeServer,
   fetchPostCountServer,
 } from './api/mypage.api.server';
-export { CountCard, FavoriteCountCard } from './ui/count-card';
+export { CountCard, FavoriteCountCard, MeetingCountCard } from './ui/count-card';
 export { MeetingTabs } from './ui/meeting-tabs';
 export { UserCard } from './ui/user-card';

--- a/src/widgets/mypage/index.ts
+++ b/src/widgets/mypage/index.ts
@@ -4,6 +4,6 @@ export {
   fetchMeServer,
   fetchPostCountServer,
 } from './api/mypage.api.server';
-export { CountCard } from './ui/count-card';
+export { CountCard, FavoriteCountCard } from './ui/count-card';
 export { MeetingTabs } from './ui/meeting-tabs';
 export { UserCard } from './ui/user-card';

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { mypageMeetingCountKey } from '@/entities/meeting';
+
 import { mypageApi } from '../api/mypage.api';
 
 import { FIVE_MINUTES_IN_MS } from './mypage.constants';
@@ -8,6 +10,7 @@ export const mypageKeys = {
   joinedMeetings: () => ['users', 'me', 'joined-meetings'] as const,
   createdMeetings: () => ['users', 'me', 'created-meetings'] as const,
   favoriteMeetings: () => ['users', 'me', 'favorite-meetings'] as const,
+  meetingCount: () => mypageMeetingCountKey,
 } as const;
 
 export const useJoinedMeetings = () =>
@@ -28,5 +31,13 @@ export const useFavoriteMeetings = () =>
   useQuery({
     queryKey: mypageKeys.favoriteMeetings(),
     queryFn: mypageApi.fetchFavoriteMeetings,
+    staleTime: FIVE_MINUTES_IN_MS,
+  });
+
+export const useMeetingCount = (initialCount: number) =>
+  useQuery({
+    queryKey: mypageKeys.meetingCount(),
+    queryFn: mypageApi.fetchMeetingCount,
+    initialData: initialCount,
     staleTime: FIVE_MINUTES_IN_MS,
   });

--- a/src/widgets/mypage/ui/count-card/count-card.tsx
+++ b/src/widgets/mypage/ui/count-card/count-card.tsx
@@ -4,6 +4,8 @@ import { useFavoritesCount } from '@/entities/favorites';
 import { cn } from '@/shared/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 
+import { useMeetingCount } from '../../model/mypage.queries';
+
 import { CountCardProps } from './count-card.types';
 import { cardVariants, countVariants } from './count-card.variants';
 
@@ -31,4 +33,9 @@ export function CountCard({ count, variant = 'meeting', className }: CountCardPr
 export function FavoriteCountCard({ initialCount }: { initialCount: number }) {
   const { data: count } = useFavoritesCount(initialCount);
   return <CountCard variant="favorite" count={count} />;
+}
+
+export function MeetingCountCard({ initialCount }: { initialCount: number }) {
+  const { data: count } = useMeetingCount(initialCount);
+  return <CountCard variant="meeting" count={count} />;
 }

--- a/src/widgets/mypage/ui/count-card/count-card.tsx
+++ b/src/widgets/mypage/ui/count-card/count-card.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useFavoritesCount } from '@/entities/favorites';
 import { cn } from '@/shared/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 
@@ -23,4 +26,9 @@ export function CountCard({ count, variant = 'meeting', className }: CountCardPr
       </CardContent>
     </Card>
   );
+}
+
+export function FavoriteCountCard({ initialCount }: { initialCount: number }) {
+  const { data: count } = useFavoritesCount(initialCount);
+  return <CountCard variant="favorite" count={count} />;
 }

--- a/src/widgets/mypage/ui/count-card/index.ts
+++ b/src/widgets/mypage/ui/count-card/index.ts
@@ -1,1 +1,1 @@
-export { CountCard, FavoriteCountCard } from './count-card';
+export { CountCard, FavoriteCountCard, MeetingCountCard } from './count-card';

--- a/src/widgets/mypage/ui/count-card/index.ts
+++ b/src/widgets/mypage/ui/count-card/index.ts
@@ -1,1 +1,1 @@
-export { CountCard } from './count-card';
+export { CountCard, FavoriteCountCard } from './count-card';


### PR DESCRIPTION
## [Feature] CountCard - 마이페이지 참여/찜 모임 count 실시간 반영

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 마이페이지 참여 모임/찜한 모임 count 카드가 새로고침 없이는 반영되지 않는 문제를 해결했습니다.
- `entities/meeting`에 `mypageMeetingCountKey` 공유 상수를 추가하여 레이어 간 query key 중복을 제거했습니다.
- `MeetingCountCard`, `FavoriteCountCard`를 클라이언트 컴포넌트로 분리하고 `initialData`로 SSR 값을 활용합니다.
- 모임 참여/탈퇴/삭제/생성 mutation 성공 시 `mypageMeetingCountKey`를 invalidate하도록 추가했습니다.
- 모임 상세 페이지 접근 불가로 수동 테스트가 어려운 상황이어서 관련 mutation에 대한 단위 테스트를 작성했습니다.

### 🧪 테스트 방법 (How to Test)

**참여 모임 count**

1. 모임 상세 페이지에서 모임에 참여하거나 탈퇴합니다.
2. 마이페이지로 이동했을 때 새로고침 없이 `참여 모임 N개` count가 반영되는지 확인합니다.
3. 모임 생성/삭제 후 동일하게 확인합니다.

**찜한 모임 count**

1. 모임 카드에서 찜 버튼을 토글합니다.
2. 마이페이지로 이동했을 때 새로고침 없이 `찜한 모임 N개` count가 반영되는지 확인합니다.

**단위 테스트**

```bash
npx jest use-create-meeting
npx jest meeting-detail.queries

