### PR TITLE
[Fix]: 마이페이지 찜 탭에서 찜 해제 시 즉시 반영 안됨

### DIFF
--- a/src/entities/favorites/api/favorites.api.ts
+++ b/src/entities/favorites/api/favorites.api.ts
@@ -1,6 +1,12 @@
 import { fetchClient } from '@/shared/api/fetch-client';
+import { FavoriteList } from '@/shared/types/generated-client';
 
 export const favoritesApi = {
+  async fetchList(): Promise<FavoriteList> {
+    const res = await fetchClient.get('/favorites');
+    if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
+    return res.json();
+  },
   async favoritePost(meetingId: number): Promise<void> {
     const response = await fetchClient.post(`/meetings/${meetingId}/favorites`);
     if (!response.ok) {

--- a/src/entities/favorites/index.ts
+++ b/src/entities/favorites/index.ts
@@ -1,3 +1,3 @@
 export { favoritesApi } from './api/favorites.api';
 export { favoriteKeys } from './model/favorite-keys';
-export { useFavoritesCount } from './model/favorites.queries';
+export { useFavoriteList,useFavoritesCount } from './model/favorites.queries';

--- a/src/entities/favorites/model/favorites.queries.ts
+++ b/src/entities/favorites/model/favorites.queries.ts
@@ -18,3 +18,10 @@ export const useFavoritesCount = (initialCount: number, options?: { enabled?: bo
     ...options,
   });
 };
+
+export const useFavoriteList = () =>
+  useQuery({
+    queryKey: favoriteKeys.list(),
+    queryFn: favoritesApi.fetchList,
+    staleTime: 1000 * 60 * 5,
+  });

--- a/src/features/favorites/model/favorites.mutations.ts
+++ b/src/features/favorites/model/favorites.mutations.ts
@@ -30,9 +30,11 @@ export const useToggleFavorite = () => {
       queryClient.setQueryData(favoriteKeys.count(), context?.previousCount);
     },
     onSuccess: (_data, { meetingId, isFavorited }) => {
-      queryClient.invalidateQueries({ queryKey: favoriteKeys.count() });
-      queryClient.invalidateQueries({ queryKey: favoriteKeys.list() });
       queryClient.setQueryData(favoriteKeys.status(meetingId), isFavorited);
+      return Promise.all([
+        queryClient.invalidateQueries({ queryKey: favoriteKeys.count() }),
+        queryClient.invalidateQueries({ queryKey: favoriteKeys.list() }),
+      ]);
     },
   });
 };

--- a/src/features/favorites/model/favorites.mutations.ts
+++ b/src/features/favorites/model/favorites.mutations.ts
@@ -31,6 +31,7 @@ export const useToggleFavorite = () => {
     },
     onSuccess: (_data, { meetingId, isFavorited }) => {
       queryClient.invalidateQueries({ queryKey: favoriteKeys.count() });
+      queryClient.invalidateQueries({ queryKey: favoriteKeys.list() });
       queryClient.setQueryData(favoriteKeys.status(meetingId), isFavorited);
     },
   });

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { favoriteKeys } from '@/entities/favorites';
 import { mypageMeetingCountKey } from '@/entities/meeting';
 
 import { mypageApi } from '../api/mypage.api';
@@ -9,7 +10,6 @@ import { FIVE_MINUTES_IN_MS } from './mypage.constants';
 export const mypageKeys = {
   joinedMeetings: () => ['users', 'me', 'joined-meetings'] as const,
   createdMeetings: () => ['users', 'me', 'created-meetings'] as const,
-  favoriteMeetings: () => ['users', 'me', 'favorite-meetings'] as const,
   meetingCount: () => mypageMeetingCountKey,
 } as const;
 
@@ -29,7 +29,7 @@ export const useCreatedMeetings = () =>
 
 export const useFavoriteMeetings = () =>
   useQuery({
-    queryKey: mypageKeys.favoriteMeetings(),
+    queryKey: favoriteKeys.list(),
     queryFn: mypageApi.fetchFavoriteMeetings,
     staleTime: FIVE_MINUTES_IN_MS,
   });

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { favoriteKeys } from '@/entities/favorites';
+import { useFavoriteList } from '@/entities/favorites';
 import { mypageMeetingCountKey } from '@/entities/meeting';
 
 import { mypageApi } from '../api/mypage.api';
@@ -27,12 +27,7 @@ export const useCreatedMeetings = () =>
     staleTime: FIVE_MINUTES_IN_MS,
   });
 
-export const useFavoriteMeetings = () =>
-  useQuery({
-    queryKey: favoriteKeys.list(),
-    queryFn: mypageApi.fetchFavoriteMeetings,
-    staleTime: FIVE_MINUTES_IN_MS,
-  });
+export { useFavoriteList as useFavoriteMeetings };
 
 export const useMeetingCount = (initialCount: number) =>
   useQuery({


### PR DESCRIPTION
## [Fix]: 마이페이지 찜 탭에서 찜 해제 시 즉시 반영 안됨

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- useFavoriteMeetings queryKey를 mypageKeys.favoriteMeetings() → favoriteKeys.list()로 통일
- useToggleFavorite onSuccess에서 favoriteKeys.list() invalidate 추가


### 🧪 테스트 방법 (How to Test)

1. 마이페이지에서 "찜한 모임" 탭으로 진입합니다.
2. 모임 카드에서 하트 버튼을 클릭하여 찜을 해제합니다.
3. 새로고침 없이 해당 카드가 탭에서 즉시 사라지는지 확인합니다.