### PR TITLE
[Feat]: 소소톡 UX 피드백 반영 및 공유/상세 인터랙션 개선

### DIFF
--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
@@ -109,9 +109,13 @@ describe('MeetingCommentItem', () => {
         wrapper: createWrapper(),
       });
 
-      const button = screen.getByRole('button', { name: '\uB354\uBCF4\uAE30' });
+      const button = screen.getByRole('button', {
+        name: '\uB354\uBCF4\uAE30',
+        hidden: true,
+      });
 
-      expect(button.closest('div.invisible')).toBeTruthy();
+      expect(button.parentElement).toHaveClass('invisible');
+      expect(button.parentElement).toHaveClass('pointer-events-none');
     });
   });
 


### PR DESCRIPTION

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- #311 관련 소소톡 UX 피드백을 반영했습니다.
- 소소톡 상세 페이지에 공유 모달을 추가하고 웹 공유 / 링크 복사 / 카카오 공유 분기를 정리했습니다.
- 소소톡 상세 액션 및 댓글 영역 UI를 다듬고 관련 테스트를 보강했습니다.
- 소소톡 본문 내 불릿/숫자 리스트 정렬 스타일을 보정했습니다.
- 모임 댓글의 대댓글 textarea가 닫힌 뒤 다시 열릴 때 초기화되도록 수정했습니다.
- 좋아요 pending 처리, 소소톡 작성 페이지 edge case, 머지 후 깨진 테스트와 필터바 lint 이슈를 함께 정리했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 `npm.cmd run test -- --runInBand` 를 실행합니다.
2. 소소톡 상세 페이지에서 공유 버튼을 눌러 공유 모달이 열리는지 확인합니다.
3. 링크 복사 / 웹 공유 / 카카오 공유 버튼이 정상적으로 동작하는지 확인합니다.
4. 소소톡 상세 본문에 불릿 또는 숫자 리스트가 포함된 게시글에서 정렬이 자연스럽게 보이는지 확인합니다.
5. 모임 상세 댓글에서 답글 입력창을 열고 내용을 입력한 뒤 닫았다가 다시 열었을 때 textarea가 초기화되는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
