### PR TITLE
## PR 제목: [Fix]: MeetingCommentItem 테스트 auth store 오류 수정

### DIFF
--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
@@ -2,8 +2,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { useAuthStore } from '@/entities/auth';
-
 import { MeetingCommentItem } from './meeting-comment-item';
 import type { MeetingComment } from './meeting-comment-section.types';
 
@@ -17,6 +15,7 @@ jest.mock('@/features/meeting-comment', () => ({
   useDeleteComment: jest.fn(() => ({ mutate: jest.fn() })),
   useCreateComment: jest.fn(() => ({ mutate: jest.fn() })),
 }));
+
 jest.mock('./format-date', () => ({
   formatCommentDate: jest.fn((date: string) => date),
 }));
@@ -61,7 +60,7 @@ describe('MeetingCommentItem', () => {
   });
 
   it('renders author, content, date, and like count', () => {
-    render(<MeetingCommentItem comment={{ ...mockComment, isMine: false }} meetingId={2} />, {
+    render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
       wrapper: createWrapper(),
     });
 
@@ -106,17 +105,11 @@ describe('MeetingCommentItem', () => {
     });
 
     it('hides the menu button for other users comments', () => {
-      render(<MeetingCommentItem comment={mockComment} meetingId={2} />, {
+      render(<MeetingCommentItem comment={mockComment} meetingId={1} />, {
         wrapper: createWrapper(),
       });
 
-      const button = screen.getByRole('button', {
-        name: '\uB354\uBCF4\uAE30',
-        hidden: true,
-      });
-
-      expect(button.parentElement).toHaveClass('invisible');
-      expect(button.parentElement).toHaveClass('pointer-events-none');
+      expect(screen.queryByRole('button', { name: '\uB354\uBCF4\uAE30' })).not.toBeInTheDocument();
     });
   });
 
@@ -194,13 +187,6 @@ describe('MeetingCommentItem', () => {
   });
 
   describe('replies', () => {
-    beforeEach(() => {
-      useAuthStore.setState({ isAuthenticated: true });
-    });
-    afterEach(() => {
-      useAuthStore.setState({ isAuthenticated: false });
-    });
-
     it('applies the reply background style for nested replies', () => {
       const { container } = render(
         <MeetingCommentItem comment={{ ...mockComment, parentId: 1 }} isReply meetingId={1} />,

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx
@@ -109,7 +109,9 @@ describe('MeetingCommentItem', () => {
         wrapper: createWrapper(),
       });
 
-      expect(screen.queryByRole('button', { name: '\uB354\uBCF4\uAE30' })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: '\uB354\uBCF4\uAE30', hidden: true })
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION


### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- `develop`에 머지된 이후 `MeetingCommentItem` 테스트에서 `useAuthStore.setState` 호출로 인해 CI가 실패하던 문제를 수정했습니다.
- 현재 `develop`의 `MeetingCommentItem` 구현에 맞게 비작성자 `더보기` 버튼 테스트 기대값을 정리했습니다.
- 답글 관련 테스트가 안정적으로 동작하도록 auth store mock 기반 테스트 흐름을 유지했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 `npm.cmd run test -- --runInBand src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.test.tsx` 를 실행합니다.
2. 테스트가 모두 통과하는지 확인합니다.
3. GitHub Actions에서 `develop` 기준 Preview 배포 워크플로우가 더 이상 해당 테스트로 실패하지 않는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
