### PR TITLE
[Style]: 모임 상세 페이지 반응형 레이아웃 개선

### DIFF
--- a/src/app/meetings/[id]/page.tsx
+++ b/src/app/meetings/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function MeetingDetailPage({ params }: Props) {
   const meetingId = Number(id);
 
   return (
-    <main className="space-y-[30px] py-10">
+    <main className="space-y-[30px] py-6 md:py-8 lg:py-10">
       <Suspense fallback={<MeetingHeroSkeleton />}>
         <MeetingHeroFetcher meetingId={meetingId} />
       </Suspense>

--- a/src/features/favorites/ui/heart-button/heart-button.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.tsx
@@ -32,6 +32,7 @@ const ringSizeClass = {
 export function HeartButton({
   className,
   sizeClass,
+  iconClass,
   size = 'lg',
   isFavorited = false,
   meetingId,
@@ -71,7 +72,7 @@ export function HeartButton({
           whileTap={isAuthenticated ? { scale: 0.8, transition: { duration: 0.1 } } : undefined}
           className={HEART_BUTTON_ICON_WRAPPER_CLASS}
         >
-          <Image src={src} alt="좋아요" width={iconPx} height={iconPx} />
+          <Image src={src} alt="좋아요" width={iconPx} height={iconPx} className={iconClass} />
         </motion.div>
       </Button>
     </div>

--- a/src/features/favorites/ui/heart-button/heart-button.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.tsx
@@ -31,6 +31,7 @@ const ringSizeClass = {
 
 export function HeartButton({
   className,
+  sizeClass,
   size = 'lg',
   isFavorited = false,
   meetingId,
@@ -58,7 +59,7 @@ export function HeartButton({
       <Button
         variant="ghost"
         size="icon"
-        className={cn(HEART_BUTTON_CLASS, ringSizeClass[size])}
+        className={cn(HEART_BUTTON_CLASS, sizeClass ?? ringSizeClass[size])}
         onClick={handleClick}
       >
         <motion.div

--- a/src/features/favorites/ui/heart-button/heart-button.types.ts
+++ b/src/features/favorites/ui/heart-button/heart-button.types.ts
@@ -3,6 +3,7 @@ import { MeetingWithHost } from '@/shared/types/generated-client';
 export interface HeartButtonProps extends Pick<MeetingWithHost, 'isFavorited'> {
   className?: string;
   sizeClass?: string;
+  iconClass?: string;
   size?: 'lg' | 'md' | 'sm';
   meetingId: number;
 }

--- a/src/features/favorites/ui/heart-button/heart-button.types.ts
+++ b/src/features/favorites/ui/heart-button/heart-button.types.ts
@@ -2,6 +2,7 @@ import { MeetingWithHost } from '@/shared/types/generated-client';
 
 export interface HeartButtonProps extends Pick<MeetingWithHost, 'isFavorited'> {
   className?: string;
+  sizeClass?: string;
   size?: 'lg' | 'md' | 'sm';
   meetingId: number;
 }

--- a/src/shared/ui/comment-input/comment-input.tsx
+++ b/src/shared/ui/comment-input/comment-input.tsx
@@ -79,7 +79,7 @@ export function CommentInput({
             event.preventDefault();
             handleSubmit();
           }}
-          className="text-sosoeat-gray-900 placeholder:text-sosoeat-gray-700 max-h-40 min-h-[23px] flex-1 resize-none border-0 bg-transparent px-0 py-1.5 text-base font-normal shadow-none focus-visible:ring-0 md:text-base"
+          className="text-sosoeat-gray-900 placeholder:text-sosoeat-gray-700 max-h-40 min-h-[23px] flex-1 resize-none overflow-hidden border-0 bg-transparent px-0 py-1.5 text-base font-normal shadow-none focus-visible:ring-0 md:text-base"
         />
 
         <Button

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -66,7 +66,7 @@ export function MeetingCommentItem({
       <div className={cn('px-4 py-3', isReply && 'bg-sosoeat-orange-100 rounded-[24px]')}>
         <div className="flex gap-2">
           {/* ── 아바타 ── */}
-          <Avatar className="size-[54px] shrink-0">
+          <Avatar className="size-10 shrink-0 md:size-[54px]">
             <AvatarImage src={author.profileUrl ?? undefined} alt={author.nickname} />
             <AvatarFallback className="text-sosoeat-orange-600">
               <UserRound className="size-6" />
@@ -213,7 +213,7 @@ export function MeetingCommentItem({
 
       {/* ── 대댓글 목록 ── */}
       {replies && replies.filter((r) => !r.isDeleted).length > 0 && (
-        <div className="mt-3 ml-[78px] space-y-3">
+        <div className="mt-3 ml-14 space-y-3 md:ml-[78px]">
           {replies
             .filter((r) => !r.isDeleted)
             .map((reply) => (

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -213,7 +213,7 @@ export function MeetingCommentItem({
 
       {/* ── 대댓글 목록 ── */}
       {replies && replies.filter((r) => !r.isDeleted).length > 0 && (
-        <div className="mt-3 ml-14 space-y-3 md:ml-[78px]">
+        <div className="mt-3 ml-16 space-y-3 md:ml-[78px]">
           {replies
             .filter((r) => !r.isDeleted)
             .map((reply) => (

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.tsx
@@ -55,7 +55,7 @@ export function MeetingCommentSection({
   return (
     <section
       className={cn(
-        'border-sosoeat-gray-200 w-full rounded-[24px] border bg-white px-6 py-4',
+        'border-sosoeat-gray-200 w-full rounded-[24px] border bg-white px-4 py-4 md:px-6',
         className
       )}
     >

--- a/src/widgets/meeting-detail/ui/meeting-description-section/meeting-description-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-description-section/meeting-description-section.tsx
@@ -5,8 +5,8 @@ interface MeetingDescriptionSectionProps {
 export function MeetingDescriptionSection({ description }: MeetingDescriptionSectionProps) {
   return (
     <section>
-      <h2 className="text-sosoeat-gray-900 mb-3 text-2xl font-semibold">모임 설명</h2>
-      <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-12 py-10">
+      <h2 className="text-sosoeat-gray-900 mb-3 text-xl font-semibold md:text-2xl">모임 설명</h2>
+      <div className="border-sosoeat-gray-200 mt-5 rounded-[16px] border bg-white px-5 py-6 md:px-8 md:py-8 lg:px-12 lg:py-10">
         <p className="text-sosoeat-gray-800 text-base font-normal whitespace-pre-line md:text-lg">
           {description}
         </p>

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
@@ -20,7 +20,7 @@ export function ActionButton({ config, category, onClick, pending }: ActionButto
   if (config.variant === 'disabled') {
     return (
       <Button
-        className="text-sosoeat-gray-700 border-sosoeat-gray-300 bg-sosoeat-gray-200 h-full w-full cursor-not-allowed rounded-2xl border-2 text-sm md:text-xl"
+        className="text-sosoeat-gray-700 border-sosoeat-gray-300 bg-sosoeat-gray-200 h-full w-full cursor-not-allowed rounded-2xl border-2 text-sm md:text-base lg:text-xl"
         disabled
       >
         {config.label}

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
@@ -17,7 +17,7 @@ export const CATEGORY_LABEL: Record<MeetingCategory, string> = {
 
 /** 기본 액션 버튼 (참여하기 / 모임 확정하기) */
 export const actionButtonVariants = cva(
-  'h-full w-full rounded-2xl text-sm md:text-xl focus-visible:ring-0 focus-visible:border-transparent',
+  'h-full w-full rounded-2xl text-sm md:text-base lg:text-xl focus-visible:ring-0 focus-visible:border-transparent',
   {
     variants: {
       category: {
@@ -30,7 +30,7 @@ export const actionButtonVariants = cva(
 
 /** 흰 버튼 (참여 취소하기 / 공유하기) */
 export const outlineButtonVariants = cva(
-  'ring-0 h-full w-full rounded-2xl bg-white text-normal md:text-xl shadow-inner focus-visible:ring-0 focus-visible:border-transparent',
+  'ring-0 h-full w-full rounded-2xl bg-white text-sm md:text-base lg:text-xl shadow-inner focus-visible:ring-0 focus-visible:border-transparent',
   {
     variants: {
       category: {

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
@@ -161,13 +161,20 @@ interface ActionRowProps {
 function ActionRow({ actionButton, meetingId, isFavorited }: ActionRowProps) {
   return (
     <div className="flex items-center gap-2">
-      <div className="h-10 w-full md:h-[62px]">{actionButton}</div>
-      {/* sm·md: 40×40 */}
+      <div className="h-10 w-full md:h-[52px] lg:h-[62px]">{actionButton}</div>
+      {/* sm: 40×40 */}
       <HeartButton
         meetingId={meetingId}
         isFavorited={isFavorited}
         size="sm"
-        className="border-sosoeat-gray-500 relative inset-auto m-0 lg:hidden"
+        className="border-sosoeat-gray-500 relative inset-auto m-0 md:hidden"
+      />
+      {/* md: 50×50 */}
+      <HeartButton
+        meetingId={meetingId}
+        isFavorited={isFavorited}
+        size="md"
+        className="border-sosoeat-gray-500 relative inset-auto m-0 hidden md:block lg:hidden"
       />
       {/* lg: 60×60 */}
       <HeartButton

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
@@ -168,26 +168,12 @@ function ActionRow({ actionButton, meetingId, isFavorited }: ActionRowProps) {
   return (
     <div className="flex items-center gap-2">
       <div className="h-10 w-full md:h-[52px] lg:h-[62px]">{actionButton}</div>
-      {/* sm: 40×40 */}
-      <HeartButton
-        meetingId={meetingId}
-        isFavorited={isFavorited}
-        size="sm"
-        className="border-sosoeat-gray-500 relative inset-auto m-0 md:hidden"
-      />
-      {/* md: 50×50 */}
-      <HeartButton
-        meetingId={meetingId}
-        isFavorited={isFavorited}
-        size="md"
-        className="border-sosoeat-gray-500 relative inset-auto m-0 hidden md:block lg:hidden"
-      />
-      {/* lg: 60×60 */}
       <HeartButton
         meetingId={meetingId}
         isFavorited={isFavorited}
         size="lg"
-        className="border-sosoeat-gray-500 relative inset-auto m-0 hidden lg:block"
+        sizeClass="size-10 md:size-[50px] lg:size-[60px]"
+        className="border-sosoeat-gray-500 relative inset-auto m-0"
       />
     </div>
   );

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
@@ -107,7 +107,7 @@ function HostRow({ name, profileImage, className }: HostRowProps) {
       </Avatar>
       <div>
         <p className="text-sosoeat-gray-600 text-xs font-medium">호스트</p>
-        <p className="text-sosoeat-gray-900 text-xs font-bold md:text-sm">{name}</p>
+        <p className="text-sosoeat-gray-900 text-xs font-bold md:text-sm lg:text-base">{name}</p>
       </div>
     </div>
   );
@@ -128,12 +128,18 @@ function InfoSection({ meeting, category, fullDateLabel, className }: InfoSectio
   return (
     <div className={cn('flex flex-col gap-1 md:gap-2', className)}>
       <InfoRow icon={<CalendarIcon />} category={category} label="날짜 및 시간">
-        <p className="text-sosoeat-gray-900 text-xs font-bold md:text-sm">{fullDateLabel}</p>
+        <p className="text-sosoeat-gray-900 text-xs font-bold md:text-sm lg:text-base">
+          {fullDateLabel}
+        </p>
       </InfoRow>
 
       <InfoRow icon={<MapPinIcon />} category={category} label="장소">
-        <p className="text-sosoeat-gray-900 text-xs font-bold md:text-sm">{meeting.region}</p>
-        <p className="text-sosoeat-gray-600 text-xs font-semibold md:text-sm">{meeting.address}</p>
+        <p className="text-sosoeat-gray-900 text-xs font-bold md:text-sm lg:text-base">
+          {meeting.region}
+        </p>
+        <p className="text-sosoeat-gray-600 text-xs font-semibold md:text-sm lg:text-base">
+          {meeting.address}
+        </p>
       </InfoRow>
 
       <ParticipantsRow
@@ -280,7 +286,7 @@ export function MeetingDetailCard(props: MeetingDetailCardProps) {
           md: text-2xl/bold
           lg: text-3xl/bold
           ════════════════════════════════════════ */}
-      <h2 className="line-clamp-2 text-xl leading-snug font-semibold md:line-clamp-none md:text-2xl md:font-bold">
+      <h2 className="line-clamp-2 text-xl leading-snug font-semibold md:line-clamp-none md:text-2xl md:font-bold lg:text-3xl">
         {meeting.name}
       </h2>
 

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.tsx
@@ -173,6 +173,7 @@ function ActionRow({ actionButton, meetingId, isFavorited }: ActionRowProps) {
         isFavorited={isFavorited}
         size="lg"
         sizeClass="size-10 md:size-[50px] lg:size-[60px]"
+        iconClass="size-6 md:size-[38px] lg:size-10"
         className="border-sosoeat-gray-500 relative inset-auto m-0"
       />
     </div>

--- a/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
@@ -93,14 +93,14 @@ export function MeetingHeroSection({ meetingId }: MeetingHeroSectionProps) {
 
   return (
     <>
-      <div className="flex flex-col gap-6 md:flex-row">
-        <div className="relative h-[241px] w-full overflow-hidden rounded-[24px] md:h-auto md:min-w-0 md:flex-1">
+      <div className="flex flex-col gap-4 md:flex-row md:gap-6">
+        <div className="relative w-full overflow-hidden rounded-[24px] max-md:aspect-[3/2] md:min-w-0 md:flex-1">
           <Image
             src={meeting.image}
             alt={meeting.name}
             fill
             priority
-            sizes="(max-width: 768px) 670px, 654px"
+            sizes="(max-width: 767px) calc(100vw - 32px), calc(50vw - 40px)"
             draggable={false}
             className="object-cover"
           />

--- a/src/widgets/meeting-detail/ui/meeting-location-section/meeting-location-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/meeting-location-section.tsx
@@ -34,7 +34,7 @@ export function MeetingLocationSection({
 
   return (
     <section>
-      <h2 className="text-sosoeat-gray-900 mb-3 text-2xl font-semibold">모임 장소</h2>
+      <h2 className="text-sosoeat-gray-900 mb-3 text-xl font-semibold md:text-2xl">모임 장소</h2>
       <div className="border-sosoeat-gray-200 mt-5 overflow-hidden rounded-[16px] border">
         <KakaoMapLoader
           appKey={kakaoMapAppKey}

--- a/src/widgets/meeting-detail/ui/meeting-recommended-section/meeting-recommended-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-recommended-section/meeting-recommended-section.tsx
@@ -18,7 +18,9 @@ export function MeetingRecommendedSection({
 
   return (
     <section>
-      <h2 className="text-sosoeat-gray-900 mb-4 text-2xl font-semibold">이런 모임은 어때요?</h2>
+      <h2 className="text-sosoeat-gray-900 mb-4 text-xl font-semibold md:text-2xl">
+        이런 모임은 어때요?
+      </h2>
       <ScrollArea className="mt-5 w-full">
         <div className="flex w-max gap-6 pb-3">
           {recommendedMeetings.map((meeting) => (


### PR DESCRIPTION
 ### 📌 유형 (Type)

  - [ ] **Feat (기능):** 새로운 기능 추가
  - [ ] **Fix (버그 수정):** 버그 수정
  - [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
  - [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

  ### 📝 변경 사항 (Changes)

  closes #329

  `md`(768px) · `lg`(1024px) 브레이크포인트 전환 시 크기가 급격하게 변하거나 고정되어 있던 문제를 수정했습니다.

  - **히어로 섹션**: 고정 높이(`h-[241px]`) → 모바일 `max-md:aspect-[3/2]`로 변경해 이미지 비율 유지 / gap `gap-4
  md:gap-6`                               
  - **상세 카드**: 액션 버튼 텍스트·높이, 정보 텍스트, 하트 버튼 크기에 `md` 중간 단계 추가
  - **섹션 공통**: 페이지·모임 설명·댓글 섹션 패딩 및 제목 크기 반응형 적용                                               
  - **댓글**: 아바타 `size-10 md:size-[54px]`, 대댓글 들여쓰기 수치 정확히 계산하여 수정 (64px → `ml-16`)
  - **HeartButton**: `sizeClass` prop 추가로 외부에서 크기 오버라이드 가능하게 하여 `MeetingDetailCard` 내 3개 DOM 분기를 
  1개로 통합                                                                                                              
                                                                                                                          
  > 디자인 시안 기준 수치와 일부 차이가 있으나, 반응형 대응을 위해 의도적으로 조정한 부분입니다.                          
                                                                                                                          
  ### 🧪 테스트 방법 (How to Test)                                                                                        
                                                                                                                          
  1. 로컬에서 앱 실행 후 `/meetings/[id]` 페이지로 이동합니다.
  2. DevTools에서 아래 뷰포트별로 확인합니다.                                                                             
     - **375px**: 이미지 3:2 비율 유지, 카드·댓글 텍스트 및 패딩 모바일 크기
     - **768px(md)**: 이미지 flex stretch, 버튼·텍스트·하트 버튼 중간 크기 전환                                           
     - **1024px(lg)**: 버튼·텍스트·패딩 최대 크기, 3열 레이아웃
  3. 댓글 > 대댓글이 있는 항목에서 대댓글 들여쓰기가 부모 텍스트 시작선에 맞는지 확인합니다.                              
  4. 하트 버튼이 기존 사용처(`main-page-card` 등)에서 정상 동작하는지 확인합니다.                                         
                                                                                                                          
  ### 📸 스크린샷 또는 영상 (Optional)                                                                                    
                                                                                                                          
  | 변경 전 (Before) | 변경 후 (After) |                                                                                  
  | :--------------: | :-------------: |                                                                                  
  |                  |                 |                                                                                  
                                                                                                                          
  ### 🚨 기타 참고 사항 (Notes)
                                                                                                                          
 - [x] **`HeartButton`에 `sizeClass`, `iconClass` prop이 추가되었습니다. 두 prop 모두 optional이며 기존 `size` 기반      
  기본값이 유지되므로 하위 호환성에 영향 없습니다.**         