### PR TITLE
[Feat]: 모임 상세 api 연동 및 찜 버튼 클릭 시 상세페이지 이동하지 않도록 이벤트 처리

### DIFF
--- a/src/features/favorites/ui/heart-button/heart-button.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.tsx
@@ -46,7 +46,10 @@ export function HeartButton({
   const src = isFavoritedState ? '/icons/main-page-heart.svg' : '/icons/main-page-not-heart.svg';
   const iconPx = sizeIcon[size];
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
     if (!isAuthenticated) {
       setLoginRequired(true);
       return;

--- a/src/features/favorites/ui/heart-button/heart-button.tsx
+++ b/src/features/favorites/ui/heart-button/heart-button.tsx
@@ -46,10 +46,7 @@ export function HeartButton({
   const src = isFavoritedState ? '/icons/main-page-heart.svg' : '/icons/main-page-not-heart.svg';
   const iconPx = sizeIcon[size];
 
-  const handleClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
+  const handleClick = () => {
     if (!isAuthenticated) {
       setLoginRequired(true);
       return;

--- a/src/widgets/mypage/model/mypage.service.ts
+++ b/src/widgets/mypage/model/mypage.service.ts
@@ -26,6 +26,7 @@ const toImageUrl = (image?: string) => (image?.startsWith('https://') ? image : 
 
 const toMeetingCard = (m: UserMeeting): MyPageCardProps => ({
   meetingId: m.id,
+  href: `/meetings/${m.id}`,
   title: m.name,
   currentCount: m.participantCount,
   maxCount: m.capacity,
@@ -43,6 +44,7 @@ export const toUserMeetingCards = (data: UserMeetingsResponse): MyPageCardProps[
 export const toFavoriteMeetingCards = (data: FavoriteList): MyPageCardProps[] =>
   data.data.map((f) => ({
     meetingId: f.meeting.id,
+    href: `/meetings/${f.meeting.id}`,
     title: f.meeting.name,
     currentCount: f.meeting.participantCount,
     maxCount: f.meeting.capacity,

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useTransition } from 'react';
 
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { useMeetingTabs } from '../../model/use-meeting-tabs';
@@ -64,7 +65,9 @@ export function MeetingTabs() {
           ) : (
             <div className="grid grid-cols-1 justify-items-center gap-4 py-4 lg:grid-cols-2 lg:justify-items-start">
               {cards.map((card) => (
-                <MyPageCard key={card.meetingId} {...card} />
+                <Link key={card.meetingId} href={`/meetings/${card.meetingId}`}>
+                  <MyPageCard {...card} />
+                </Link>
               ))}
             </div>
           )}

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useTransition } from 'react';
 
-import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { useMeetingTabs } from '../../model/use-meeting-tabs';
@@ -65,9 +64,7 @@ export function MeetingTabs() {
           ) : (
             <div className="grid grid-cols-1 justify-items-center gap-4 py-4 lg:grid-cols-2 lg:justify-items-start">
               {cards.map((card) => (
-                <Link key={card.meetingId} href={`/meetings/${card.meetingId}`}>
-                  <MyPageCard {...card} />
-                </Link>
+                <MyPageCard key={card.meetingId} {...card} href={`/meetings/${card.meetingId}`} />
               ))}
             </div>
           )}

--- a/src/widgets/mypage/ui/mypage-card/mypage-card.tsx
+++ b/src/widgets/mypage/ui/mypage-card/mypage-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 
 import { Calendar, Clock, LucideIcon, MapPin, UserRound } from 'lucide-react';
 
@@ -83,17 +84,20 @@ function StatusBadgeGroup({
       ) : (
         <EstablishmentStatusBadge confirmedAt={null} variant={variant} />
       )}
-      <HeartButton
-        className="relative -top-3 left-0 ml-auto max-md:hidden"
-        meetingId={meetingId}
-        isFavorited={isFavorited}
-      />
+      <div className="relative z-10 ml-auto max-md:hidden">
+        <HeartButton
+          className="relative -top-3 left-0"
+          meetingId={meetingId}
+          isFavorited={isFavorited}
+        />
+      </div>
     </div>
   );
 }
 
 export function MyPageCard({
   meetingId,
+  href,
   title,
   currentCount,
   maxCount,
@@ -113,11 +117,12 @@ export function MyPageCard({
   return (
     <Card
       className={cn(
-        'flex overflow-hidden rounded-4xl border-none p-0 shadow-none',
+        'relative flex overflow-hidden rounded-4xl border-none p-0 shadow-none',
         'gap-0 max-md:w-85.75 max-md:flex-col md:h-60 md:w-132.5 md:flex-row md:items-center md:gap-4 md:px-4 lg:w-full',
         className
       )}
     >
+      <Link href={href} aria-label={title} className="absolute inset-0 z-0" />
       {/* 이미지 */}
       <div className="relative shrink-0 overflow-hidden max-md:h-39 max-md:w-full max-md:rounded-t-4xl md:size-47 md:rounded-2xl">
         <Image src={imageUrl} alt={imageAlt ?? title} fill className="object-cover" />
@@ -125,11 +130,13 @@ export function MyPageCard({
         {/* 이미지 위 오버레이 (모바일 전용) */}
         <div className="absolute top-1 right-4 left-4 flex items-center justify-between md:hidden">
           <VariantBadge variant={variant} />
-          <HeartButton
-            className="relative top-3 left-1"
-            meetingId={meetingId}
-            isFavorited={isFavorited}
-          />
+          <div className="relative z-10">
+            <HeartButton
+              className="relative top-3 left-1"
+              meetingId={meetingId}
+              isFavorited={isFavorited}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/widgets/mypage/ui/mypage-card/mypage-card.types.ts
+++ b/src/widgets/mypage/ui/mypage-card/mypage-card.types.ts
@@ -1,5 +1,6 @@
 export interface MyPageCardProps {
   meetingId: number;
+  href: string;
   title: string;
   currentCount: number;
   maxCount: number;


### PR DESCRIPTION
## [Feat]: 모임 상세 api 연동 및 찜 버튼 클릭 시 상세페이지 이동하지 않도록 이벤트 처리

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

마이페이지 탭의 모임 카드 클릭 시 모임 상세 페이지(/meetings/[id])로 이동하도록 연동했습니다.

- mypage-card.types.ts — href prop 추가
- mypage-card.tsx — 카드 내부에 absolute inset-0 Link를 깔고 HeartButton은 z-10으로 분리하는 확장형 링크 패턴
- mypage.service.ts — 나의 모임 / 찜한 모임 / 내가 만든 모임 매핑 시 href 필드 추가
- meeting-tabs.tsx — 외부 Link 래퍼 제거 후 href prop으로 전달

### 🧪 테스트 방법 (How to Test)

1. 로그인 후 /mypage 접속합니다.
2. 나의 모임 탭에서 모임 카드 클릭 → /meetings/{id} 상세 페이지로 이동 확인합니다.
3. 찜한 모임 탭, 내가 만든 모임 탭에서도 동일하게 확인합니다.
4. 각 카드의 하트(찜) 버튼 클릭 → 상세 페이지로 이동하지 않고 찜 토글만 동작하는지 확인합니다.


