### PR TITLE
[Style]: home 페이지 추천 소잇 카드 반응형 그리드 레이아웃 개선 

### DIFF
--- a/src/entities/meeting/ui/main-page-card/main-page-card.constants.ts
+++ b/src/entities/meeting/ui/main-page-card/main-page-card.constants.ts
@@ -1,5 +1,5 @@
 export const MAIN_PAGE_CARD_CLASS =
-  'min-w-[360px] h-105 w-full max-w-90 cursor-pointer gap-0 overflow-hidden rounded-2xl border border-[#F3F4F6] bg-white py-0 font-medium shadow-none ring-0';
+  'h-105 w-full max-w-90 cursor-pointer gap-0 overflow-hidden rounded-2xl border border-[#F3F4F6] bg-white py-0 font-medium shadow-none ring-0';
 
 export const MAIN_PAGE_CARD_IMAGE_WRAPPER_CLASS =
   'relative h-[180px] w-full shrink-0 overflow-hidden';

--- a/src/widgets/home/ui/main-page-section/main-page-section.tsx
+++ b/src/widgets/home/ui/main-page-section/main-page-section.tsx
@@ -18,7 +18,7 @@ export async function MainPageSection() {
         <Image src="icons/main-page-twinkle.svg" alt="twinkle" width={18} height={18} />
         추천 소잇
       </h2>
-      <div className="grid grid-cols-1 place-items-center gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 justify-items-center gap-6 md:grid-cols-2 lg:grid-cols-3">
         {meetings.map((meeting) => (
           <MainPageCardWithHeart key={meeting.id} meeting={meeting} />
         ))}


### PR DESCRIPTION
  ### 📌 유형 (Type)                                                                                                   
  
  - [ ] **Feat (기능):** 새로운 기능 추가                                                                              
  - [ ] **Fix (버그 수정):** 버그 수정
  - [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)                                                       
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)                                                              
  - [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)                                        
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등
                                                                                                                       
  ### 📝 변경 사항 (Changes)
                                                                                                                       
  - 홈 화면 추천 소잇 섹션에서 뷰포트 크기에 따라 카드가 겹치거나 양쪽이 잘리는 문제가 있었습니다.                     
  - `MainPageCard`의 `min-w-[360px]`을 제거하여 좁은 뷰포트에서 카드가 그리드 셀을 초과하는 문제를 해결했습니다.
  - 그리드 정렬을 `place-items-center` → `justify-items-center`로 수정했습니다.                                        
                                                                                                                       
  > **참고:** lg → md 전환 시 그리드 컬럼이 3개 → 2개로 줄어들면서 카드 너비가 360px에서 셀 너비(약 356px)로 소폭      
  줄어드는 트레이드오프가 있습니다.                                                                                    
                                                                                                                       
  ### 🧪 테스트 방법 (How to Test)                                                                                     
  
  1. 로컬 환경에서 앱을 실행합니다.                                                                                    
  2. `/home` 페이지로 이동합니다.
  3. 브라우저 너비를 lg(1024px) → md(768px) → sm(375px) 순으로 줄이며 추천 소잇 섹션을 확인합니다.
  4. 각 구간에서 카드가 3열 → 2열 → 1열로 정상 전환되고, 카드 겹침 및 좌우 스크롤이 발생하지 않는지 확인합니다.        
                                                                                                                       
  ### 📸 스크린샷 또는 영상 (Optional)                                                                                 
                                                                                                                       
  | 변경 전 (Before) | 변경 후 (After) |                                                                               
  | :--------------: | :-------------: |
  |                  |                 |

  ### 🚨 기타 참고 사항 (Notes)                                                                                        
  
  - [x] **코드 리뷰 시 특별히 확인이 필요한 부분:** lg → md 전환 시 카드 너비가 360px → ~356px으로 소폭 줄어드는 점    
  확인 부탁드립니다.