### PR TITLE
[Fix]: 에러 토스트 메시지 말투 통일 및 누락 핸들러 추가 

### DIFF
--- a/src/features/auth/model/auth.mutations.ts
+++ b/src/features/auth/model/auth.mutations.ts
@@ -50,8 +50,8 @@ export const useSignUpMutation = () => {
       toast.success('회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.');
       router.push('/login');
     },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : '회원가입에 실패했습니다.');
+    onError: () => {
+      toast.error('회원가입 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });
 };

--- a/src/features/meeting-comment/model/meeting-comment.mutations.test.ts
+++ b/src/features/meeting-comment/model/meeting-comment.mutations.test.ts
@@ -75,7 +75,7 @@ describe('useCreateComment', () => {
     result.current.mutate({ content: '새 댓글' });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith('댓글 작성 실패');
+    expect(toast.error).toHaveBeenCalledWith('댓글 작성 중 문제가 생겼어요. 다시 시도해 주세요.');
   });
 });
 
@@ -104,6 +104,6 @@ describe('useDeleteComment', () => {
     result.current.mutate(10);
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).toHaveBeenCalledWith('댓글 삭제 실패');
+    expect(toast.error).toHaveBeenCalledWith('댓글 삭제 중 문제가 생겼어요. 다시 시도해 주세요.');
   });
 });

--- a/src/features/meeting-comment/model/meeting-comment.mutations.ts
+++ b/src/features/meeting-comment/model/meeting-comment.mutations.ts
@@ -60,11 +60,11 @@ export const useCreateComment = (meetingId: number, author: CommentAuthor) => {
       queryClient.invalidateQueries({ queryKey: meetingCommentKeys.list(meetingId) });
       queryClient.invalidateQueries({ queryKey: meetingCommentKeys.count(meetingId) });
     },
-    onError: (error: Error, _, context) => {
+    onError: (_error: Error, _, context) => {
       if (context?.previousComments) {
         queryClient.setQueryData(meetingCommentKeys.list(meetingId), context.previousComments);
       }
-      toast.error(error.message || '댓글 작성 중 오류가 발생했습니다.');
+      toast.error('댓글 작성 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });
 };
@@ -108,11 +108,11 @@ export const useUpdateComment = (meetingId: number) => {
       queryClient.invalidateQueries({ queryKey: meetingCommentKeys.list(meetingId) });
       toast.success('댓글이 수정되었습니다.');
     },
-    onError: (error: Error, _, context) => {
+    onError: (_error: Error, _, context) => {
       if (context?.previousComments) {
         queryClient.setQueryData(meetingCommentKeys.list(meetingId), context.previousComments);
       }
-      toast.error(error.message || '댓글 수정 중 오류가 발생했습니다.');
+      toast.error('댓글 수정 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });
 };
@@ -151,11 +151,11 @@ export const useDeleteComment = (meetingId: number) => {
       queryClient.invalidateQueries({ queryKey: meetingCommentKeys.count(meetingId) });
       toast.success('댓글이 삭제되었습니다.');
     },
-    onError: (error: Error, _, context) => {
+    onError: (_error: Error, _, context) => {
       if (context?.previousComments) {
         queryClient.setQueryData(meetingCommentKeys.list(meetingId), context.previousComments);
       }
-      toast.error(error.message || '댓글 삭제 중 오류가 발생했습니다.');
+      toast.error('댓글 삭제 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });
 };
@@ -169,7 +169,7 @@ export const useLikeComment = (meetingId: number) => {
         ? meetingCommentApi.unlikeComment(commentId)
         : meetingCommentApi.likeComment(commentId),
     onError: () => {
-      toast.error('좋아요 처리 중 오류가 발생했습니다.');
+      toast.error('좋아요 처리 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: meetingCommentKeys.list(meetingId) });

--- a/src/features/meeting-create/model/use-create-meeting.ts
+++ b/src/features/meeting-create/model/use-create-meeting.ts
@@ -23,8 +23,8 @@ export const useCreateMeeting = () => {
       void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
       toast.success('모임이 생성되었습니다.');
     },
-    onError: (error: Error) => {
-      toast.error(error.message || '모임 생성 중 오류가 발생했습니다.');
+    onError: () => {
+      toast.error('모임 생성 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });
 };

--- a/src/features/meeting-edit/model/use-update-meeting.ts
+++ b/src/features/meeting-edit/model/use-update-meeting.ts
@@ -11,7 +11,7 @@ export const useUpdateMeeting = (id: number, onSuccess?: () => void) =>
       toast.success('모임이 수정되었습니다.');
       onSuccess?.();
     },
-    onError: (error: Error) => {
-      toast.error(error.message || '모임 수정 중 오류가 발생했습니다.');
+    onError: () => {
+      toast.error('모임 수정 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });

--- a/src/features/profile-edit/model/profile-edit.mutations.ts
+++ b/src/features/profile-edit/model/profile-edit.mutations.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
 
 import { useAuthStore } from '@/entities/auth';
 import type { User } from '@/shared/types/generated-client';
@@ -23,6 +24,9 @@ export const useUpdateProfile = (onSuccess?: (user: User) => void) => {
         image: data.image,
       });
       onSuccess?.(data);
+    },
+    onError: () => {
+      toast.error('프로필 수정 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });
 };

--- a/src/features/sosotalk-write/model/use-sosotalk-write-page.test.ts
+++ b/src/features/sosotalk-write/model/use-sosotalk-write-page.test.ts
@@ -102,7 +102,9 @@ describe('useSosoTalkWritePage', () => {
       });
     });
 
-    expect(mockToastError).toHaveBeenCalledWith('게시글 등록에 실패했어요. 다시 시도해 주세요.');
+    expect(mockToastError).toHaveBeenCalledWith(
+      '게시글 등록 중 문제가 생겼어요. 다시 시도해 주세요.'
+    );
     expect(mockReplace).not.toHaveBeenCalled();
     expect(result.current.isSubmitting).toBe(false);
   });
@@ -168,7 +170,9 @@ describe('useSosoTalkWritePage', () => {
       });
     });
 
-    expect(mockToastError).toHaveBeenCalledWith('게시글 수정에 실패했어요. 다시 시도해 주세요.');
+    expect(mockToastError).toHaveBeenCalledWith(
+      '게시글 수정 중 문제가 생겼어요. 다시 시도해 주세요.'
+    );
     expect(mockReplace).not.toHaveBeenCalledWith('/sosotalk/9');
     expect(result.current.isSubmitting).toBe(false);
   });

--- a/src/features/sosotalk-write/model/use-sosotalk-write-page.ts
+++ b/src/features/sosotalk-write/model/use-sosotalk-write-page.ts
@@ -72,7 +72,7 @@ export function useSosoTalkWritePage({ editPostId }: UseSosoTalkWritePageParams)
 
       router.replace(`/sosotalk/${createdPost.id}`);
     } catch {
-      toast.error('게시글 등록에 실패했어요. 다시 시도해 주세요.');
+      toast.error('게시글 등록 중 문제가 생겼어요. 다시 시도해 주세요.');
     } finally {
       setIsSubmitting(false);
     }
@@ -104,7 +104,7 @@ export function useSosoTalkWritePage({ editPostId }: UseSosoTalkWritePageParams)
 
       router.replace(`/sosotalk/${editPostId}`);
     } catch {
-      toast.error('게시글 수정에 실패했어요. 다시 시도해 주세요.');
+      toast.error('게시글 수정 중 문제가 생겼어요. 다시 시도해 주세요.');
     } finally {
       setIsSubmitting(false);
     }

--- a/src/widgets/meeting-detail/model/meeting-detail.queries.ts
+++ b/src/widgets/meeting-detail/model/meeting-detail.queries.ts
@@ -33,7 +33,7 @@ export const useConfirmMeeting = (id: number) => {
       }
       return { previous };
     },
-    onError: (error: Error, _, context) => {
+    onError: (_error: Error, _, context) => {
       if (context?.previous !== undefined) {
         queryClient.setQueryData(meetingsQueryOptions.meetingDetail(id).queryKey, context.previous);
       } else {
@@ -41,7 +41,7 @@ export const useConfirmMeeting = (id: number) => {
           queryKey: meetingsQueryOptions.meetingDetail(id).queryKey,
         });
       }
-      toast.error(error.message || '모임 확정 중 오류가 발생했습니다.');
+      toast.error('모임 확정 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
     onSuccess: () => {
       toast.success('모임이 확정되었습니다.');
@@ -67,8 +67,8 @@ export const useDeleteMeeting = (id: number) => {
       toast.success('모임이 삭제되었습니다.');
       router.back();
     },
-    onError: (error: Error) => {
-      toast.error(error.message || '모임 삭제 중 오류가 발생했습니다.');
+    onError: () => {
+      toast.error('모임 삭제 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
   });
 };
@@ -95,7 +95,7 @@ export const useJoinMeeting = (id: number) => {
       }
       return { previous };
     },
-    onError: (error: Error, _, context) => {
+    onError: (_error: Error, _, context) => {
       if (context?.previous !== undefined) {
         queryClient.setQueryData(meetingsQueryOptions.meetingDetail(id).queryKey, context.previous);
       } else {
@@ -103,7 +103,7 @@ export const useJoinMeeting = (id: number) => {
           queryKey: meetingsQueryOptions.meetingDetail(id).queryKey,
         });
       }
-      toast.error(error.message || '모임 참여 중 오류가 발생했습니다.');
+      toast.error('모임 참여 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });
@@ -141,7 +141,7 @@ export const useLeaveMeeting = (id: number) => {
       }
       return { previous };
     },
-    onError: (error: Error, _, context) => {
+    onError: (_error: Error, _, context) => {
       if (context?.previous !== undefined) {
         queryClient.setQueryData(meetingsQueryOptions.meetingDetail(id).queryKey, context.previous);
       } else {
@@ -149,7 +149,7 @@ export const useLeaveMeeting = (id: number) => {
           queryKey: meetingsQueryOptions.meetingDetail(id).queryKey,
         });
       }
-      toast.error(error.message || '모임 참여 취소 중 오류가 발생했습니다.');
+      toast.error('모임 참여 취소 중 문제가 생겼어요. 다시 시도해 주세요.');
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: mypageMeetingCountKey });

--- a/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.test.tsx
@@ -64,7 +64,7 @@ describe('MeetingLocationAddressRow', () => {
     await user.click(screen.getByRole('button', { name: '주소 복사' }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('복사에 실패했습니다.');
+      expect(toast.error).toHaveBeenCalledWith('주소 복사 중 문제가 생겼어요. 다시 시도해 주세요.');
     });
     expect(toast.success).not.toHaveBeenCalled();
   });

--- a/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/_components/meeting-location-address-row.tsx
@@ -15,7 +15,7 @@ export function MeetingLocationAddressRow({ address }: MeetingLocationAddressRow
       await writeClipboardText(address);
       toast.success('주소가 복사되었습니다.');
     } catch {
-      toast.error('복사에 실패했습니다.');
+      toast.error('주소 복사 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-comment-actions.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-comment-actions.ts
@@ -57,7 +57,7 @@ export function useSosoTalkPostDetailCommentActions({
       });
       setCommentInput('');
     } catch {
-      toast.error('댓글 등록에 실패했어요. 다시 시도해 주세요.');
+      toast.error('댓글 등록 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 
@@ -94,7 +94,7 @@ export function useSosoTalkPostDetailCommentActions({
       });
       handleCancelEditComment();
     } catch {
-      toast.error('댓글 수정에 실패했어요. 다시 시도해 주세요.');
+      toast.error('댓글 수정 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 
@@ -127,7 +127,7 @@ export function useSosoTalkPostDetailCommentActions({
 
       setPendingDeleteCommentId(null);
     } catch {
-      toast.error('댓글 삭제에 실패했어요. 다시 시도해 주세요.');
+      toast.error('댓글 삭제 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-post-actions.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/model/use-sosotalk-post-detail-post-actions.ts
@@ -70,7 +70,7 @@ export function useSosoTalkPostDetailPostActions({
       }
     } catch {
       setOptimisticIsLiked(null);
-      toast.error('좋아요 처리에 실패했어요. 다시 시도해 주세요.');
+      toast.error('좋아요 처리 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 
@@ -102,7 +102,7 @@ export function useSosoTalkPostDetailPostActions({
         return;
       }
 
-      toast.error('공유에 실패했어요. 다시 시도해 주세요.');
+      toast.error('공유 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 
@@ -120,7 +120,7 @@ export function useSosoTalkPostDetailPostActions({
       toast.success('링크를 복사했어요.');
       setIsShareModalOpen(false);
     } catch {
-      toast.error('링크 복사에 실패했어요. 다시 시도해 주세요.');
+      toast.error('링크 복사 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 
@@ -146,7 +146,7 @@ export function useSosoTalkPostDetailPostActions({
       setIsDeleteModalOpen(false);
       router.push('/sosotalk');
     } catch {
-      toast.error('게시글 삭제에 실패했어요. 다시 시도해 주세요.');
+      toast.error('게시글 삭제 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-share-modal.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-share-modal.tsx
@@ -92,7 +92,7 @@ export function SosoTalkShareModal({
 
   const handleKakaoShare = () => {
     if (!window.Kakao) {
-      toast.error('카카오톡 공유를 준비하지 못했어요. 다시 시도해 주세요.');
+      toast.error('카카오톡 공유 중 문제가 생겼어요. 다시 시도해 주세요.');
       return;
     }
 


### PR DESCRIPTION
  ### 📌 유형 (Type)                                                                                                   
                                                                                                                       
  다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.                                                            
                                                                                                                       
  - [ ] **Feat (기능):** 새로운 기능 추가                                                                              
  - [x] **Fix (버그 수정):** 버그 수정                                                                                 
  - [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)                                                       
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)                                                              
  - [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)                                        
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등                                                    
                                                                                                                       
  ### 📝 변경 사항 (Changes)                                                                                           
                                                                                                                       
  - 관련 이슈: #339                                                                                                    
   
  앱 전반에 걸쳐 에러 토스트 메시지의 말투가 제각각이었습니다. 일부는 `error.message`를 그대로 노출하거나, 반말/딱딱한 
  표현이 혼재되어 사용자 경험이 일관되지 않았습니다.
                                                                                                                       
  모든 에러 토스트를 아래 패턴으로 통일했습니다:                                                                       
   
  > **`{동작}중 문제가 생겼어요. 다시 시도해 주세요.`**                                                                
                  
  **말투 선정 이유:**                                                                                                  
  - 서비스 특성상 따뜻하고 친근한 말투를 지향하므로 `-해요` 체 사용
  - `다시 시도해 주세요.`를 고정 후행 문구로 두어 사용자에게 명확한 다음 행동을 안내                                   
  - `error.message` 직접 노출은 내부 구현 세부정보나 영문 에러가 그대로 보일 수 있어 제거                              
                                                                                                                       
  **변경 범위:**                                                                                                       
                                                                                                                       
  | 영역 | 대상 액션 |                                                                                                 
  |------|----------|
  | 모임 상세 | 확정, 삭제, 참여, 참여 취소 |                                                                          
  | 모임 댓글 | 작성, 수정, 삭제, 좋아요 |                                                                             
  | 모임 생성/수정 | 생성, 수정 |
  | 회원가입 | 회원가입 |                                                                                              
  | 주소 복사 | 복사 |                                                                                                 
  | 소소톡 | 게시글 등록/수정/삭제, 댓글 등록/수정/삭제, 좋아요, 공유, 링크 복사 |                                     
  | 프로필 수정 | 수정 (누락된 `onError` 핸들러 추가) |                                                                
                                                                                                                       
  ### 🧪 테스트 방법 (How to Test)                                                                                     
                                                                                                                       
  1. 각 기능에서 의도적으로 에러를 발생시킵니다 (네트워크 오프라인 또는 잘못된 요청).                                  
  2. 에러 토스트가 `{동작}중 문제가 생겼어요. 다시 시도해 주세요.` 형식으로 표시되는지 확인합니다.
  3. `error.message` 원문(영문 에러 등)이 노출되지 않는지 확인합니다.                                                  
  4. 프로필 수정 실패 시 이전에는 토스트가 없었으나 이제 표시되는지 확인합니다.                                        
                                                                                                                       
  ### 📸 스크린샷 또는 영상 (Optional)                                                                                 
                                                                                                                       
  (UI 변경 없음 — 텍스트 메시지만 변경)                                                                                
   
  | 변경 전 (Before) | 변경 후 (After) |                                                                               
  | :--------------: | :-------------: |
  |                  |                 |                                                                               
   
  ### 🚨 기타 참고 사항 (Notes)                                                                                        
                  
  - [x] 향후 새 에러 토스트 추가 시 `{동작}중 문제가 생겼어요. 다시 시도해 주세요.` 패턴을 컨벤션으로 따라주세요!   