### PR TITLE
[Refactor]: 클라이언트 API 에러 파싱 로직 parseResponse로 통일

### DIFF
--- a/src/entities/auth/api/auth.api.ts
+++ b/src/entities/auth/api/auth.api.ts
@@ -1,4 +1,5 @@
 import { fetchClient } from '@/shared/api/fetch-client';
+import { parseResponse, parseVoidResponse } from '@/shared/api/parse-response';
 import { LoginRequest, SignupRequest } from '@/shared/types/generated-client/models';
 
 import { AuthUser } from '../model/auth.types';
@@ -19,13 +20,7 @@ export const authApi = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '로그인에 실패했습니다.');
-    }
-
-    return response.json();
+    return parseResponse<AuthResponse>(response, '로그인에 실패했습니다.');
   },
 
   /**
@@ -34,13 +29,7 @@ export const authApi = {
    */
   async checkEmailDuplicate(email: string): Promise<{ available: boolean }> {
     const response = await fetchClient.post('/auth/email-check', { email });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '올바른 이메일 형식이 아닙니다.');
-    }
-
-    return response.json();
+    return parseResponse<{ available: boolean }>(response, '올바른 이메일 형식이 아닙니다.');
   },
 
   /**
@@ -49,11 +38,7 @@ export const authApi = {
    */
   async signUp(payload: SignupRequest): Promise<void> {
     const response = await fetchClient.post('/auth/signup', payload);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '회원가입에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '회원가입에 실패했습니다.');
   },
 
   /**
@@ -79,12 +64,6 @@ export const authApi = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '소셜 로그인에 실패했습니다.');
-    }
-
-    return response.json();
+    return parseResponse<AuthResponse>(response, '소셜 로그인에 실패했습니다.');
   },
 };

--- a/src/entities/favorites/api/favorites.api.ts
+++ b/src/entities/favorites/api/favorites.api.ts
@@ -1,30 +1,32 @@
 import { fetchClient } from '@/shared/api/fetch-client';
+import { parseResponse, parseVoidResponse } from '@/shared/api/parse-response';
 import { FavoriteList } from '@/shared/types/generated-client';
 
 export const favoritesApi = {
   async fetchList(): Promise<FavoriteList> {
     const res = await fetchClient.get('/favorites');
-    if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
-    return res.json();
+    return parseResponse<FavoriteList>(
+      res,
+      '찜 목록을 불러오는 중 문제가 생겼어요. 다시 시도해 주세요.'
+    );
   },
+
   async favoritePost(meetingId: number): Promise<void> {
     const response = await fetchClient.post(`/meetings/${meetingId}/favorites`);
-    if (!response.ok) {
-      throw new Error('찜하기에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '찜하기에 실패했습니다.');
   },
+
   async favoriteDelete(meetingId: number): Promise<void> {
     const response = await fetchClient.delete(`/meetings/${meetingId}/favorites`);
-    if (!response.ok) {
-      throw new Error('찜하기 취소에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '찜하기 취소에 실패했습니다.');
   },
+
   async getCount(): Promise<number> {
     const response = await fetchClient.get('/favorites/count');
-    if (!response.ok) {
-      throw new Error('찜한 모임 개수 조회에 실패했습니다.');
-    }
-    const data = await response.json();
+    const data = await parseResponse<{ count: number }>(
+      response,
+      '찜한 모임 개수 조회에 실패했습니다.'
+    );
     return data.count ?? 0;
   },
 };

--- a/src/entities/image/api/images.api.ts
+++ b/src/entities/image/api/images.api.ts
@@ -1,4 +1,5 @@
 import { fetchClient } from '@/shared/api/fetch-client';
+import { parseResponse } from '@/shared/api/parse-response';
 import {
   PresignedUrlRequestContentTypeEnum,
   PresignedUrlRequestFolderEnum,
@@ -43,18 +44,13 @@ export const imagesApi = {
       contentType,
       folder,
     });
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '이미지 업로드에 실패했습니다.');
-    }
-
-    return response.json();
+    return parseResponse<PresignedUrlResponse>(response, '이미지 업로드에 실패했습니다.');
   },
 
   /**
    * S3에 이미지 직접 업로드
    * PUT presignedUrl
+   * S3 presigned URL은 에러 응답이 JSON이 아니므로 parseResponse 미사용
    */
   async uploadToS3(presignedUrl: string, file: File): Promise<void> {
     const response = await fetch(presignedUrl, {
@@ -62,7 +58,6 @@ export const imagesApi = {
       headers: { 'Content-Type': file.type.trim() },
       body: file,
     });
-
     if (!response.ok) {
       throw new Error('이미지 업로드에 실패했습니다.');
     }

--- a/src/entities/meeting-comment/api/meeting-comment.api.ts
+++ b/src/entities/meeting-comment/api/meeting-comment.api.ts
@@ -1,4 +1,5 @@
 import { commentClient } from '@/shared/api/comment-client';
+import { parseResponse, parseVoidResponse } from '@/shared/api/parse-response';
 
 export type MeetingComment = {
   id: number;
@@ -59,20 +60,15 @@ export const meetingCommentApi = {
       }
     }
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '댓글을 불러오는데 실패했습니다.');
-    }
-    return response.json();
+    return parseResponse<MeetingComment[]>(response, '댓글을 불러오는데 실패했습니다.');
   },
 
   async getCommentCount(meetingId: number): Promise<MeetingCommentCountResponse> {
     const response = await commentClient.get(`/meetings/${meetingId}/comments/count`);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '댓글 수를 불러오는데 실패했습니다.');
-    }
-    return response.json();
+    return parseResponse<MeetingCommentCountResponse>(
+      response,
+      '댓글 수를 불러오는데 실패했습니다.'
+    );
   },
 
   async createComment(
@@ -80,11 +76,7 @@ export const meetingCommentApi = {
     payload: CreateMeetingCommentRequest
   ): Promise<MeetingComment> {
     const response = await commentClient.post(`/meetings/${meetingId}/comments`, payload);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '댓글 작성에 실패했습니다.');
-    }
-    return response.json();
+    return parseResponse<MeetingComment>(response, '댓글 작성에 실패했습니다.');
   },
 
   async updateComment(
@@ -92,50 +84,31 @@ export const meetingCommentApi = {
     payload: UpdateMeetingCommentRequest
   ): Promise<MeetingComment> {
     const response = await commentClient.patch(`/comments/${commentId}`, payload);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '댓글 수정에 실패했습니다.');
-    }
-    return response.json();
+    return parseResponse<MeetingComment>(response, '댓글 수정에 실패했습니다.');
   },
 
   async deleteComment(commentId: number): Promise<void> {
     const response = await commentClient.delete(`/comments/${commentId}`);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '댓글 삭제에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '댓글 삭제에 실패했습니다.');
   },
 
   async likeComment(commentId: number): Promise<void> {
     const response = await commentClient.post(`/comments/${commentId}/likes`);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '좋아요에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '좋아요에 실패했습니다.');
   },
 
   async unlikeComment(commentId: number): Promise<void> {
     const response = await commentClient.delete(`/comments/${commentId}/likes`);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '좋아요 취소에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '좋아요 취소에 실패했습니다.');
   },
 
   async syncCreateMeeting(payload: SyncMeetingRequest): Promise<void> {
     const response = await commentClient.post('/meetings', payload);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 동기화에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '모임 동기화에 실패했습니다.');
   },
 
   async syncDeleteMeeting(meetingId: number): Promise<void> {
     const response = await commentClient.delete(`/meetings/${meetingId}`);
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 삭제 동기화에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '모임 삭제 동기화에 실패했습니다.');
   },
 };

--- a/src/entities/meeting/api/meetings.api.ts
+++ b/src/entities/meeting/api/meetings.api.ts
@@ -1,6 +1,7 @@
 import qs from 'qs';
 
 import { fetchClient } from '@/shared/api/fetch-client';
+import { parseResponse, parseVoidResponse } from '@/shared/api/parse-response';
 import { MeetingList, TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
 import { CreateMeeting } from '@/shared/types/generated-client/models/CreateMeeting';
 import { MeetingWithHost } from '@/shared/types/generated-client/models/MeetingWithHost';
@@ -24,32 +25,18 @@ const makeQueryString = (params: Omit<TeamIdMeetingsGetRequest, 'teamId'>): stri
 export const meetingsApi = {
   async getById(id: number): Promise<Meeting> {
     const response = await fetchClient.get(`/meetings/${id}`);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 조회에 실패했습니다.');
-    }
-
-    return response.json();
+    return parseResponse<Meeting>(response, '모임 조회에 실패했습니다.');
   },
+
   async getList(): Promise<MeetingList> {
     const response = await fetchClient.get('/meetings');
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 목록 조회에 실패했습니다.');
-    }
-    return response.json();
+    return parseResponse<MeetingList>(response, '모임 목록 조회에 실패했습니다.');
   },
 
   async getByFilter(options: Omit<TeamIdMeetingsGetRequest, 'teamId'>): Promise<MeetingList> {
     const queryString = makeQueryString(options);
     const response = await fetchClient.get(`/meetings${queryString}`);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 목록 조회에 실패했습니다.');
-    }
-    return response.json();
+    return parseResponse<MeetingList>(response, '모임 목록 조회에 실패했습니다.');
   },
 
   /**
@@ -58,13 +45,7 @@ export const meetingsApi = {
    */
   async create(payload: CreateMeeting): Promise<MeetingWithHost> {
     const response = await fetchClient.post('/meetings', payload);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 생성에 실패했습니다.');
-    }
-
-    return response.json();
+    return parseResponse<MeetingWithHost>(response, '모임 생성에 실패했습니다.');
   },
 
   /**
@@ -73,50 +54,26 @@ export const meetingsApi = {
    */
   async update(id: number, payload: UpdateMeeting): Promise<MeetingWithHost> {
     const response = await fetchClient.patch(`/meetings/${id}`, payload);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 수정에 실패했습니다.');
-    }
-
-    return response.json();
+    return parseResponse<MeetingWithHost>(response, '모임 수정에 실패했습니다.');
   },
 
   async updateStatus(id: number, payload: UpdateMeetingStatus): Promise<MeetingWithHost> {
     const response = await fetchClient.patch(`/meetings/${id}/status`, payload);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 상태 변경에 실패했습니다.');
-    }
-
-    return response.json();
+    return parseResponse<MeetingWithHost>(response, '모임 상태 변경에 실패했습니다.');
   },
 
   async deleteMeeting(id: number): Promise<void> {
     const response = await fetchClient.delete(`/meetings/${id}`);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 삭제에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '모임 삭제에 실패했습니다.');
   },
 
   async join(id: number): Promise<void> {
     const response = await fetchClient.post(`/meetings/${id}/join`);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 참여에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '모임 참여에 실패했습니다.');
   },
 
   async leave(id: number): Promise<void> {
     const response = await fetchClient.delete(`/meetings/${id}/join`);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || '모임 참여 취소에 실패했습니다.');
-    }
+    return parseVoidResponse(response, '모임 참여 취소에 실패했습니다.');
   },
 };

--- a/src/entities/post/api/posts.api.ts
+++ b/src/entities/post/api/posts.api.ts
@@ -1,4 +1,5 @@
 import { fetchClient } from '@/shared/api/fetch-client';
+import { parseResponse } from '@/shared/api/parse-response';
 import { CommentFromJSON } from '@/shared/types/generated-client/models/Comment';
 import { PostLikeFromJSON } from '@/shared/types/generated-client/models/PostLike';
 import { PostListFromJSON } from '@/shared/types/generated-client/models/PostList';
@@ -79,12 +80,8 @@ export const getSosoTalkPostList = async (
   });
 
   const response = await fetchClient.get(`/posts?${searchParams.toString()}`);
-
-  if (!response.ok) {
-    throw new Error('소소톡 게시글 목록을 불러오지 못했습니다.');
-  }
-
-  return PostListFromJSON(await response.json()) as GetSosoTalkPostListResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 게시글 목록을 불러오지 못했습니다.');
+  return PostListFromJSON(data) as GetSosoTalkPostListResponse;
 };
 
 export const getSosoTalkPostDetail = async (
@@ -92,11 +89,8 @@ export const getSosoTalkPostDetail = async (
 ): Promise<GetSosoTalkPostDetailResponse> => {
   const response = await fetchClient.get(`/posts/${postId}`);
 
-  if (!response.ok) {
-    throw new Error('소소톡 게시글을 불러오지 못했습니다.');
-  }
-
-  return PostWithCommentsFromJSON(await response.json()) as GetSosoTalkPostDetailResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 게시글을 불러오지 못했습니다.');
+  return PostWithCommentsFromJSON(data) as GetSosoTalkPostDetailResponse;
 };
 
 export const createSosoTalkPost = async ({
@@ -104,11 +98,8 @@ export const createSosoTalkPost = async ({
 }: CreateSosoTalkPostParams): Promise<CreateSosoTalkPostResponse> => {
   const response = await fetchClient.post('/posts', payload);
 
-  if (!response.ok) {
-    throw new Error('소소톡 게시글 작성에 실패했습니다.');
-  }
-
-  return PostWithAuthorFromJSON(await response.json()) as CreateSosoTalkPostResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 게시글 작성에 실패했습니다.');
+  return PostWithAuthorFromJSON(data) as CreateSosoTalkPostResponse;
 };
 
 export const requestSosoTalkPostImageUploadUrl = async (
@@ -119,14 +110,11 @@ export const requestSosoTalkPostImageUploadUrl = async (
     contentType: getSosoTalkImageContentType(file),
     folder: PresignedUrlRequestFolderEnum.Posts,
   });
-
-  if (!response.ok) {
-    throw new Error('소소톡 이미지 업로드 URL 발급에 실패했습니다.');
-  }
-
-  return PresignedUrlResponseFromJSON(
-    await response.json()
-  ) as RequestSosoTalkPostImageUploadUrlResponse;
+  const data = await parseResponse<unknown>(
+    response,
+    '소소톡 이미지 업로드 URL 발급에 실패했습니다.'
+  );
+  return PresignedUrlResponseFromJSON(data) as RequestSosoTalkPostImageUploadUrlResponse;
 };
 
 export const uploadSosoTalkPostImage = async (file: File): Promise<string> => {
@@ -152,25 +140,16 @@ export const createSosoTalkPostLike = async (
 ): Promise<CreateSosoTalkPostLikeResponse> => {
   const response = await fetchClient.post(`/posts/${postId}/like`);
 
-  if (!response.ok) {
-    throw new Error('소소톡 게시글 좋아요에 실패했습니다.');
-  }
-
-  return PostLikeFromJSON(await response.json()) as CreateSosoTalkPostLikeResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 게시글 좋아요에 실패했습니다.');
+  return PostLikeFromJSON(data) as CreateSosoTalkPostLikeResponse;
 };
 
 export const deleteSosoTalkPostLike = async (
   postId: number
 ): Promise<DeleteSosoTalkPostLikeResponse> => {
   const response = await fetchClient.delete(`/posts/${postId}/like`);
-
-  if (!response.ok) {
-    throw new Error('소소톡 게시글 좋아요 취소에 실패했습니다.');
-  }
-
-  return TeamIdMeetingsMeetingIdDelete200ResponseFromJSON(
-    await response.json()
-  ) as DeleteSosoTalkPostLikeResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 게시글 좋아요 취소에 실패했습니다.');
+  return TeamIdMeetingsMeetingIdDelete200ResponseFromJSON(data) as DeleteSosoTalkPostLikeResponse;
 };
 
 export const createSosoTalkComment = async ({
@@ -178,12 +157,8 @@ export const createSosoTalkComment = async ({
   payload,
 }: CreateSosoTalkCommentParams): Promise<CreateSosoTalkCommentResponse> => {
   const response = await fetchClient.post(`/posts/${postId}/comments`, payload);
-
-  if (!response.ok) {
-    throw new Error('소소톡 댓글 작성에 실패했습니다.');
-  }
-
-  return CommentFromJSON(await response.json()) as CreateSosoTalkCommentResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 댓글 작성에 실패했습니다.');
+  return CommentFromJSON(data) as CreateSosoTalkCommentResponse;
 };
 
 export const updateSosoTalkComment = async ({
@@ -192,12 +167,8 @@ export const updateSosoTalkComment = async ({
   payload,
 }: UpdateSosoTalkCommentParams): Promise<UpdateSosoTalkCommentResponse> => {
   const response = await fetchClient.patch(`/posts/${postId}/comments/${commentId}`, payload);
-
-  if (!response.ok) {
-    throw new Error('소소톡 댓글 수정에 실패했습니다.');
-  }
-
-  return CommentFromJSON(await response.json()) as UpdateSosoTalkCommentResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 댓글 수정에 실패했습니다.');
+  return CommentFromJSON(data) as UpdateSosoTalkCommentResponse;
 };
 
 export const deleteSosoTalkComment = async ({
@@ -205,14 +176,8 @@ export const deleteSosoTalkComment = async ({
   commentId,
 }: CommentMutationParams): Promise<DeleteSosoTalkCommentResponse> => {
   const response = await fetchClient.delete(`/posts/${postId}/comments/${commentId}`);
-
-  if (!response.ok) {
-    throw new Error('소소톡 댓글 삭제에 실패했습니다.');
-  }
-
-  return TeamIdMeetingsMeetingIdDelete200ResponseFromJSON(
-    await response.json()
-  ) as DeleteSosoTalkCommentResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 댓글 삭제에 실패했습니다.');
+  return TeamIdMeetingsMeetingIdDelete200ResponseFromJSON(data) as DeleteSosoTalkCommentResponse;
 };
 
 export const updateSosoTalkPost = async ({
@@ -220,24 +185,14 @@ export const updateSosoTalkPost = async ({
   payload,
 }: UpdateSosoTalkPostParams): Promise<UpdateSosoTalkPostResponse> => {
   const response = await fetchClient.patch(`/posts/${postId}`, payload);
-
-  if (!response.ok) {
-    throw new Error('소소톡 게시글 수정에 실패했습니다.');
-  }
-
-  return PostWithAuthorFromJSON(await response.json()) as UpdateSosoTalkPostResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 게시글 수정에 실패했습니다.');
+  return PostWithAuthorFromJSON(data) as UpdateSosoTalkPostResponse;
 };
 
 export const deleteSosoTalkPost = async ({
   postId,
 }: SosoTalkPostMutationParams): Promise<DeleteSosoTalkPostResponse> => {
   const response = await fetchClient.delete(`/posts/${postId}`);
-
-  if (!response.ok) {
-    throw new Error('소소톡 게시글 삭제에 실패했습니다.');
-  }
-
-  return TeamIdMeetingsMeetingIdDelete200ResponseFromJSON(
-    await response.json()
-  ) as DeleteSosoTalkPostResponse;
+  const data = await parseResponse<unknown>(response, '소소톡 게시글 삭제에 실패했습니다.');
+  return TeamIdMeetingsMeetingIdDelete200ResponseFromJSON(data) as DeleteSosoTalkPostResponse;
 };

--- a/src/features/notifications/api/notifications.api.ts
+++ b/src/features/notifications/api/notifications.api.ts
@@ -1,4 +1,5 @@
 import { fetchClient } from '@/shared/api/fetch-client';
+import { parseResponse, parseVoidResponse } from '@/shared/api/parse-response';
 import {
   Notification,
   NotificationList,
@@ -13,8 +14,10 @@ export const notificationApi = {
     if (options.size) params.append('size', String(options.size));
 
     const response = await fetchClient.get(`/notifications?${params.toString()}`);
-    const data: NotificationList = await response.json();
-
+    const data = await parseResponse<NotificationList>(
+      response,
+      '알림 목록을 불러오는 중 문제가 생겼어요. 다시 시도해 주세요.'
+    );
     const items = data.data.map((item: Notification) => ({
       ...item,
       createdAt: new Date(item.createdAt as unknown as string),
@@ -22,10 +25,13 @@ export const notificationApi = {
 
     return { ...data, data: items };
   },
+
   getNotificationList: async () => {
     const response = await fetchClient.get('/notifications');
-    const data: NotificationList = await response.json();
-
+    const data = await parseResponse<NotificationList>(
+      response,
+      '알림 목록을 불러오는 중 문제가 생겼어요. 다시 시도해 주세요.'
+    );
     const items = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : [];
 
     return items.map((item: Notification) => ({
@@ -33,25 +39,26 @@ export const notificationApi = {
       createdAt: new Date(item.createdAt as unknown as string),
     }));
   },
+
   getUnreadCount: async () => {
     const response = await fetchClient.get('/notifications/unread-count');
-    const data = await response.json();
-
+    const data = await parseResponse<{ count: number }>(
+      response,
+      '알림 개수를 불러오는 중 문제가 생겼어요. 다시 시도해 주세요.'
+    );
     return typeof data?.count === 'number' ? data.count : 0;
   },
+
   markAsRead: async (notificationId: number) => {
     const response = await fetchClient.put(`/notifications/${notificationId}/read`);
-    if (!response.ok) {
-      throw new Error(`Failed to mark notification ${notificationId} as read`);
-    }
-    return response;
+    return parseVoidResponse(response, '알림 읽음 처리 중 문제가 생겼어요. 다시 시도해 주세요.');
   },
+
   markAllAsRead: async () => {
     const response = await fetchClient.put('/notifications/read-all');
-
-    if (!response.ok) {
-      throw new Error('Failed to mark all notifications as read');
-    }
-    return response;
+    return parseVoidResponse(
+      response,
+      '알림 전체 읽음 처리 중 문제가 생겼어요. 다시 시도해 주세요.'
+    );
   },
 };

--- a/src/features/notifications/ui/notification/notification-tab/notification-tab.test.tsx
+++ b/src/features/notifications/ui/notification/notification-tab/notification-tab.test.tsx
@@ -54,7 +54,7 @@ jest.mock('@/features/notifications/api/notifications.api', () => ({
 
 describe('NotificationTab', () => {
   beforeEach(() => {
-    jest.spyOn(notificationApi, 'markAsRead').mockResolvedValue({ ok: true } as Response);
+    jest.spyOn(notificationApi, 'markAsRead').mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/src/shared/api/parse-response.ts
+++ b/src/shared/api/parse-response.ts
@@ -1,0 +1,25 @@
+/**
+ * fetch Response를 파싱하는 공통 유틸입니다.
+ * - 응답 실패 시 에러 메시지를 추출해 throw합니다.
+ * - 응답 성공 시 JSON을 파싱해 반환합니다.
+ */
+export async function parseResponse<T>(response: Response, fallbackMessage: string): Promise<T> {
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.message || fallbackMessage);
+  }
+  return response.json();
+}
+
+/**
+ * 응답 본문이 없는 요청(DELETE, PUT 등)에 사용합니다.
+ */
+export async function parseVoidResponse(
+  response: Response,
+  fallbackMessage: string
+): Promise<void> {
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.message || fallbackMessage);
+  }
+}


### PR DESCRIPTION
### 📌 유형 (Type)                                                                                                      
                                                                                                                          
  - [ ] **Feat (기능):** 새로운 기능 추가                                                                                 
  - [ ] **Fix (버그 수정):** 버그 수정                                                                                    
  - [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)                                                          
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)                                                                 
  - [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)                                           
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등                                                       
                                                                                                                          
  ### 📝 변경 사항 (Changes)                                                                                              
                                                                                                                          
  closes #346     

  기존에 클라이언트 API 함수마다 아래 패턴이 7개 파일에 걸쳐 중복되어 있었습니다.                                         
   
  ```ts                                                                                                                   
  if (!response.ok) {
    const errorData = await response.json().catch(() => ({}));                                                            
    throw new Error(errorData.message || '...');
  }                                                                                                                       
  return response.json();
  ```

  이를 공통 유틸(`src/shared/api/parse-response.ts`)로 분리하고 전체 API 파일에 일괄 적용했습니다.                        
  **기능 변경은 없으며, 코드 구조 정리만 포함됩니다.**
                                                                                                                          
  - `parseResponse<T>` — `response.ok` 체크 후 JSON 파싱 및 반환
  - `parseVoidResponse` — `response.ok` 체크만 수행 (응답 바디 없는 경우)                                                 
  - 두 함수를 별도로 유지한 이유: 반환 타입과 사용 의도가 달라 **가독성** 측면에서 분리                                   
                                                                                                                          
  적용된 파일:                                                                                                            
  - `src/entities/meeting/api/meetings.api.ts`                                                                            
  - `src/entities/meeting-comment/api/meeting-comment.api.ts`
  - `src/entities/auth/api/auth.api.ts`                                                                                   
  - `src/entities/favorites/api/favorites.api.ts`
  - `src/entities/image/api/images.api.ts`                                                                                
  - `src/features/notifications/api/notifications.api.ts`                                                                 
  - `src/entities/post/api/posts.api.ts`
                                                                                                                          
  리팩토링 중 발견된 버그도 함께 수정했습니다.                                                                            
   
  - `favorites.api.ts` — 에러 시 빈 배열을 반환하던 문제 → 에러를 throw하도록 수정                                        
  - `notifications.api.ts` — `response.ok` 체크 누락 수정, 영문 에러 메시지 한국어화
                                                                                                                          
  ### 🧪 테스트 방법 (How to Test)                                                                                        
   
  1. 로컬 환경에서 앱을 실행합니다.                                                                                       
  2. 모임 목록 조회, 모임 생성, 댓글 작성, 알림 조회 등 주요 API 동작을 확인합니다.
  3. 네트워크 탭에서 API 요청/응답이 이전과 동일하게 동작하는지 확인합니다.                                               
  4. 에러 상황(서버 오류 등) 발생 시 에러 토스트가 정상 노출되는지 확인합니다.                                            
                                                                                                                          
  ### 📸 스크린샷 또는 영상 (Optional)                                                                                    
                                                                                                                          
  (UI 변경 없음)  

  ### 🚨 기타 참고 사항 (Notes)                                                                                           
   
  - [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**                                                 
    - `auth.logout()`은 의도적으로 에러 체크 없음 — BFF에서 응답 성공 여부와 무관하게 항상 쿠키를 파기하므로 클라이언트
  세션은 항상 종료된 것으로 처리합니다.                                                                                   
    - S3 업로드(`uploadToS3`)는 응답이 JSON이 아니므로 `parseResponse` 미사용, raw fetch + 수동 체크를 유지합니다.
    - `posts.api.ts`는 OpenAPI Generator의 `FromJSON` 함수가 `any`를 받는 구조상 `parseResponse<unknown>` 후 타입         
  캐스팅하는 패턴을 사용합니다. 이는 기존 코드의 한계이며 이번 PR 범위 밖입니다.                                          