### PR TITLE
[Fix]: 나의 모임 / 내가 만든 모임 하트 활성화

### DIFF
--- a/src/widgets/mypage/model/mypage.service.ts
+++ b/src/widgets/mypage/model/mypage.service.ts
@@ -20,24 +20,28 @@ const toVariant = (type?: string): 'groupBuy' | 'groupEat' =>
 
 const toImageUrl = (image?: string) => (image?.startsWith('https://') ? image : undefined);
 
-const toMeetingCard = (m: UserMeetingWithImage): MyPageCardProps => ({
-  meetingId: m.id,
-  href: `/meetings/${m.id}`,
-  title: m.name,
-  currentCount: m.participantCount,
-  maxCount: m.capacity,
-  location: m.region,
-  ...parseDateTime(m.dateTime),
-  variant: toVariant(m.type),
-  confirmedAt: m.confirmedAt ? new Date(m.confirmedAt) : null,
-  isCompleted: isCompleted(m.dateTime),
-  isHost: m.role === UserMeetingRoleEnum.Host,
-  imageUrl: toImageUrl(m.image),
-  isFavorited: false,
-});
+const toMeetingCard =
+  (favoritedIds: Set<number>) =>
+  (m: UserMeetingWithImage): MyPageCardProps => ({
+    meetingId: m.id,
+    href: `/meetings/${m.id}`,
+    title: m.name,
+    currentCount: m.participantCount,
+    maxCount: m.capacity,
+    location: m.region,
+    ...parseDateTime(m.dateTime),
+    variant: toVariant(m.type),
+    confirmedAt: m.confirmedAt ? new Date(m.confirmedAt) : null,
+    isCompleted: isCompleted(m.dateTime),
+    isHost: m.role === UserMeetingRoleEnum.Host,
+    imageUrl: toImageUrl(m.image),
+    isFavorited: favoritedIds.has(m.id),
+  });
 
-export const toUserMeetingCards = (data: UserMeetingsResponseWithImage): MyPageCardProps[] =>
-  data.data.map(toMeetingCard);
+export const toUserMeetingCards = (
+  data: UserMeetingsResponseWithImage,
+  favoritedIds: Set<number> = new Set()
+): MyPageCardProps[] => data.data.map(toMeetingCard(favoritedIds));
 
 export const toFavoriteMeetingCards = (data: FavoriteList): MyPageCardProps[] =>
   data.data.map((f) => ({

--- a/src/widgets/mypage/model/use-meeting-tabs.ts
+++ b/src/widgets/mypage/model/use-meeting-tabs.ts
@@ -1,7 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import { useCreatedMeetings, useFavoriteMeetings, useJoinedMeetings } from './mypage.queries';
 import { toFavoriteMeetingCards, toUserMeetingCards } from './mypage.service';
 import { TabValue } from './mypage.types';
@@ -11,18 +9,18 @@ export function useMeetingTabs(activeTab: TabValue) {
   const createdQuery = useCreatedMeetings();
   const favoriteQuery = useFavoriteMeetings();
 
-  const cards = useMemo(() => {
-    if (activeTab === 'all' && joinedQuery.data) {
-      return toUserMeetingCards(joinedQuery.data);
-    }
-    if (activeTab === 'created' && createdQuery.data) {
-      return toUserMeetingCards(createdQuery.data);
-    }
-    if (activeTab === 'favorite' && favoriteQuery.data) {
-      return toFavoriteMeetingCards(favoriteQuery.data);
-    }
-    return [];
-  }, [activeTab, joinedQuery.data, createdQuery.data, favoriteQuery.data]);
+  const favoritedIds = new Set(favoriteQuery.data?.data.map((f) => f.meeting.id) ?? []);
+
+  let cards: ReturnType<typeof toUserMeetingCards>;
+  if (activeTab === 'all' && joinedQuery.data) {
+    cards = toUserMeetingCards(joinedQuery.data, favoritedIds);
+  } else if (activeTab === 'created' && createdQuery.data) {
+    cards = toUserMeetingCards(createdQuery.data, favoritedIds);
+  } else if (activeTab === 'favorite' && favoriteQuery.data) {
+    cards = toFavoriteMeetingCards(favoriteQuery.data);
+  } else {
+    cards = [];
+  }
 
   const isLoading =
     (activeTab === 'all' && joinedQuery.isLoading) ||

--- a/src/widgets/mypage/model/use-meeting-tabs.ts
+++ b/src/widgets/mypage/model/use-meeting-tabs.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { useCreatedMeetings, useFavoriteMeetings, useJoinedMeetings } from './mypage.queries';
 import { toFavoriteMeetingCards, toUserMeetingCards } from './mypage.service';
 import { TabValue } from './mypage.types';
@@ -9,18 +11,19 @@ export function useMeetingTabs(activeTab: TabValue) {
   const createdQuery = useCreatedMeetings();
   const favoriteQuery = useFavoriteMeetings();
 
-  const favoritedIds = new Set(favoriteQuery.data?.data.map((f) => f.meeting.id) ?? []);
-
-  let cards: ReturnType<typeof toUserMeetingCards>;
-  if (activeTab === 'all' && joinedQuery.data) {
-    cards = toUserMeetingCards(joinedQuery.data, favoritedIds);
-  } else if (activeTab === 'created' && createdQuery.data) {
-    cards = toUserMeetingCards(createdQuery.data, favoritedIds);
-  } else if (activeTab === 'favorite' && favoriteQuery.data) {
-    cards = toFavoriteMeetingCards(favoriteQuery.data);
-  } else {
-    cards = [];
-  }
+  const cards = useMemo(() => {
+    const favoritedIds = new Set(favoriteQuery.data?.data.map((f) => f.meeting.id) ?? []);
+    if (activeTab === 'all' && joinedQuery.data) {
+      return toUserMeetingCards(joinedQuery.data, favoritedIds);
+    }
+    if (activeTab === 'created' && createdQuery.data) {
+      return toUserMeetingCards(createdQuery.data, favoritedIds);
+    }
+    if (activeTab === 'favorite' && favoriteQuery.data) {
+      return toFavoriteMeetingCards(favoriteQuery.data);
+    }
+    return [];
+  }, [activeTab, joinedQuery.data, createdQuery.data, favoriteQuery.data]);
 
   const isLoading =
     (activeTab === 'all' && joinedQuery.isLoading) ||


### PR DESCRIPTION
## [Fix]: 나의 모임 / 내가 만든 모임 하트 활성화

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

찜한 모임 탭에서만 하트 버튼이 활성화되고, 나의 모임 / 내가 만든 모임 탭에서는 항상 비활성화되던 버그를 수정했습니다.

**원인**
: `toMeetingCard`에서 `isFavorited: false`로 하드코딩되어 있어 탭과 무관하게 항상 비활성 상태였습니다.

**수정 내용**
- `mypage.service.ts`: `toUserMeetingCards`가 `favoritedIds: Set<number>`를 받아 각 카드의 `isFavorited`를 정확히 설정하도록 수정
- `use-meeting-tabs.ts`: 이미 캐싱된 favorites list에서 찜한 미팅 ID Set을 만들어 전달 (추가 API 호출 없음)
### 🧪 테스트 방법 (How to Test)

1. 로그인 후 특정 모임을 찜합니다.
2. 마이페이지 이동합니다.
3. **나의 모임** 탭에서 찜한 모임의 하트 버튼이 활성화(빨간색)되어 있는지 확인합니다.
4. **내가 만든 모임** 탭에서도 동일하게 확인합니다.
5. 하트 버튼 토글 시 세 탭 모두에서 상태가 정상적으로 반영되는지 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

**[나의 모임 / 내가 만든 모임 하트 활성화]**

<img width="1137" height="581" alt="image" src="https://github.com/user-attachments/assets/afdfdb0f-eb5a-4d32-9fde-96eb632ac6d0" />
<img width="1130" height="331" alt="image" src="https://github.com/user-attachments/assets/fc0f1f6e-3e97-42af-9e1a-74f9115921b2" />
