### PR TITLE
fix: COMMENT_SERVER_URL trailing slash로 인한 이중 슬래시 버그 수정

### DIFF
--- a/src/shared/api/comment-server.ts
+++ b/src/shared/api/comment-server.ts
@@ -1,6 +1,6 @@
 import { CookieStorage } from '../lib/cookie-storage';
 
-const COMMENT_SERVER_URL = process.env.COMMENT_SERVER_URL;
+const COMMENT_SERVER_URL = process.env.COMMENT_SERVER_URL?.replace(/\/$/, '');
 
 /**
  * [Server-only] commentServer


### PR DESCRIPTION
### 📌 유형 (Type)

   - [ ] **Feat (기능):** 새로운 기능 추가
   - [x] **Fix (버그 수정):** 버그 수정
   - [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
   - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
   - [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
   - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

   ### 📝 변경 사항 (Changes)

   - `COMMENT_SERVER_URL` 환경변수에 trailing slash가 포함된 경우, URL 조합 시 이중 슬래시(`//`)가 발생해 comment 서버가 404를 반환했습니다.
   - 4월 10일 `MeetingCommentFetcher`에 `HydrationBoundary`가 추가된 이후, SSR의 빈 배열(`[]`)이 클라이언트 캐시에 주입되고 `staleTime: 30_000`으로
   인해 클라이언트 재요청이 없어 댓글이 미노출되는 문제로 이어졌습니다.
   - `/api/comment-proxy` 라우트에는 이미 `replace(/\/$/, '')`가 적용되어 있었으나 `comment-server.ts`에만 누락되어 있어, 동일한 처리를 추가했습니다.

   ### 🧪 테스트 방법 (How to Test)

   1. 로컬 환경에서 앱을 실행합니다.
   2. 모임 상세 페이지(`/meetings/:id`)로 이동합니다.
   3. 댓글 섹션에 댓글이 정상적으로 노출되는지 확인합니다.

   ### 📸 스크린샷 또는 영상 (Optional)

   | 변경 전 (Before) | 변경 후 (After) |
   | :--------------: | :-------------: |
   |  댓글 미노출   |  댓글 정상 노출  |