### PR TITLE
[Refactor]: sosotalk 메인 페이지 서버 초기 데이터 적용

### DIFF
--- a/src/app/sosotalk/page.tsx
+++ b/src/app/sosotalk/page.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from 'next';
 
-import { SosoTalkMainPage } from '@/widgets/sosotalk';
+import { SearchParams } from 'nuqs';
+
+import { getSosoTalkPosts } from '@/entities/post/index.server';
+import {
+  createSosoTalkMainPageQueryParams,
+  SosoTalkMainPage,
+  sosotalkSearchParamsCache,
+} from '@/widgets/sosotalk';
 
 export const metadata: Metadata = {
   title: '소소톡',
@@ -13,6 +20,18 @@ export const metadata: Metadata = {
   },
 };
 
-export default function SosoTalkPage() {
-  return <SosoTalkMainPage />;
+type SosoTalkPageProps = {
+  searchParams?: Promise<SearchParams>;
+};
+
+export default async function SosoTalkPage({ searchParams }: SosoTalkPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  const { tab, sort } = sosotalkSearchParamsCache.parse(resolvedSearchParams);
+  const queryParams = createSosoTalkMainPageQueryParams(tab, sort);
+
+  const initialData = await getSosoTalkPosts(queryParams).catch(() => null);
+
+  return (
+    <SosoTalkMainPage initialData={initialData ?? undefined} initialTab={tab} initialSort={sort} />
+  );
 }

--- a/src/entities/post/api/posts.server.ts
+++ b/src/entities/post/api/posts.server.ts
@@ -1,0 +1,38 @@
+import { apiServer } from '@/shared/api/api-server';
+import { parseResponse } from '@/shared/api/parse-response';
+import { PostListFromJSON } from '@/shared/types/generated-client/models/PostList';
+
+import type { GetSosoTalkPostListParams, GetSosoTalkPostListResponse } from '../model/post.types';
+
+const DEFAULT_SOSOTALK_POST_LIST_PARAMS: Required<
+  Pick<GetSosoTalkPostListParams, 'type' | 'sortBy' | 'sortOrder' | 'size'>
+> = {
+  type: 'all',
+  sortBy: 'createdAt',
+  sortOrder: 'desc',
+  size: 10,
+};
+
+export async function getSosoTalkPosts(
+  params: GetSosoTalkPostListParams = {}
+): Promise<GetSosoTalkPostListResponse> {
+  const mergedParams = {
+    ...DEFAULT_SOSOTALK_POST_LIST_PARAMS,
+    ...params,
+  };
+  const searchParams = new URLSearchParams();
+
+  Object.entries(mergedParams).forEach(([key, value]) => {
+    if (value == null) {
+      return;
+    }
+
+    searchParams.set(key, String(value));
+  });
+
+  const query = searchParams.toString();
+  const response = await apiServer.get(`/posts${query ? `?${query}` : ''}`);
+  const data = await parseResponse<unknown>(response, '소소톡 게시글 목록을 불러오지 못했습니다.');
+
+  return PostListFromJSON(data) as GetSosoTalkPostListResponse;
+}

--- a/src/entities/post/index.server.ts
+++ b/src/entities/post/index.server.ts
@@ -1,0 +1,1 @@
+export { getSosoTalkPosts } from './api/posts.server';

--- a/src/entities/post/model/post.queries.ts
+++ b/src/entities/post/model/post.queries.ts
@@ -34,10 +34,14 @@ export const sosotalkQueryKeys = {
   postDetail: (postId?: number) => ['sosotalk-post-detail', postId] as const,
 };
 
-export const sosotalkPostListQueryOptions = (params?: GetSosoTalkPostListParams) =>
+export const sosotalkPostListQueryOptions = (
+  params?: GetSosoTalkPostListParams,
+  initialData?: GetSosoTalkPostListResponse
+) =>
   queryOptions({
     queryKey: sosotalkQueryKeys.postList(params),
     queryFn: () => getSosoTalkPostList(params),
+    initialData,
     staleTime: SOSOTALK_QUERY_STALE_TIME,
     gcTime: SOSOTALK_QUERY_GC_TIME,
   });
@@ -57,8 +61,10 @@ export const sosotalkPostDetailQueryOptions = (postId?: number) =>
     gcTime: SOSOTALK_QUERY_GC_TIME,
   });
 
-export const useGetSosoTalkPostList = (params?: GetSosoTalkPostListParams) =>
-  useQuery(sosotalkPostListQueryOptions(params));
+export const useGetSosoTalkPostList = (
+  params?: GetSosoTalkPostListParams,
+  initialData?: GetSosoTalkPostListResponse
+) => useQuery(sosotalkPostListQueryOptions(params, initialData));
 
 export const useGetSosoTalkPostDetail = (postId?: number) =>
   useQuery(sosotalkPostDetailQueryOptions(postId));

--- a/src/widgets/sosotalk/index.ts
+++ b/src/widgets/sosotalk/index.ts
@@ -1,2 +1,4 @@
+export { sosotalkSearchParamsCache } from './model/search-param';
 export { SosoTalkMainPage } from './ui/sosotalk-main-page';
+export { createSosoTalkMainPageQueryParams } from './ui/sosotalk-main-page/model/sosotalk-main-page.utils';
 export { SosoTalkPostDetailPage } from './ui/sosotalk-post-detail/sosotalk-post-detail-page';

--- a/src/widgets/sosotalk/model/search-param.ts
+++ b/src/widgets/sosotalk/model/search-param.ts
@@ -1,0 +1,6 @@
+import { createSearchParamsCache, parseAsStringEnum } from 'nuqs/server';
+
+export const sosotalkSearchParamsCache = createSearchParamsCache({
+  tab: parseAsStringEnum(['all', 'popular']).withDefault('all'),
+  sort: parseAsStringEnum(['comments', 'likes', 'latest']).withDefault('latest'),
+});

--- a/src/widgets/sosotalk/ui/sosotalk-filter-bar/sosotalk-filter-bar.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-filter-bar/sosotalk-filter-bar.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useSyncExternalStore } from 'react';
-
 import { ChevronDown } from 'lucide-react';
 
 import { cn } from '@/shared/lib/utils';
@@ -39,12 +37,6 @@ export const SosoTalkFilterBar = ({
   onTabChange = () => {},
   onSortChange = () => {},
 }: SosoTalkFilterBarProps) => {
-  const isMounted = useSyncExternalStore(
-    () => () => {},
-    () => true,
-    () => false
-  );
-
   const selectedSortOption =
     sortOptions.find((option) => option.value === activeSort) ??
     sortOptions[0] ??
@@ -110,32 +102,29 @@ export const SosoTalkFilterBar = ({
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              className="text-sosoeat-gray-900 inline-flex h-8 items-center gap-1 text-base leading-none font-medium disabled:pointer-events-none md:hidden"
-              aria-label="?뺣젹 ?듭뀡"
-              disabled={!isMounted}
+              className="text-sosoeat-gray-900 inline-flex h-8 items-center gap-1 text-base leading-none font-medium md:hidden"
+              aria-label="정렬 옵션 열기"
             >
               <span>{selectedSortOption.label}</span>
               <ChevronDown className="size-4" aria-hidden />
             </button>
           </DropdownMenuTrigger>
-          {isMounted ? (
-            <DropdownMenuContent align="end" className="md:hidden">
-              <DropdownMenuRadioGroup
-                value={activeSort}
-                onValueChange={(value) => onSortChange(value as typeof activeSort)}
-              >
-                {sortOptions.map((option) => (
-                  <DropdownMenuRadioItem
-                    key={option.value}
-                    value={option.value}
-                    className="text-sosoeat-gray-900 py-2"
-                  >
-                    {option.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          ) : null}
+          <DropdownMenuContent align="end" className="md:hidden">
+            <DropdownMenuRadioGroup
+              value={activeSort}
+              onValueChange={(value) => onSortChange(value as typeof activeSort)}
+            >
+              {sortOptions.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.value}
+                  value={option.value}
+                  className="text-sosoeat-gray-900 py-2"
+                >
+                  {option.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
         </DropdownMenu>
       </div>
     </section>

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts
@@ -1,7 +1,7 @@
 import { createSosoTalkMainPageQueryParams } from './sosotalk-main-page.utils';
 
 describe('createSosoTalkMainPageQueryParams', () => {
-  it('인기 탭과 댓글 정렬 조합을 목록 쿼리 파라미터로 변환한다', () => {
+  it('인기 탭과 댓글순 정렬 조합을 목록 쿼리 파라미터로 변환한다', () => {
     expect(createSosoTalkMainPageQueryParams('popular', 'comments')).toEqual({
       type: 'best',
       sortBy: 'commentCount',
@@ -10,10 +10,19 @@ describe('createSosoTalkMainPageQueryParams', () => {
     });
   });
 
-  it('전체 탭과 최신 정렬 조합을 목록 쿼리 파라미터로 변환한다', () => {
+  it('전체 탭과 최신순 정렬 조합을 목록 쿼리 파라미터로 변환한다', () => {
     expect(createSosoTalkMainPageQueryParams('all', 'latest')).toEqual({
       type: 'all',
       sortBy: 'createdAt',
+      sortOrder: 'desc',
+      size: 10,
+    });
+  });
+
+  it('전체 탭과 좋아요순 정렬 조합을 목록 쿼리 파라미터로 변환한다', () => {
+    expect(createSosoTalkMainPageQueryParams('all', 'likes')).toEqual({
+      type: 'all',
+      sortBy: 'likeCount',
       sortOrder: 'desc',
       size: 10,
     });

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react';
+
+import type { GetSosoTalkPostListResponse } from '@/entities/post';
+import { mapPostToSosoTalkCardItem, useGetSosoTalkPostList } from '@/entities/post';
+
+import { useSosoTalkMainPage } from './use-sosotalk-main-page';
+
+jest.mock('nuqs', () => ({
+  parseAsStringLiteral: () => ({
+    withDefault: () => ({
+      withOptions: () => ({}),
+    }),
+  }),
+  useQueryState: jest.fn(),
+}));
+
+jest.mock('@/entities/post', () => ({
+  mapPostToSosoTalkCardItem: jest.fn(),
+  useGetSosoTalkPostList: jest.fn(),
+}));
+
+const mockUseQueryState = jest.requireMock('nuqs').useQueryState as jest.Mock;
+const mockUseGetSosoTalkPostList = useGetSosoTalkPostList as jest.Mock;
+const mockMapPostToSosoTalkCardItem = mapPostToSosoTalkCardItem as jest.Mock;
+
+const initialData: GetSosoTalkPostListResponse = {
+  data: [
+    {
+      id: 1,
+      teamId: 'dallaem',
+      title: '게시글',
+      content: '<p>본문</p>',
+      image: '',
+      authorId: 2,
+      viewCount: 0,
+      likeCount: 0,
+      createdAt: new Date('2026-04-14T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-14T00:00:00.000Z'),
+      author: {
+        id: 2,
+        name: '테스터',
+        image: '',
+      },
+      count: {
+        comments: 0,
+      },
+    },
+  ],
+  hasMore: false,
+};
+
+describe('useSosoTalkMainPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseGetSosoTalkPostList.mockReturnValue({
+      data: initialData,
+      isLoading: false,
+      isError: false,
+    });
+    mockMapPostToSosoTalkCardItem.mockImplementation((post) => post);
+  });
+
+  it('현재 탭과 정렬이 초기 상태와 같으면 initialData를 쿼리 초기값으로 전달한다', () => {
+    mockUseQueryState
+      .mockReturnValueOnce(['all', jest.fn()])
+      .mockReturnValueOnce(['latest', jest.fn()]);
+
+    renderHook(() =>
+      useSosoTalkMainPage({
+        initialData,
+        initialTab: 'all',
+        initialSort: 'latest',
+      })
+    );
+
+    expect(mockUseGetSosoTalkPostList).toHaveBeenCalledWith(
+      {
+        type: 'all',
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+        size: 10,
+      },
+      initialData
+    );
+  });
+
+  it('현재 탭과 정렬이 초기 상태와 다르면 initialData를 재사용하지 않는다', () => {
+    mockUseQueryState
+      .mockReturnValueOnce(['popular', jest.fn()])
+      .mockReturnValueOnce(['likes', jest.fn()]);
+
+    renderHook(() =>
+      useSosoTalkMainPage({
+        initialData,
+        initialTab: 'all',
+        initialSort: 'latest',
+      })
+    );
+
+    expect(mockUseGetSosoTalkPostList).toHaveBeenCalledWith(
+      {
+        type: 'best',
+        sortBy: 'likeCount',
+        sortOrder: 'desc',
+        size: 10,
+      },
+      undefined
+    );
+  });
+});

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
@@ -1,7 +1,10 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
+
+import type { GetSosoTalkPostListResponse } from '@/entities/post';
 import { mapPostToSosoTalkCardItem, useGetSosoTalkPostList } from '@/entities/post';
 
 import type {
@@ -11,15 +14,39 @@ import type {
 
 import { createSosoTalkMainPageQueryParams } from './sosotalk-main-page.utils';
 
-export function useSosoTalkMainPage() {
-  const [activeTab, setActiveTab] = useState<SosoTalkTabValue>('all');
-  const [activeSort, setActiveSort] = useState<SosoTalkSortValue>('latest');
+interface UseSosoTalkMainPageParams {
+  initialData?: GetSosoTalkPostListResponse;
+  initialTab?: SosoTalkTabValue;
+  initialSort?: SosoTalkSortValue;
+}
+
+export function useSosoTalkMainPage({
+  initialData,
+  initialTab = 'all',
+  initialSort = 'latest',
+}: UseSosoTalkMainPageParams) {
+  const [activeTab, setActiveTab] = useQueryState<SosoTalkTabValue>(
+    'tab',
+    parseAsStringLiteral(['all', 'popular'] as const)
+      .withDefault('all')
+      .withOptions({ history: 'push' })
+  );
+  const [activeSort, setActiveSort] = useQueryState<SosoTalkSortValue>(
+    'sort',
+    parseAsStringLiteral(['comments', 'likes', 'latest'] as const)
+      .withDefault('latest')
+      .withOptions({ history: 'push' })
+  );
 
   const queryParams = useMemo(
     () => createSosoTalkMainPageQueryParams(activeTab, activeSort),
     [activeSort, activeTab]
   );
-  const { data, isLoading, isError } = useGetSosoTalkPostList(queryParams);
+  const shouldUseInitialData = activeTab === initialTab && activeSort === initialSort;
+  const { data, isLoading, isError } = useGetSosoTalkPostList(
+    queryParams,
+    shouldUseInitialData ? initialData : undefined
+  );
   const posts = useMemo(() => data?.data.map(mapPostToSosoTalkCardItem) ?? [], [data]);
 
   return {
@@ -28,7 +55,7 @@ export function useSosoTalkMainPage() {
     isError,
     isLoading,
     posts,
-    setActiveSort,
-    setActiveTab,
+    setActiveSort: (value: SosoTalkSortValue) => void setActiveSort(value),
+    setActiveTab: (value: SosoTalkTabValue) => void setActiveTab(value),
   };
 }

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 
 import { Plus } from 'lucide-react';
 
+import type { GetSosoTalkPostListResponse } from '@/entities/post';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 
@@ -15,14 +16,22 @@ import { useSosoTalkMainPage } from './model';
 
 interface SosoTalkMainPageProps {
   className?: string;
+  initialData?: GetSosoTalkPostListResponse;
+  initialTab?: 'all' | 'popular';
+  initialSort?: 'comments' | 'likes' | 'latest';
 }
 
 const SOSOTALK_BANNER_IMAGE =
   'https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=1600&auto=format&fit=crop';
 
-export const SosoTalkMainPage = ({ className }: SosoTalkMainPageProps) => {
+export const SosoTalkMainPage = ({
+  className,
+  initialData,
+  initialTab,
+  initialSort,
+}: SosoTalkMainPageProps) => {
   const { activeSort, activeTab, isError, isLoading, posts, setActiveSort, setActiveTab } =
-    useSosoTalkMainPage();
+    useSosoTalkMainPage({ initialData, initialTab, initialSort });
 
   return (
     <div className={cn('bg-background min-h-screen w-full bg-[#f9f9f9] pb-24 md:pb-28', className)}>


### PR DESCRIPTION
### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 정리 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드, 테스트, 라이브러리 업데이트, 설정 등

### 🔎 변경 사항 (Changes)

- #363
- 소소토크 메인 페이지가 서버에서 초기 목록 데이터를 받아 첫 렌더에 바로 사용할 수 있도록 변경했습니다.
- `tab`, `sort` 쿼리 파라미터를 서버에서도 동일하게 해석하도록 정리했습니다.
- 클라이언트에서는 현재 URL 상태가 서버 초기 상태와 같을 때만 `initialData`를 재사용하도록 처리했습니다.
- 필터 바 렌더 구조를 정리해 hydration warning 원인이 될 수 있던 불일치 가능성을 줄였습니다.
- 쿼리 파라미터 변환 테스트와 `initialData` 조건 테스트를 추가했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬에서 `npm run dev`를 실행합니다.
2. `/sosotalk`에 접속해 첫 진입 시 목록이 정상적으로 노출되는지 확인합니다.
3. `tab`, `sort` 값을 바꿨을 때 목록이 정상 갱신되는지 확인합니다.
4. 브라우저 콘솔에서 hydration 관련 경고가 없는지 확인합니다.
5. 아래 명령어가 통과하는지 확인합니다.
   - `npm run type-check`
   - `npm test -- --runInBand src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts`

### 📷 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### ✅ 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
- 필터 바 hydration warning 대응 방향이 적절한지 한 번 더 봐주시면 좋겠습니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
