### PR TITLE
[Feat]: 이런 모임은 어때요? 섹션 개선 - ghost image 수정 및 지난 모임 필터링

### DIFF
--- a/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
@@ -13,10 +13,10 @@ export async function MeetingRecommendedFetcher({ meetingId }: Props) {
     data: [],
   }));
 
-  return (
-    <MeetingRecommendedSection
-      meetings={meetingList.data as unknown as Meeting[]}
-      currentMeetingId={meetingId}
-    />
+  const now = new Date();
+  const futureMeetings = (meetingList.data as unknown as Meeting[]).filter(
+    (m) => new Date(m.dateTime) > now
   );
+
+  return <MeetingRecommendedSection meetings={futureMeetings} currentMeetingId={meetingId} />;
 }

--- a/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.tsx
@@ -42,6 +42,7 @@ export default function RecommendedMeetingCard({ meeting, onClick }: Recommended
               fill
               sizes="302px"
               className="object-cover"
+              draggable={false}
             />
             <div
               className="absolute right-5 bottom-5 cursor-pointer"


### PR DESCRIPTION
  ### 📌 유형 (Type)                                                                                           
                                                                                                               
  - [x] **Feat (기능):** 새로운 기능 추가                                                                      
  - [x] **Fix (버그 수정):** 버그 수정                                                                         
                                                                                                               
  ### 📝 변경 사항 (Changes)
                                                                                                               
  - 어떤 문제가 있었는지? (#367)                                                                               
   
    1. 미팅 상세페이지 "이런 모임은 어때요?" 카드 이미지를 드래그하면 브라우저 기본 동작으로 ghost image가     
  생성되어 커서를 따라오는 현상이 발생했습니다.             
    2. 이미 지난 모임이 추천 목록에 노출되고 있었습니다.                                                       
                                                                                                               
  - 무엇을 어떻게 변경했는지?                                                                                  
                                                                                                               
    1. `RecommendedMeetingCard`의 `<Image>` 컴포넌트에 `draggable={false}` 속성을 추가해 ghost image 발생을    
  차단했습니다.                                             
    2. 백엔드 API(`/{teamId}/meetings`)가 날짜 기준 필터링을 지원하지 않아, Next.js Server                     
  Component(`MeetingRecommendedFetcher`)에서 `dateTime > now` 조건으로 지난 모임을 제외했습니다.               
   
  ### 🧪 테스트 방법 (How to Test)                                                                             
                                                            
  1. 로컬 환경에서 앱을 실행합니다.                                                                            
  2. 임의의 미팅 상세페이지(`/meetings/:id`)로 이동합니다.
  3. 하단 "이런 모임은 어때요?" 섹션 카드 이미지를 마우스로 드래그합니다.                                      
     - **기대 결과:** ghost image 없이 드래그가 무시됩니다.                                                    
  4. 추천 목록에 노출된 모임의 날짜를 확인합니다.                                                              
     - **기대 결과:** 현재 시각 이전의 모임은 표시되지 않습니다.                                               
                                                                                                               
  ### 📸 스크린샷 또는 영상 (Optional)                      
                                                                                                               
  | 변경 전 (Before) | 변경 후 (After) |                                                                       
  | :--------------: | :-------------: |
  |                  |                 |                                                                       
                                                            
  ### 🚨 기타 참고 사항 (Notes)                                                                                
                                                            
  - [x] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**                                      
                                                            
    `MeetingRecommendedFetcher`에서 `getMeetings` 반환 타입(`MeetingWithHost`)과 엔티티 타입(`Meeting`)이 달라 
  `as unknown as Meeting[]` 이중 캐스팅이 발생하고 있습니다. OpenAPI generated 타입과 엔티티 타입 통일 작업을
  별도 PR에서 진행 예정입니다.  