### PR TITLE
[Refactor]: MeetingWithHost → Meeting 타입 통일 및 이중 캐스팅 제거

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 
+import type { Meeting } from '@/entities/meeting';
 import { getMeetings } from '@/entities/meeting/index.server';
-import { MeetingWithHost } from '@/shared/types/generated-client/models/MeetingWithHost';
 import {
   BestSoeatSection,
   CtaSection,
@@ -13,9 +13,7 @@ import {
 
 const MainBanner = dynamic(() => import('@/widgets/main-banner').then((mod) => mod.MainBanner));
 
-async function getHomeMeetings(
-  params: Parameters<typeof getMeetings>[0]
-): Promise<MeetingWithHost[]> {
+async function getHomeMeetings(params: Parameters<typeof getMeetings>[0]): Promise<Meeting[]> {
   try {
     const { data } = await getMeetings(params);
     return data;

--- a/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
@@ -1,4 +1,3 @@
-import type { Meeting } from '@/entities/meeting';
 import { getMeetings } from '@/entities/meeting/index.server';
 import { MeetingRecommendedSection } from '@/widgets/meeting-detail';
 import { getMeetingById } from '@/widgets/meeting-detail/index.server';
@@ -14,9 +13,7 @@ export async function MeetingRecommendedFetcher({ meetingId }: Props) {
   }));
 
   const now = new Date();
-  const futureMeetings = (meetingList.data as unknown as Meeting[]).filter(
-    (m) => new Date(m.dateTime) > now
-  );
+  const futureMeetings = meetingList.data.filter((m) => new Date(m.dateTime) > now);
 
   return <MeetingRecommendedSection meetings={futureMeetings} currentMeetingId={meetingId} />;
 }

--- a/src/entities/meeting/api/meetings.api.ts
+++ b/src/entities/meeting/api/meetings.api.ts
@@ -2,13 +2,12 @@ import qs from 'qs';
 
 import { fetchClient } from '@/shared/api/fetch-client';
 import { parseResponse, parseVoidResponse } from '@/shared/api/parse-response';
-import { MeetingList, TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
+import { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
 import { CreateMeeting } from '@/shared/types/generated-client/models/CreateMeeting';
-import { MeetingWithHost } from '@/shared/types/generated-client/models/MeetingWithHost';
 import { UpdateMeeting } from '@/shared/types/generated-client/models/UpdateMeeting';
 import { UpdateMeetingStatus } from '@/shared/types/generated-client/models/UpdateMeetingStatus';
 
-import type { Meeting } from '../model/meeting.types';
+import type { Meeting, MeetingListResult } from '../model/meeting.types';
 
 const makeQueryString = (params: Omit<TeamIdMeetingsGetRequest, 'teamId'>): string => {
   return qs.stringify(params, {
@@ -28,38 +27,38 @@ export const meetingsApi = {
     return parseResponse<Meeting>(response, '모임 조회에 실패했습니다.');
   },
 
-  async getList(): Promise<MeetingList> {
+  async getList(): Promise<MeetingListResult> {
     const response = await fetchClient.get('/meetings');
-    return parseResponse<MeetingList>(response, '모임 목록 조회에 실패했습니다.');
+    return parseResponse<MeetingListResult>(response, '모임 목록 조회에 실패했습니다.');
   },
 
-  async getByFilter(options: Omit<TeamIdMeetingsGetRequest, 'teamId'>): Promise<MeetingList> {
+  async getByFilter(options: Omit<TeamIdMeetingsGetRequest, 'teamId'>): Promise<MeetingListResult> {
     const queryString = makeQueryString(options);
     const response = await fetchClient.get(`/meetings${queryString}`);
-    return parseResponse<MeetingList>(response, '모임 목록 조회에 실패했습니다.');
+    return parseResponse<MeetingListResult>(response, '모임 목록 조회에 실패했습니다.');
   },
 
   /**
    * 모임 생성 요청
    * POST /meetings
    */
-  async create(payload: CreateMeeting): Promise<MeetingWithHost> {
+  async create(payload: CreateMeeting): Promise<Meeting> {
     const response = await fetchClient.post('/meetings', payload);
-    return parseResponse<MeetingWithHost>(response, '모임 생성에 실패했습니다.');
+    return parseResponse<Meeting>(response, '모임 생성에 실패했습니다.');
   },
 
   /**
    * 모임 수정 요청
    * PATCH /meetings/:id
    */
-  async update(id: number, payload: UpdateMeeting): Promise<MeetingWithHost> {
+  async update(id: number, payload: UpdateMeeting): Promise<Meeting> {
     const response = await fetchClient.patch(`/meetings/${id}`, payload);
-    return parseResponse<MeetingWithHost>(response, '모임 수정에 실패했습니다.');
+    return parseResponse<Meeting>(response, '모임 수정에 실패했습니다.');
   },
 
-  async updateStatus(id: number, payload: UpdateMeetingStatus): Promise<MeetingWithHost> {
+  async updateStatus(id: number, payload: UpdateMeetingStatus): Promise<Meeting> {
     const response = await fetchClient.patch(`/meetings/${id}/status`, payload);
-    return parseResponse<MeetingWithHost>(response, '모임 상태 변경에 실패했습니다.');
+    return parseResponse<Meeting>(response, '모임 상태 변경에 실패했습니다.');
   },
 
   async deleteMeeting(id: number): Promise<void> {

--- a/src/entities/meeting/api/meetings.server.ts
+++ b/src/entities/meeting/api/meetings.server.ts
@@ -1,5 +1,6 @@
 import { apiServer } from '@/shared/api/api-server';
-import { MeetingList } from '@/shared/types/generated-client/models/MeetingList';
+
+import type { MeetingListResult } from '../model/meeting.types';
 
 export interface GetMeetingsParams {
   type?: string;
@@ -17,7 +18,7 @@ export interface GetMeetingsParams {
  * 모임 목록 조회 (서버 컴포넌트 전용)
  * GET /meetings
  */
-export async function getMeetings(params?: GetMeetingsParams): Promise<MeetingList> {
+export async function getMeetings(params?: GetMeetingsParams): Promise<MeetingListResult> {
   const searchParams = new URLSearchParams();
   if (params) {
     Object.entries(params).forEach(([key, value]) => {

--- a/src/entities/meeting/model/meeting.types.ts
+++ b/src/entities/meeting/model/meeting.types.ts
@@ -20,7 +20,6 @@ export type Meeting = {
   hostId: number;
   /** 댓글 서버 모임 동기화 등에 사용 (백엔드 모임 상세 응답에 포함) */
   teamId: string;
-  createdBy: number;
   updatedAt: string;
   host: {
     id: number;
@@ -29,4 +28,10 @@ export type Meeting = {
   };
   isFavorited?: boolean;
   isJoined?: boolean;
+};
+
+export type MeetingListResult = {
+  data: Meeting[];
+  nextCursor: string;
+  hasMore: boolean;
 };

--- a/src/entities/meeting/model/meetings.options.ts
+++ b/src/entities/meeting/model/meetings.options.ts
@@ -1,7 +1,8 @@
-import type { MeetingList, TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
+import type { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
 
 import { meetingsApi } from '../api/meetings.api';
 import type { getMeetings } from '../index.server';
+import type { MeetingListResult } from '../model/meeting.types';
 
 const searchKeys = {
   all: () => ['search'] as const,
@@ -44,7 +45,7 @@ export const meetingsQueryOptions = {
     queryFn: ({ pageParam }: { pageParam?: string }) =>
       meetingsApi.getByFilter({ ...options, cursor: pageParam }),
     initialPageParam: undefined,
-    getNextPageParam: (lastPage: MeetingList) => {
+    getNextPageParam: (lastPage: MeetingListResult) => {
       return lastPage.hasMore ? lastPage.nextCursor : undefined;
     },
     initialData: initialData ? { pages: [initialData], pageParams: [undefined] } : undefined,

--- a/src/entities/meeting/ui/main-page-card/main-page-card.stories.tsx
+++ b/src/entities/meeting/ui/main-page-card/main-page-card.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { addDays, addMonths } from 'date-fns';
 
-import type { MeetingWithHost } from '@/shared/types/generated-client';
+import type { Meeting } from '../../model/meeting.types';
 
 import { MainPageCard } from './main-page-card';
 
@@ -19,11 +19,7 @@ meetingDate.setHours(18, 30, 0, 0);
 const registrationEndDate = addDays(addMonths(now, 1), 4);
 registrationEndDate.setHours(12, 0, 0, 0);
 
-const createdAt = new Date('2025-03-22T00:00:00');
-const updatedAt = new Date('2025-03-21T00:00:00');
-
-/** `confirmedAt: null`은 DTO 타입과 다르지만 `EstablishmentStatusBadge` 동작과 맞춤 */
-const MOCK_MEETING = {
+const MOCK_MEETING: Meeting = {
   id: 1,
   teamId: 'storybook',
   name: '강남역에서 점심 같이 먹어요',
@@ -32,25 +28,23 @@ const MOCK_MEETING = {
   address: '서울특별시 강남구 테헤란로',
   latitude: 37.498,
   longitude: 127.028,
-  dateTime: meetingDate,
-  registrationEnd: registrationEndDate,
+  dateTime: meetingDate.toISOString(),
+  registrationEnd: registrationEndDate.toISOString(),
   capacity: 6,
   participantCount: 3,
   image:
     'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&q=80&w=720',
   description: '',
-  canceledAt: createdAt,
+  canceledAt: null,
   confirmedAt: null,
   hostId: 1,
-  createdBy: 1,
-  createdAt,
-  updatedAt,
+  updatedAt: new Date('2025-03-21T00:00:00').toISOString(),
   host: {
     id: 1,
     name: '김소소',
     image: 'https://i.pravatar.cc/32?img=47',
   },
-} as unknown as MeetingWithHost;
+};
 
 export const Default: Story = {
   args: { meeting: MOCK_MEETING },
@@ -82,7 +76,7 @@ export const EstablishedGroupEat: Story = {
   args: {
     meeting: {
       ...MOCK_MEETING,
-      confirmedAt: new Date('2025-03-22T12:00:00'),
+      confirmedAt: '2025-03-22T12:00:00.000Z',
     },
   },
 };
@@ -92,7 +86,7 @@ export const EstablishedGroupBuy: Story = {
     meeting: {
       ...MOCK_MEETING,
       type: 'groupBuy',
-      confirmedAt: new Date('2025-03-22T12:00:00'),
+      confirmedAt: '2025-03-22T12:00:00.000Z',
     },
   },
 };

--- a/src/entities/meeting/ui/main-page-card/main-page-card.test.tsx
+++ b/src/entities/meeting/ui/main-page-card/main-page-card.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import type { MeetingWithHost } from '@/shared/types/generated-client';
-
+import type { Meeting } from '../../model/meeting.types';
 import { useTimeFormatter } from '../../model/use-time-formatter';
 
 import { MainPageCard } from './main-page-card';
@@ -61,7 +60,7 @@ jest.mock('next/image', () => ({
     <img src={src} alt={alt} data-testid="main-page-card-image" {...rest} />
   ),
 }));
-function createMockMeeting(overrides: Partial<MeetingWithHost> = {}): MeetingWithHost {
+function createMockMeeting(overrides: Partial<Meeting> = {}): Meeting {
   const now = new Date('2025-03-19T10:00:00+09:00');
   const registrationEnd = new Date(now);
   registrationEnd.setDate(registrationEnd.getDate() + 7);
@@ -75,20 +74,17 @@ function createMockMeeting(overrides: Partial<MeetingWithHost> = {}): MeetingWit
     address: '서울특별시 강남구',
     latitude: 37.498,
     longitude: 127.028,
-    dateTime: new Date('2025-04-24T18:30:00+09:00'),
-    registrationEnd,
+    dateTime: '2025-04-24T18:30:00+09:00',
+    registrationEnd: registrationEnd.toISOString(),
     capacity: 6,
     participantCount: 3,
     image:
       'https://plus.unsplash.com/premium_photo-1774002133542-bbef3f2cc3d5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     description: '',
-    canceledAt: now,
-    confirmedAt: new Date('2025-03-22T12:00:00+09:00'),
+    canceledAt: now.toISOString(),
+    confirmedAt: '2025-03-22T12:00:00+09:00',
     hostId: 1,
-    createdBy: 1,
-    createdAt: now,
-    updatedAt: now,
-    isCompleted: false,
+    updatedAt: now.toISOString(),
     host: {
       id: 1,
       name: '김소소',
@@ -197,7 +193,7 @@ describe('MainPageCard', () => {
       const meeting = {
         ...createMockMeeting(),
         confirmedAt: null,
-      } as unknown as MeetingWithHost;
+      };
       render(<MainPageCard meeting={meeting} />);
 
       expect(screen.queryByText('개설확정')).not.toBeInTheDocument();
@@ -206,7 +202,7 @@ describe('MainPageCard', () => {
 
     it('confirmedAt이 있으면 개설확정이 표시된다', () => {
       const meeting = createMockMeeting({
-        confirmedAt: new Date('2025-03-22T12:00:00+09:00'),
+        confirmedAt: '2025-03-22T12:00:00+09:00',
       });
       render(<MainPageCard meeting={meeting} />);
 
@@ -221,16 +217,14 @@ describe('MainPageCard', () => {
         isEnded: true,
         showCountdown: false,
       });
-      const pastDate = new Date('2025-03-19T09:00:00+09:00');
-      const meeting = createMockMeeting({ registrationEnd: pastDate });
+      const meeting = createMockMeeting({ registrationEnd: '2025-03-19T09:00:00+09:00' });
       render(<MainPageCard meeting={meeting} />);
 
       expect(screen.getByText('마감 종료')).toBeInTheDocument();
     });
 
     it('마감 전 모임일 때 남은 시간이 표시된다', async () => {
-      const futureDate = new Date('2025-03-26T10:00:00+09:00');
-      const meeting = createMockMeeting({ registrationEnd: futureDate });
+      const meeting = createMockMeeting({ registrationEnd: '2025-03-26T10:00:00+09:00' });
 
       (useTimeFormatter as jest.Mock).mockReturnValue({
         contentText: '모집완료 1일 0시간 남았어요!',

--- a/src/entities/meeting/ui/main-page-card/main-page-card.tsx
+++ b/src/entities/meeting/ui/main-page-card/main-page-card.tsx
@@ -140,12 +140,15 @@ export const MainPageCard = ({ meeting, renderFavoriteButton }: MainPageCardProp
             </div>
             <div className={MAIN_PAGE_CARD_BADGES_ROW_CLASS}>
               <DeadlineBadge
-                registrationEnd={meeting.registrationEnd}
+                registrationEnd={new Date(meeting.registrationEnd)}
                 variant={variant}
                 className="mt-0 min-w-0 flex-1"
               />
               <div className="hidden md:block">
-                <EstablishmentStatusBadge confirmedAt={meeting.confirmedAt} variant={variant} />
+                <EstablishmentStatusBadge
+                  confirmedAt={meeting.confirmedAt ? new Date(meeting.confirmedAt) : null}
+                  variant={variant}
+                />
               </div>
             </div>
 

--- a/src/entities/meeting/ui/main-page-card/main-page-card.tsx
+++ b/src/entities/meeting/ui/main-page-card/main-page-card.tsx
@@ -58,7 +58,7 @@ const getProgressVariant = (meetingType: string): ProgressProps['variant'] =>
 
 export const MainPageCard = ({ meeting, renderFavoriteButton }: MainPageCardProps) => {
   const variant = getProgressVariant(meeting.type);
-  const formatted = format(meeting.dateTime, 'M/d(E) HH:mm', { locale: ko });
+  const formatted = format(new Date(meeting.dateTime), 'M/d(E) HH:mm', { locale: ko });
   const progress =
     (meeting.participantCount / (meeting.capacity <= 0 ? 1 : meeting.capacity)) * 100;
 

--- a/src/entities/meeting/ui/main-page-card/main-page-card.types.ts
+++ b/src/entities/meeting/ui/main-page-card/main-page-card.types.ts
@@ -1,6 +1,6 @@
-import type { MeetingWithHost } from '@/shared/types/generated-client';
+import type { Meeting } from '../../model/meeting.types';
 
 export interface MainPageCardProps {
-  meeting: MeetingWithHost;
+  meeting: Meeting;
   renderFavoriteButton?: (id: number, isFavorited: boolean) => React.ReactNode;
 }

--- a/src/features/favorites/ui/heart-button/heart-button.types.ts
+++ b/src/features/favorites/ui/heart-button/heart-button.types.ts
@@ -1,6 +1,6 @@
-import { MeetingWithHost } from '@/shared/types/generated-client';
+import type { Meeting } from '@/entities/meeting';
 
-export interface HeartButtonProps extends Pick<MeetingWithHost, 'isFavorited'> {
+export interface HeartButtonProps extends Pick<Meeting, 'isFavorited'> {
   className?: string;
   sizeClass?: string;
   iconClass?: string;

--- a/src/widgets/home/ui/best-soeat-section/best-soeat-section.tsx
+++ b/src/widgets/home/ui/best-soeat-section/best-soeat-section.tsx
@@ -6,16 +6,16 @@ import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import useEmblaCarousel from 'embla-carousel-react';
 
-import { MeetingWithHost } from '@/shared/types/generated-client/models/MeetingWithHost';
+import type { Meeting } from '@/entities/meeting';
 
 import { BestSoeatCard } from '../best-soeat-card';
 
-function formatDateTime(date: Date): string {
-  return format(date, 'M/d(E) HH:mm', { locale: ko });
+function formatDateTime(date: string | Date): string {
+  return format(new Date(date), 'M/d(E) HH:mm', { locale: ko });
 }
 
 interface BestSoeatSectionProps {
-  meetings: MeetingWithHost[];
+  meetings: Meeting[];
 }
 
 export function BestSoeatSection({ meetings }: BestSoeatSectionProps) {

--- a/src/widgets/home/ui/main-page-section/main-page-card-with-heart.tsx
+++ b/src/widgets/home/ui/main-page-section/main-page-card-with-heart.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import type { Meeting } from '@/entities/meeting';
 import { MainPageCard } from '@/entities/meeting';
 import { HeartButton } from '@/features/favorites';
-import type { MeetingWithHost } from '@/shared/types/generated-client';
 
 interface MainPageCardWithHeartProps {
-  meeting: MeetingWithHost;
+  meeting: Meeting;
 }
 
 export function MainPageCardWithHeart({ meeting }: MainPageCardWithHeartProps) {

--- a/src/widgets/home/ui/main-page-section/main-page-section.tsx
+++ b/src/widgets/home/ui/main-page-section/main-page-section.tsx
@@ -1,11 +1,11 @@
 // app/_components/main-page-section/main-page-section.tsx
 import Image from 'next/image';
 
-import { MeetingWithHost } from '@/shared/types/generated-client/models/MeetingWithHost';
+import type { Meeting } from '@/entities/meeting';
 
 import { MainPageCardWithHeart } from './main-page-card-with-heart';
 
-export function MainPageSection({ meetings }: { meetings: MeetingWithHost[] }) {
+export function MainPageSection({ meetings }: { meetings: Meeting[] }) {
   return (
     <section className="px-4">
       <h2 className="mb-3 flex items-center gap-3 text-lg font-bold md:text-xl lg:text-2xl">

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.stories.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.stories.tsx
@@ -34,7 +34,6 @@ const mockMeeting: Meeting = {
   description: '',
   hostId: 1,
   teamId: 'test-team',
-  createdBy: 1,
   updatedAt: '2024/03/01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.test.tsx
@@ -28,7 +28,6 @@ const mockMeeting: Meeting = {
   description: '',
   hostId: 1,
   teamId: 'test-team',
-  createdBy: 1,
   updatedAt: '2024-03-01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,

--- a/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.test.tsx
@@ -84,7 +84,6 @@ const MOCK_MEETING: Meeting = {
   canceledAt: null,
   hostId: 7,
   teamId: 'team9',
-  createdBy: 7,
   updatedAt: '2026-04-10T09:00:00.000Z',
   host: {
     id: 7,

--- a/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.stories.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.stories.tsx
@@ -20,7 +20,6 @@ const mockMeeting: Meeting = {
   description: '',
   hostId: 1,
   teamId: 'test-team',
-  createdBy: 1,
   updatedAt: '2024-03-01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,

--- a/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.test.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-recommended-card/meeting-recommended-card.test.tsx
@@ -42,7 +42,6 @@ const mockMeeting: Meeting = {
   description: '',
   hostId: 1,
   teamId: 'test-team',
-  createdBy: 1,
   updatedAt: '2024-03-01T00:00:00.000Z',
   host: { id: 1, name: '김소소' },
   isFavorited: false,

--- a/src/widgets/search/model/use-search-infinite-options.ts
+++ b/src/widgets/search/model/use-search-infinite-options.ts
@@ -3,8 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 
 import { useQueries } from '@tanstack/react-query';
 
-import { meetingsQueryOptions } from '@/entities/meeting';
-import { MeetingWithHost, TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
+import { type Meeting, meetingsQueryOptions } from '@/entities/meeting';
+import { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
 
 type MeetingsOptions = Omit<TeamIdMeetingsGetRequest, 'teamId' | 'region'> & {
   region?: string | string[];
@@ -22,7 +22,7 @@ export const useSearchInfiniteOptions = (options: MeetingsOptions) => {
 
   const [cursor, setCursor] = useState<Record<string, string | undefined>>({});
   const [hasMoreByRegion, setHasMoreByRegion] = useState<Record<string, boolean>>({});
-  const [accumlated, setAccumlated] = useState<Record<string, Array<MeetingWithHost>>>({});
+  const [accumlated, setAccumlated] = useState<Record<string, Array<Meeting>>>({});
 
   // (regionKey, region, cursor) 기준으로 중복 처리 방지
   const processedRef = useRef<Set<string>>(new Set());


### PR DESCRIPTION
### 📌 유형 (Type)                                                                                               
                                                                                                                   
  - [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)                                                   
                                                                                                                   
  ### 📝 변경 사항 (Changes)                                                                                       
                                                                                                                   
  closes #373                                                                                                      
                                                                                                                   
  OpenAPI Generator가 자동 생성한 `MeetingWithHost`와 직접 정의한 엔티티 타입 `Meeting`이 병존하면서 `as unknown as
   Meeting[]` 이중 캐스팅이 발생하는 문제를 해결했습니다.                                                          
                                                            
  - `Meeting` 타입에서 앱 코드에서 미사용인 `createdBy` 필드 제거                                                  
  - `MeetingListResult` 커스텀 타입을 정의하고, API 레이어(`meetings.server.ts`, `meetings.api.ts`,
  `meetings.options.ts`)의 반환 타입을 `MeetingList` → `MeetingListResult`, `MeetingWithHost` → `Meeting`으로 교체 
  - `MainPageCard`, `MainPageCardWithHeart`, `BestSoeatSection`, `MainPageSection`, `home/page.tsx`,               
  `heart-button`, `use-search-infinite-options` 등 컴포넌트·훅의 `MeetingWithHost` 참조를 `Meeting`으로 일괄 교체
  - `meeting-recommended-fetcher.tsx`의 `as unknown as Meeting[]` 이중 캐스팅 제거                                 
  - 테스트·스토리 목 데이터를 `Meeting` 타입 기준(ISO 문자열 날짜)으로 정리
                                                                                                                   
  **개선 효과**                                             
                                                                                                                   
  - **타입 안전성 향상:** `as unknown as` 이중 캐스팅을 제거해 컴파일 타임에 타입 불일치를 감지할 수 있게 됩니다.
  기존에는 캐스팅으로 타입 오류가 묵인되던 코드가 이제 정확한 타입 검사를 받습니다.                                
  - **타입 거짓말 제거:** `MeetingWithHost.dateTime`은 스펙상 `Date`지만 실제 런타임에서는 ISO 문자열입니다.
  `Meeting` 타입은 이를 `string`으로 정확하게 모델링해 런타임 동작과 타입이 일치합니다.                            
  - **번들 최적화:** 기존에는 `MeetingWithHost`를 값으로 import해 generated-client의 런타임 함수(역직렬화 로직
  등)가 번들에 포함될 여지가 있었습니다. `Meeting`은 순수 타입 정의이므로 `import type`으로만 참조되어 번들에      
  포함되지 않습니다.                                                                                               
  - **단일 진실 공급원:** 모임 도메인 타입이 `Meeting` 하나로 통일되어 새 필드 추가나 타입 변경 시 수정 지점이
  명확해집니다.                                                                                                    
                                                            
  ### 🧪 테스트 방법 (How to Test)                                                                                 
                                                                                                                   
  1. 로컬 환경에서 앱을 실행합니다. (`npm run dev`)
  2. 홈 페이지(`/home`)에서 추천 소잇, 베스트 소잇 카드가 정상적으로 렌더링되는지 확인합니다.                      
  3. 검색 페이지에서 모임 목록이 정상적으로 노출되는지 확인합니다.
  4. 모임 상세 페이지(`/meetings/:id`) 하단 "이런 모임 어때요?" 섹션에 과거 모임이 포함되지 않는지 확인합니다.     
  5. `npm run type-check` 및 `npm run test` 통과를 확인합니다.
                                                                                                                   
  ### 📸 스크린샷 또는 영상 (Optional)                                                                             
                                                                                                                   
  UI 변경 없음                                                                                                     
                                                                                                                   
  ### 🚨 기타 참고 사항 (Notes)                                                                                    
                                                            
  - `MeetingWithHost.dateTime`은 OpenAPI 스펙상 `Date`이지만 런타임에서는 `response.json()`을 통해 항상 ISO
  문자열로 전달됩니다. `Meeting` 타입은 이를 `string`으로 정확히 모델링하고 있으며, `new Date(meeting.dateTime)`
  변환이 필요한 시점에만 명시적으로 수행합니다.
  - `generated-client` 내부 파일은 자동 생성 코드이므로 변경하지 않았습니다.                                       