### PR TITLE
[Feat]: 모임/프로필 이미지 크롭 UI 공통화 및 업로드 플로우 개선

### DIFF
--- a/src/features/meeting-create/model/use-meeting-image-editor.ts
+++ b/src/features/meeting-create/model/use-meeting-image-editor.ts
@@ -3,6 +3,8 @@
 import { useRef, useState } from 'react';
 import type { Area } from 'react-easy-crop';
 
+import { toast } from 'sonner';
+
 import { useUploadImage } from '@/entities/image';
 import { getCroppedImg } from '@/shared/lib/image-crop';
 import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
@@ -37,12 +39,12 @@ export function useMeetingImageEditor(onChange: (url: string) => void) {
       const file = new File([blob], 'meeting.jpg', { type: 'image/jpeg' });
       const publicUrl = await mutateAsync(file);
       if (publicUrl) onChange(publicUrl);
-      setCropModalOpen(false);
-    } catch (error) {
-      console.error('모임 이미지 처리 중 오류가 발생했습니다:', error);
-    } finally {
       URL.revokeObjectURL(rawSrc);
       setRawSrc(null);
+      setCropModalOpen(false);
+    } catch (error) {
+      console.error('이미지 처리 중 오류가 발생했습니다:', error);
+      toast.error('이미지 업로드 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/features/meeting-create/model/use-meeting-image-editor.ts
+++ b/src/features/meeting-create/model/use-meeting-image-editor.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import type { Area } from 'react-easy-crop';
+
+import { useUploadImage } from '@/entities/image';
+import { getCroppedImg } from '@/shared/lib/image-crop';
+import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
+
+export function useMeetingImageEditor(onChange: (url: string) => void) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { mutateAsync, isPending } = useUploadImage(PresignedUrlRequestFolderEnum.Meetings);
+
+  const [rawSrc, setRawSrc] = useState<string | null>(null);
+  const [cropModalOpen, setCropModalOpen] = useState(false);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+
+  const openFileDialog = () => inputRef.current?.click();
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (rawSrc) URL.revokeObjectURL(rawSrc);
+    setRawSrc(URL.createObjectURL(file));
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+    setCropModalOpen(true);
+    e.target.value = '';
+  };
+
+  const handleCropConfirm = async () => {
+    if (!rawSrc || !croppedAreaPixels) return;
+    try {
+      const blob = await getCroppedImg(rawSrc, croppedAreaPixels);
+      const file = new File([blob], 'meeting.jpg', { type: 'image/jpeg' });
+      const publicUrl = await mutateAsync(file);
+      if (publicUrl) onChange(publicUrl);
+      setCropModalOpen(false);
+    } catch (error) {
+      console.error('모임 이미지 처리 중 오류가 발생했습니다:', error);
+    } finally {
+      URL.revokeObjectURL(rawSrc);
+      setRawSrc(null);
+    }
+  };
+
+  const handleCropCancel = () => {
+    if (rawSrc) URL.revokeObjectURL(rawSrc);
+    setRawSrc(null);
+    setCropModalOpen(false);
+  };
+
+  return {
+    inputRef,
+    isPending,
+    rawSrc,
+    cropModalOpen,
+    crop,
+    zoom,
+    openFileDialog,
+    handleFileChange,
+    handleCropConfirm,
+    handleCropCancel,
+    setCrop,
+    setZoom,
+    setCroppedAreaPixels,
+  };
+}

--- a/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
+++ b/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { ImagePlus, Loader2, XIcon } from 'lucide-react';
 
 import { MIME_TO_EXT } from '@/entities/image';
+import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { BaseImageCropper } from '@/shared/ui/image-editor/base-image-cropper';
@@ -43,7 +44,7 @@ export function MeetingImageEditor({ imageUrl, onChange, error }: MeetingImageEd
 
   return (
     <>
-      <div className={imageUrl && !isPending ? 'relative w-full' : 'relative w-36.75'}>
+      <div className={cn('relative', imageUrl ? 'w-full' : 'w-36.75')}>
         {imageUrl && !isPending ? (
           <Image
             src={imageUrl}
@@ -131,7 +132,10 @@ export function MeetingImageEditor({ imageUrl, onChange, error }: MeetingImageEd
 
           <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
             <Button
-              className={`${actionButtonClassName} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
+              className={cn(
+                actionButtonClassName,
+                'border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700'
+              )}
               onClick={handleCropCancel}
             >
               취소

--- a/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
+++ b/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import Image from 'next/image';
+
+import { ImagePlus, Loader2, XIcon } from 'lucide-react';
+
+import { MIME_TO_EXT } from '@/entities/image';
+import { Button } from '@/shared/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { BaseImageCropper } from '@/shared/ui/image-editor/base-image-cropper';
+
+import { useMeetingImageEditor } from '../../model/use-meeting-image-editor';
+
+import sliderStyles from '@/shared/ui/image-editor/image-editor-slider.module.css';
+
+const ACCEPTED_IMAGE_TYPES = Object.keys(MIME_TO_EXT).join(',');
+
+const actionButtonClassName =
+  'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold';
+
+interface MeetingImageEditorProps {
+  imageUrl?: string;
+  onChange: (url: string) => void;
+  error?: string;
+}
+
+export function MeetingImageEditor({ imageUrl, onChange, error }: MeetingImageEditorProps) {
+  const {
+    inputRef,
+    isPending,
+    rawSrc,
+    cropModalOpen,
+    crop,
+    zoom,
+    openFileDialog,
+    handleFileChange,
+    handleCropConfirm,
+    handleCropCancel,
+    setCrop,
+    setZoom,
+    setCroppedAreaPixels,
+  } = useMeetingImageEditor(onChange);
+
+  return (
+    <>
+      <div className={imageUrl && !isPending ? 'relative w-full' : 'relative w-36.75'}>
+        {imageUrl && !isPending ? (
+          <Image
+            src={imageUrl}
+            alt="모임 이미지"
+            width={0}
+            height={0}
+            sizes="100vw"
+            className="h-auto w-full rounded-2xl"
+          />
+        ) : (
+          <div className="bg-sosoeat-gray-100 text-sosoeat-gray-500 flex h-36.75 w-36.75 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed text-sm">
+            {isPending ? (
+              <Loader2 className="h-6 w-6 animate-spin" />
+            ) : (
+              <ImagePlus className="h-6 w-6" />
+            )}
+          </div>
+        )}
+        {!isPending && (
+          <button
+            type="button"
+            onClick={openFileDialog}
+            className="absolute inset-0 cursor-pointer rounded-2xl"
+            aria-label="이미지 선택"
+          />
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          className="sr-only"
+          accept={ACCEPTED_IMAGE_TYPES}
+          disabled={isPending}
+          onChange={handleFileChange}
+        />
+      </div>
+      {error && (
+        <p className="animate-in fade-in slide-in-from-top-1 text-destructive text-xs">{error}</p>
+      )}
+
+      <Dialog open={cropModalOpen} onOpenChange={(open) => !open && handleCropCancel()}>
+        <DialogContent
+          showCloseButton={false}
+          className="w-85.75 max-w-none rounded-4xl bg-white p-9 shadow-xl sm:max-w-none md:w-136"
+        >
+          <DialogHeader className="flex w-full flex-row items-center justify-between">
+            <DialogTitle className="text-xl font-semibold text-gray-900">미리 보기</DialogTitle>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-8 shrink-0 cursor-pointer text-[#737373] hover:bg-transparent hover:text-[#737373]"
+              aria-label="닫기"
+              onClick={handleCropCancel}
+            >
+              <XIcon className="size-6" strokeWidth={1.8} />
+            </Button>
+          </DialogHeader>
+
+          <div className="relative h-72 w-full overflow-hidden rounded-3xl bg-white">
+            {rawSrc && (
+              <BaseImageCropper
+                image={rawSrc}
+                crop={crop}
+                zoom={zoom}
+                aspect={4 / 3}
+                showGrid={true}
+                onCropChange={setCrop}
+                onZoomChange={setZoom}
+                onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
+              />
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <input
+              type="range"
+              min={1}
+              max={3}
+              step={0.01}
+              value={zoom}
+              onChange={(e) => setZoom(Number(e.target.value))}
+              className={sliderStyles.slider}
+            />
+          </div>
+
+          <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
+            <Button
+              className={`${actionButtonClassName} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
+              onClick={handleCropCancel}
+            >
+              취소
+            </Button>
+            <Button
+              disabled={isPending}
+              onClick={handleCropConfirm}
+              className={`${actionButtonClassName} bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 cursor-pointer text-white`}
+            >
+              {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : '적용하기'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/meeting-create/ui/_components/step2-basic-info.tsx
+++ b/src/features/meeting-create/ui/_components/step2-basic-info.tsx
@@ -5,9 +5,6 @@ import { Controller } from 'react-hook-form';
 
 import Image from 'next/image';
 
-import { ImagePlus, Loader2 } from 'lucide-react';
-
-import { MIME_TO_EXT, useUploadImage } from '@/entities/image';
 import type { LocationSearchResult } from '@/entities/location';
 import { LocationSearchModal } from '@/entities/location';
 import { cn } from '@/shared/lib/utils';
@@ -15,14 +12,13 @@ import { Input } from '@/shared/ui/input/input';
 
 import type { StepProps } from '../../model/meeting-create.types';
 
-const ACCEPTED_IMAGE_TYPES = Object.keys(MIME_TO_EXT).join(',');
+import { MeetingImageEditor } from './meeting-image-editor';
 
 /**
  * 2단계: 모임 기본 정보 입력 (이름, 장소, 이미지)
  */
 export const StepBasicInfo = ({ form }: StepProps) => {
   const { register } = form;
-  const { mutateAsync, isPending, error: uploadError } = useUploadImage('meetings');
   const [locationModalOpen, setLocationModalOpen] = useState(false);
 
   const handleLocationSelect = (result: LocationSearchResult) => {
@@ -33,23 +29,6 @@ export const StepBasicInfo = ({ form }: StepProps) => {
     form.setValue('latitude', result.latitude);
     form.setValue('longitude', result.longitude);
     setLocationModalOpen(false);
-  };
-
-  const handleFileChange = async (
-    e: React.ChangeEvent<HTMLInputElement>,
-    onChange: (value: string) => void
-  ) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    try {
-      const url = await mutateAsync(file);
-      onChange(url);
-    } catch {
-      // 업로드 실패 시 uploadError로 표시
-    } finally {
-      e.target.value = ''; // 성공이나 실패 모두 초기화하여 재시도 가능하도록 처리
-    }
   };
 
   const requiredIndicator = <span className="text-destructive ml-0.5">*</span>;
@@ -118,49 +97,11 @@ export const StepBasicInfo = ({ form }: StepProps) => {
             <label className="text-sosoeat-gray-900 ml-1 text-sm font-medium md:text-base">
               이미지{requiredIndicator}
             </label>
-            <div className={field.value && !isPending ? 'relative w-full' : 'relative w-[147px]'}>
-              {field.value && !isPending ? (
-                <Image
-                  src={field.value as string}
-                  alt="모임 이미지"
-                  width={0}
-                  height={0}
-                  sizes="100vw"
-                  className="h-auto w-full rounded-2xl"
-                />
-              ) : (
-                <div className="bg-sosoeat-gray-100 text-sosoeat-gray-500 flex h-[147px] w-[147px] flex-col items-center justify-center gap-2 rounded-2xl border border-dashed text-sm">
-                  {isPending ? (
-                    <Loader2 className="h-6 w-6 animate-spin" />
-                  ) : (
-                    <ImagePlus className="h-6 w-6" />
-                  )}
-                </div>
-              )}
-              {/* 이미지 업로드/변경을 위한 클릭 overlay */}
-              {!isPending && (
-                <label
-                  htmlFor="image"
-                  className="absolute inset-0 cursor-pointer rounded-2xl"
-                  aria-label="이미지 선택"
-                />
-              )}
-              <input
-                type="file"
-                id="image"
-                className="sr-only"
-                accept={ACCEPTED_IMAGE_TYPES}
-                disabled={isPending}
-                onChange={(e) => handleFileChange(e, field.onChange)}
-              />
-            </div>
-            {(error || uploadError) && (
-              <p className="animate-in fade-in slide-in-from-top-1 text-destructive text-xs">
-                {uploadError instanceof Error
-                  ? uploadError.message
-                  : error?.message || '이미지 업로드에 실패했습니다.'}
-              </p>
-            )}
+            <MeetingImageEditor
+              imageUrl={field.value as string}
+              onChange={field.onChange}
+              error={error?.message}
+            />
           </div>
         )}
       />

--- a/src/features/meeting-create/ui/meeting-create-modal.test.tsx
+++ b/src/features/meeting-create/ui/meeting-create-modal.test.tsx
@@ -6,6 +6,28 @@ import userEvent from '@testing-library/user-event';
 
 import { MeetingCreateModal } from './meeting-create-modal';
 
+jest.mock('./_components/meeting-image-editor', () => ({
+  MeetingImageEditor: ({
+    imageUrl,
+    onChange,
+    error,
+  }: {
+    imageUrl?: string;
+    onChange: (url: string) => void;
+    error?: string;
+  }) => (
+    <div>
+      <input
+        type="file"
+        aria-label="이미지 선택"
+        onChange={() => onChange('https://s3.example.com/image.jpg')}
+      />
+      {imageUrl ? <img alt="모임 이미지" src={imageUrl} /> : null}
+      {error ? <p>{error}</p> : null}
+    </div>
+  ),
+}));
+
 // useUploadImage mock — 이미지 업로드를 즉시 성공으로 처리
 jest.mock('@/entities/image', () => ({
   useUploadImage: () => ({

--- a/src/features/profile-edit/model/use-profile-image-editor.ts
+++ b/src/features/profile-edit/model/use-profile-image-editor.ts
@@ -3,6 +3,8 @@
 import { useRef, useState } from 'react';
 import type { Area } from 'react-easy-crop';
 
+import { toast } from 'sonner';
+
 import { useUploadImage } from '@/entities/image';
 import { getCroppedImg } from '@/shared/lib/image-crop';
 import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
@@ -37,12 +39,12 @@ export function useProfileImageEditor(onChange: (url: string) => void) {
       const file = new File([blob], 'profile.jpg', { type: 'image/jpeg' });
       const publicUrl = await mutateAsync(file);
       if (publicUrl) onChange(publicUrl);
+      URL.revokeObjectURL(rawSrc);
+      setRawSrc(null);
       setCropModalOpen(false);
     } catch (error) {
       console.error('프로필 이미지 처리 중 오류가 발생했습니다:', error);
-    } finally {
-      URL.revokeObjectURL(rawSrc);
-      setRawSrc(null);
+      toast.error('이미지 업로드 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import Cropper from 'react-easy-crop';
-
 import Image from 'next/image';
 
 import { Loader2, Pencil, XIcon } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { BaseImageCropper } from '@/shared/ui/image-editor/base-image-cropper';
 
 import { useProfileImageEditor } from '../../../model/use-profile-image-editor';
 import type { ProfileImageEditorProps } from '../edit-profile-modal.types';
+
+import sliderStyles from '@/shared/ui/image-editor/image-editor-slider.module.css';
 
 const actionButtonClassName =
   'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold';
@@ -84,13 +85,13 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
 
           <div className="relative h-72 w-full overflow-hidden rounded-2xl bg-white">
             {rawSrc && (
-              <Cropper
+              <BaseImageCropper
                 image={rawSrc}
                 crop={crop}
                 zoom={zoom}
                 aspect={1}
                 cropShape="round"
-                showGrid={false}
+                showGrid={true}
                 onCropChange={setCrop}
                 onZoomChange={setZoom}
                 onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
@@ -99,7 +100,6 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
           </div>
 
           <div className="flex flex-col gap-2">
-            <span className="text-sm text-gray-500">확대/축소</span>
             <input
               type="range"
               min={1}
@@ -107,7 +107,7 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
               step={0.01}
               value={zoom}
               onChange={(e) => setZoom(Number(e.target.value))}
-              className="h-1 w-full cursor-pointer accent-orange-500"
+              className={sliderStyles.slider}
             />
           </div>
 

--- a/src/shared/ui/image-editor/base-image-cropper.tsx
+++ b/src/shared/ui/image-editor/base-image-cropper.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { CropperProps } from 'react-easy-crop';
+import Cropper from 'react-easy-crop';
+
+const defaultCropperStyle: CropperProps['style'] = {
+  containerStyle: {
+    backgroundColor: '#ffffff',
+  },
+  cropAreaStyle: {
+    color: 'rgba(0, 0, 0, 0.03)',
+    border: '1px solid rgba(255, 255, 255, 0.9)',
+  },
+};
+
+type BaseImageCropperProps = {
+  image?: CropperProps['image'];
+  video?: CropperProps['video'];
+  crop: CropperProps['crop'];
+  zoom: CropperProps['zoom'];
+  aspect: CropperProps['aspect'];
+  cropShape?: CropperProps['cropShape'];
+  showGrid?: CropperProps['showGrid'];
+  objectFit?: CropperProps['objectFit'];
+  onCropChange: CropperProps['onCropChange'];
+  onZoomChange?: CropperProps['onZoomChange'];
+  onCropComplete?: CropperProps['onCropComplete'];
+  onCropAreaChange?: CropperProps['onCropAreaChange'];
+  onMediaLoaded?: CropperProps['onMediaLoaded'];
+  classes?: CropperProps['classes'];
+  style?: CropperProps['style'];
+  cropperProps?: CropperProps['cropperProps'];
+  mediaProps?: CropperProps['mediaProps'];
+};
+
+export function BaseImageCropper({ style, ...props }: BaseImageCropperProps) {
+  return (
+    <Cropper
+      {...props}
+      style={{
+        ...defaultCropperStyle,
+        ...style,
+        containerStyle: {
+          ...defaultCropperStyle.containerStyle,
+          ...style?.containerStyle,
+        },
+        mediaStyle: {
+          ...defaultCropperStyle.mediaStyle,
+          ...style?.mediaStyle,
+        },
+        cropAreaStyle: {
+          ...defaultCropperStyle.cropAreaStyle,
+          ...style?.cropAreaStyle,
+        },
+      }}
+    />
+  );
+}

--- a/src/shared/ui/image-editor/image-editor-slider.module.css
+++ b/src/shared/ui/image-editor/image-editor-slider.module.css
@@ -1,0 +1,41 @@
+.slider {
+  width: 100%;
+  cursor: pointer;
+  appearance: none;
+  background: transparent;
+}
+
+.slider:focus {
+  outline: none;
+}
+
+.slider::-webkit-slider-runnable-track {
+  height: 1px;
+  border-radius: 9999px;
+  background: #d4d4d8;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  margin-top: -6px;
+  border: none;
+  border-radius: 9999px;
+  background: #f97316;
+}
+
+.slider::-moz-range-track {
+  height: 1px;
+  border-radius: 9999px;
+  background: #d4d4d8;
+}
+
+.slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border: none;
+  border-radius: 9999px;
+  background: #f97316;
+}


### PR DESCRIPTION
## [Feat]: 모임/프로필 이미지 크롭 UI 공통화 및 업로드 플로우 개선

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 모임 생성 이미지 업로드 시 원본 파일을 바로 업로드하던 흐름을, 업로드 전 크롭/확대·축소를 적용할 수 있는 플로우로 변경했습니다.
- react-easy-crop 기반의 공용 BaseImageCropper와 공용 range slider 스타일을 추가해 모임 생성과 프로필 편집에서 동일한 이미지 편집 UI를 재사용하도록 정리했습니다.
- **step2-basic-info**에 있던 인라인 이미지 업로드 UI/로직을 **MeetingImageEditor**로 분리해 책임을 명확히 했습니다.
- 관련 테스트에서 새 이미지 편집 흐름으로 인해 실패하던 부분은 MeetingImageEditor mock으로 보완해 기존 모달 테스트가 안정적으로 통과하도록 수정했습니다.


### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 앱을 실행한 뒤 모임 생성 모달을 열고 2단계 기본 정보 화면으로 이동합니다.
2. 이미지를 업로드한 뒤 크롭 모달이 열리는지 확인하고, 슬라이더로 확대/축소 후 적용하기를 눌러 이미지가 반영되는지 확인합니다.
3. 프로필 편집 화면에서도 이미지 업로드 후 동일한 크롭 UI와 슬라이더 스타일이 노출되는지 확인합니다.
4. npm run type-check 와 관련 테스트를 실행해 오류 없이 통과하는지 확인합니다.


### 📸 스크린샷 또는 영상 (Optional)

<img width="672" height="565" alt="image" src="https://github.com/user-attachments/assets/63fea7e5-acfd-4137-9556-4257150246c5" />
