### PR TITLE
[Fix]: 카카오 프로필 이미지 HTTP URL로 인한 이미지 로드 실패 수정

### DIFF
--- a/src/features/meeting-create/model/use-meeting-image-editor.ts
+++ b/src/features/meeting-create/model/use-meeting-image-editor.ts
@@ -3,6 +3,8 @@
 import { useRef, useState } from 'react';
 import type { Area } from 'react-easy-crop';
 
+import { toast } from 'sonner';
+
 import { useUploadImage } from '@/entities/image';
 import { getCroppedImg } from '@/shared/lib/image-crop';
 import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
@@ -37,12 +39,12 @@ export function useMeetingImageEditor(onChange: (url: string) => void) {
       const file = new File([blob], 'meeting.jpg', { type: 'image/jpeg' });
       const publicUrl = await mutateAsync(file);
       if (publicUrl) onChange(publicUrl);
-      setCropModalOpen(false);
-    } catch (error) {
-      console.error('모임 이미지 처리 중 오류가 발생했습니다:', error);
-    } finally {
       URL.revokeObjectURL(rawSrc);
       setRawSrc(null);
+      setCropModalOpen(false);
+    } catch (error) {
+      console.error('이미지 처리 중 오류가 발생했습니다:', error);
+      toast.error('이미지 업로드 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/features/meeting-create/model/use-meeting-image-editor.ts
+++ b/src/features/meeting-create/model/use-meeting-image-editor.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import type { Area } from 'react-easy-crop';
+
+import { useUploadImage } from '@/entities/image';
+import { getCroppedImg } from '@/shared/lib/image-crop';
+import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
+
+export function useMeetingImageEditor(onChange: (url: string) => void) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { mutateAsync, isPending } = useUploadImage(PresignedUrlRequestFolderEnum.Meetings);
+
+  const [rawSrc, setRawSrc] = useState<string | null>(null);
+  const [cropModalOpen, setCropModalOpen] = useState(false);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+
+  const openFileDialog = () => inputRef.current?.click();
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (rawSrc) URL.revokeObjectURL(rawSrc);
+    setRawSrc(URL.createObjectURL(file));
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+    setCropModalOpen(true);
+    e.target.value = '';
+  };
+
+  const handleCropConfirm = async () => {
+    if (!rawSrc || !croppedAreaPixels) return;
+    try {
+      const blob = await getCroppedImg(rawSrc, croppedAreaPixels);
+      const file = new File([blob], 'meeting.jpg', { type: 'image/jpeg' });
+      const publicUrl = await mutateAsync(file);
+      if (publicUrl) onChange(publicUrl);
+      setCropModalOpen(false);
+    } catch (error) {
+      console.error('모임 이미지 처리 중 오류가 발생했습니다:', error);
+    } finally {
+      URL.revokeObjectURL(rawSrc);
+      setRawSrc(null);
+    }
+  };
+
+  const handleCropCancel = () => {
+    if (rawSrc) URL.revokeObjectURL(rawSrc);
+    setRawSrc(null);
+    setCropModalOpen(false);
+  };
+
+  return {
+    inputRef,
+    isPending,
+    rawSrc,
+    cropModalOpen,
+    crop,
+    zoom,
+    openFileDialog,
+    handleFileChange,
+    handleCropConfirm,
+    handleCropCancel,
+    setCrop,
+    setZoom,
+    setCroppedAreaPixels,
+  };
+}

--- a/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
+++ b/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { ImagePlus, Loader2, XIcon } from 'lucide-react';
 
 import { MIME_TO_EXT } from '@/entities/image';
+import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { BaseImageCropper } from '@/shared/ui/image-editor/base-image-cropper';
@@ -43,7 +44,7 @@ export function MeetingImageEditor({ imageUrl, onChange, error }: MeetingImageEd
 
   return (
     <>
-      <div className={imageUrl && !isPending ? 'relative w-full' : 'relative w-36.75'}>
+      <div className={cn('relative', imageUrl ? 'w-full' : 'w-36.75')}>
         {imageUrl && !isPending ? (
           <Image
             src={imageUrl}
@@ -131,7 +132,10 @@ export function MeetingImageEditor({ imageUrl, onChange, error }: MeetingImageEd
 
           <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
             <Button
-              className={`${actionButtonClassName} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
+              className={cn(
+                actionButtonClassName,
+                'border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700'
+              )}
               onClick={handleCropCancel}
             >
               취소

--- a/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
+++ b/src/features/meeting-create/ui/_components/meeting-image-editor.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import Image from 'next/image';
+
+import { ImagePlus, Loader2, XIcon } from 'lucide-react';
+
+import { MIME_TO_EXT } from '@/entities/image';
+import { Button } from '@/shared/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { BaseImageCropper } from '@/shared/ui/image-editor/base-image-cropper';
+
+import { useMeetingImageEditor } from '../../model/use-meeting-image-editor';
+
+import sliderStyles from '@/shared/ui/image-editor/image-editor-slider.module.css';
+
+const ACCEPTED_IMAGE_TYPES = Object.keys(MIME_TO_EXT).join(',');
+
+const actionButtonClassName =
+  'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold';
+
+interface MeetingImageEditorProps {
+  imageUrl?: string;
+  onChange: (url: string) => void;
+  error?: string;
+}
+
+export function MeetingImageEditor({ imageUrl, onChange, error }: MeetingImageEditorProps) {
+  const {
+    inputRef,
+    isPending,
+    rawSrc,
+    cropModalOpen,
+    crop,
+    zoom,
+    openFileDialog,
+    handleFileChange,
+    handleCropConfirm,
+    handleCropCancel,
+    setCrop,
+    setZoom,
+    setCroppedAreaPixels,
+  } = useMeetingImageEditor(onChange);
+
+  return (
+    <>
+      <div className={imageUrl && !isPending ? 'relative w-full' : 'relative w-36.75'}>
+        {imageUrl && !isPending ? (
+          <Image
+            src={imageUrl}
+            alt="모임 이미지"
+            width={0}
+            height={0}
+            sizes="100vw"
+            className="h-auto w-full rounded-2xl"
+          />
+        ) : (
+          <div className="bg-sosoeat-gray-100 text-sosoeat-gray-500 flex h-36.75 w-36.75 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed text-sm">
+            {isPending ? (
+              <Loader2 className="h-6 w-6 animate-spin" />
+            ) : (
+              <ImagePlus className="h-6 w-6" />
+            )}
+          </div>
+        )}
+        {!isPending && (
+          <button
+            type="button"
+            onClick={openFileDialog}
+            className="absolute inset-0 cursor-pointer rounded-2xl"
+            aria-label="이미지 선택"
+          />
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          className="sr-only"
+          accept={ACCEPTED_IMAGE_TYPES}
+          disabled={isPending}
+          onChange={handleFileChange}
+        />
+      </div>
+      {error && (
+        <p className="animate-in fade-in slide-in-from-top-1 text-destructive text-xs">{error}</p>
+      )}
+
+      <Dialog open={cropModalOpen} onOpenChange={(open) => !open && handleCropCancel()}>
+        <DialogContent
+          showCloseButton={false}
+          className="w-85.75 max-w-none rounded-4xl bg-white p-9 shadow-xl sm:max-w-none md:w-136"
+        >
+          <DialogHeader className="flex w-full flex-row items-center justify-between">
+            <DialogTitle className="text-xl font-semibold text-gray-900">미리 보기</DialogTitle>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-8 shrink-0 cursor-pointer text-[#737373] hover:bg-transparent hover:text-[#737373]"
+              aria-label="닫기"
+              onClick={handleCropCancel}
+            >
+              <XIcon className="size-6" strokeWidth={1.8} />
+            </Button>
+          </DialogHeader>
+
+          <div className="relative h-72 w-full overflow-hidden rounded-3xl bg-white">
+            {rawSrc && (
+              <BaseImageCropper
+                image={rawSrc}
+                crop={crop}
+                zoom={zoom}
+                aspect={4 / 3}
+                showGrid={true}
+                onCropChange={setCrop}
+                onZoomChange={setZoom}
+                onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
+              />
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <input
+              type="range"
+              min={1}
+              max={3}
+              step={0.01}
+              value={zoom}
+              onChange={(e) => setZoom(Number(e.target.value))}
+              className={sliderStyles.slider}
+            />
+          </div>
+
+          <DialogFooter className="flex flex-row gap-3 border-0 bg-white">
+            <Button
+              className={`${actionButtonClassName} border-sosoeat-gray-300 hover:bg-sosoeat-gray-100 cursor-pointer border bg-white text-gray-700`}
+              onClick={handleCropCancel}
+            >
+              취소
+            </Button>
+            <Button
+              disabled={isPending}
+              onClick={handleCropConfirm}
+              className={`${actionButtonClassName} bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 cursor-pointer text-white`}
+            >
+              {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : '적용하기'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/meeting-create/ui/_components/step2-basic-info.tsx
+++ b/src/features/meeting-create/ui/_components/step2-basic-info.tsx
@@ -5,9 +5,6 @@ import { Controller } from 'react-hook-form';
 
 import Image from 'next/image';
 
-import { ImagePlus, Loader2 } from 'lucide-react';
-
-import { MIME_TO_EXT, useUploadImage } from '@/entities/image';
 import type { LocationSearchResult } from '@/entities/location';
 import { LocationSearchModal } from '@/entities/location';
 import { cn } from '@/shared/lib/utils';
@@ -15,14 +12,13 @@ import { Input } from '@/shared/ui/input/input';
 
 import type { StepProps } from '../../model/meeting-create.types';
 
-const ACCEPTED_IMAGE_TYPES = Object.keys(MIME_TO_EXT).join(',');
+import { MeetingImageEditor } from './meeting-image-editor';
 
 /**
  * 2단계: 모임 기본 정보 입력 (이름, 장소, 이미지)
  */
 export const StepBasicInfo = ({ form }: StepProps) => {
   const { register } = form;
-  const { mutateAsync, isPending, error: uploadError } = useUploadImage('meetings');
   const [locationModalOpen, setLocationModalOpen] = useState(false);
 
   const handleLocationSelect = (result: LocationSearchResult) => {
@@ -33,23 +29,6 @@ export const StepBasicInfo = ({ form }: StepProps) => {
     form.setValue('latitude', result.latitude);
     form.setValue('longitude', result.longitude);
     setLocationModalOpen(false);
-  };
-
-  const handleFileChange = async (
-    e: React.ChangeEvent<HTMLInputElement>,
-    onChange: (value: string) => void
-  ) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    try {
-      const url = await mutateAsync(file);
-      onChange(url);
-    } catch {
-      // 업로드 실패 시 uploadError로 표시
-    } finally {
-      e.target.value = ''; // 성공이나 실패 모두 초기화하여 재시도 가능하도록 처리
-    }
   };
 
   const requiredIndicator = <span className="text-destructive ml-0.5">*</span>;
@@ -118,49 +97,11 @@ export const StepBasicInfo = ({ form }: StepProps) => {
             <label className="text-sosoeat-gray-900 ml-1 text-sm font-medium md:text-base">
               이미지{requiredIndicator}
             </label>
-            <div className={field.value && !isPending ? 'relative w-full' : 'relative w-[147px]'}>
-              {field.value && !isPending ? (
-                <Image
-                  src={field.value as string}
-                  alt="모임 이미지"
-                  width={0}
-                  height={0}
-                  sizes="100vw"
-                  className="h-auto w-full rounded-2xl"
-                />
-              ) : (
-                <div className="bg-sosoeat-gray-100 text-sosoeat-gray-500 flex h-[147px] w-[147px] flex-col items-center justify-center gap-2 rounded-2xl border border-dashed text-sm">
-                  {isPending ? (
-                    <Loader2 className="h-6 w-6 animate-spin" />
-                  ) : (
-                    <ImagePlus className="h-6 w-6" />
-                  )}
-                </div>
-              )}
-              {/* 이미지 업로드/변경을 위한 클릭 overlay */}
-              {!isPending && (
-                <label
-                  htmlFor="image"
-                  className="absolute inset-0 cursor-pointer rounded-2xl"
-                  aria-label="이미지 선택"
-                />
-              )}
-              <input
-                type="file"
-                id="image"
-                className="sr-only"
-                accept={ACCEPTED_IMAGE_TYPES}
-                disabled={isPending}
-                onChange={(e) => handleFileChange(e, field.onChange)}
-              />
-            </div>
-            {(error || uploadError) && (
-              <p className="animate-in fade-in slide-in-from-top-1 text-destructive text-xs">
-                {uploadError instanceof Error
-                  ? uploadError.message
-                  : error?.message || '이미지 업로드에 실패했습니다.'}
-              </p>
-            )}
+            <MeetingImageEditor
+              imageUrl={field.value as string}
+              onChange={field.onChange}
+              error={error?.message}
+            />
           </div>
         )}
       />

--- a/src/features/meeting-create/ui/meeting-create-modal.test.tsx
+++ b/src/features/meeting-create/ui/meeting-create-modal.test.tsx
@@ -6,6 +6,28 @@ import userEvent from '@testing-library/user-event';
 
 import { MeetingCreateModal } from './meeting-create-modal';
 
+jest.mock('./_components/meeting-image-editor', () => ({
+  MeetingImageEditor: ({
+    imageUrl,
+    onChange,
+    error,
+  }: {
+    imageUrl?: string;
+    onChange: (url: string) => void;
+    error?: string;
+  }) => (
+    <div>
+      <input
+        type="file"
+        aria-label="이미지 선택"
+        onChange={() => onChange('https://s3.example.com/image.jpg')}
+      />
+      {imageUrl ? <img alt="모임 이미지" src={imageUrl} /> : null}
+      {error ? <p>{error}</p> : null}
+    </div>
+  ),
+}));
+
 // useUploadImage mock — 이미지 업로드를 즉시 성공으로 처리
 jest.mock('@/entities/image', () => ({
   useUploadImage: () => ({

--- a/src/features/meeting-create/ui/meeting-create-modal.test.tsx
+++ b/src/features/meeting-create/ui/meeting-create-modal.test.tsx
@@ -22,6 +22,7 @@ jest.mock('./_components/meeting-image-editor', () => ({
         aria-label="이미지 선택"
         onChange={() => onChange('https://s3.example.com/image.jpg')}
       />
+      {/* eslint-disable-next-line @next/next/no-img-element */}
       {imageUrl ? <img alt="모임 이미지" src={imageUrl} /> : null}
       {error ? <p>{error}</p> : null}
     </div>

--- a/src/features/notifications/ui/notification/notification-item/notification-item.thumbnail.tsx
+++ b/src/features/notifications/ui/notification/notification-item/notification-item.thumbnail.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react';
 
 import Image from 'next/image';
 
+import { toHttpsUrl } from '@/shared/lib/to-https-url';
+
 import type { NotificationThumbnailKey } from '../../../lib/notification-view.utils';
 
 import { ApprovedIcon, CommentIcon, MeetingIcon, UserIcon } from './notification-item.icons';
@@ -31,7 +33,13 @@ export const NotificationItemThumbnail = ({
   if (image) {
     return (
       <div className="size-[40px] shrink-0 overflow-hidden rounded-[8px]">
-        <Image src={image} alt="" width={80} height={80} className="size-full object-cover" />
+        <Image
+          src={toHttpsUrl(image)!}
+          alt=""
+          width={80}
+          height={80}
+          className="size-full object-cover"
+        />
       </div>
     );
   }

--- a/src/features/profile-edit/model/use-profile-image-editor.ts
+++ b/src/features/profile-edit/model/use-profile-image-editor.ts
@@ -3,6 +3,8 @@
 import { useRef, useState } from 'react';
 import type { Area } from 'react-easy-crop';
 
+import { toast } from 'sonner';
+
 import { useUploadImage } from '@/entities/image';
 import { getCroppedImg } from '@/shared/lib/image-crop';
 import { PresignedUrlRequestFolderEnum } from '@/shared/types/generated-client';
@@ -37,12 +39,12 @@ export function useProfileImageEditor(onChange: (url: string) => void) {
       const file = new File([blob], 'profile.jpg', { type: 'image/jpeg' });
       const publicUrl = await mutateAsync(file);
       if (publicUrl) onChange(publicUrl);
+      URL.revokeObjectURL(rawSrc);
+      setRawSrc(null);
       setCropModalOpen(false);
     } catch (error) {
       console.error('프로필 이미지 처리 중 오류가 발생했습니다:', error);
-    } finally {
-      URL.revokeObjectURL(rawSrc);
-      setRawSrc(null);
+      toast.error('이미지 업로드 중 문제가 생겼어요. 다시 시도해 주세요.');
     }
   };
 

--- a/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import { Loader2, Pencil, XIcon } from 'lucide-react';
 
+import { toHttpsUrl } from '@/shared/lib/to-https-url';
 import { Button } from '@/shared/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { BaseImageCropper } from '@/shared/ui/image-editor/base-image-cropper';
@@ -37,7 +38,7 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
     <div className="flex justify-center">
       <div className="relative h-32.5 w-32.5 md:h-50 md:w-50">
         <Image
-          src={imageUrl || '/images/basic-profile.svg'}
+          src={toHttpsUrl(imageUrl) || '/images/basic-profile.svg'}
           alt="프로필 이미지"
           fill
           className="ring-sosoeat-gray-300 rounded-full object-cover ring-1"

--- a/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
+++ b/src/features/profile-edit/ui/edit-profile-modal/_components/profile-image-editor.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import Cropper from 'react-easy-crop';
-
 import Image from 'next/image';
 
 import { Loader2, Pencil, XIcon } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { BaseImageCropper } from '@/shared/ui/image-editor/base-image-cropper';
 
 import { useProfileImageEditor } from '../../../model/use-profile-image-editor';
 import type { ProfileImageEditorProps } from '../edit-profile-modal.types';
+
+import sliderStyles from '@/shared/ui/image-editor/image-editor-slider.module.css';
 
 const actionButtonClassName =
   'w-fill h-12 md:h-15 flex-1 md:rounded-2xl rounded-xl py-3 text-base md:text-xl font-semibold';
@@ -84,13 +85,13 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
 
           <div className="relative h-72 w-full overflow-hidden rounded-2xl bg-white">
             {rawSrc && (
-              <Cropper
+              <BaseImageCropper
                 image={rawSrc}
                 crop={crop}
                 zoom={zoom}
                 aspect={1}
                 cropShape="round"
-                showGrid={false}
+                showGrid={true}
                 onCropChange={setCrop}
                 onZoomChange={setZoom}
                 onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
@@ -99,7 +100,6 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
           </div>
 
           <div className="flex flex-col gap-2">
-            <span className="text-sm text-gray-500">확대/축소</span>
             <input
               type="range"
               min={1}
@@ -107,7 +107,7 @@ export function ProfileImageEditor({ imageUrl, onChange }: ProfileImageEditorPro
               step={0.01}
               value={zoom}
               onChange={(e) => setZoom(Number(e.target.value))}
-              className="h-1 w-full cursor-pointer accent-orange-500"
+              className={sliderStyles.slider}
             />
           </div>
 

--- a/src/shared/lib/to-https-url.ts
+++ b/src/shared/lib/to-https-url.ts
@@ -1,0 +1,4 @@
+export function toHttpsUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  return url.startsWith('http://') ? url.replace('http://', 'https://') : url;
+}

--- a/src/shared/ui/image-editor/base-image-cropper.tsx
+++ b/src/shared/ui/image-editor/base-image-cropper.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { CropperProps } from 'react-easy-crop';
+import Cropper from 'react-easy-crop';
+
+const defaultCropperStyle: CropperProps['style'] = {
+  containerStyle: {
+    backgroundColor: '#ffffff',
+  },
+  cropAreaStyle: {
+    color: 'rgba(0, 0, 0, 0.03)',
+    border: '1px solid rgba(255, 255, 255, 0.9)',
+  },
+};
+
+type BaseImageCropperProps = {
+  image?: CropperProps['image'];
+  video?: CropperProps['video'];
+  crop: CropperProps['crop'];
+  zoom: CropperProps['zoom'];
+  aspect: CropperProps['aspect'];
+  cropShape?: CropperProps['cropShape'];
+  showGrid?: CropperProps['showGrid'];
+  objectFit?: CropperProps['objectFit'];
+  onCropChange: CropperProps['onCropChange'];
+  onZoomChange?: CropperProps['onZoomChange'];
+  onCropComplete?: CropperProps['onCropComplete'];
+  onCropAreaChange?: CropperProps['onCropAreaChange'];
+  onMediaLoaded?: CropperProps['onMediaLoaded'];
+  classes?: CropperProps['classes'];
+  style?: CropperProps['style'];
+  cropperProps?: CropperProps['cropperProps'];
+  mediaProps?: CropperProps['mediaProps'];
+};
+
+export function BaseImageCropper({ style, ...props }: BaseImageCropperProps) {
+  return (
+    <Cropper
+      {...props}
+      style={{
+        ...defaultCropperStyle,
+        ...style,
+        containerStyle: {
+          ...defaultCropperStyle.containerStyle,
+          ...style?.containerStyle,
+        },
+        mediaStyle: {
+          ...defaultCropperStyle.mediaStyle,
+          ...style?.mediaStyle,
+        },
+        cropAreaStyle: {
+          ...defaultCropperStyle.cropAreaStyle,
+          ...style?.cropAreaStyle,
+        },
+      }}
+    />
+  );
+}

--- a/src/shared/ui/image-editor/image-editor-slider.module.css
+++ b/src/shared/ui/image-editor/image-editor-slider.module.css
@@ -1,0 +1,41 @@
+.slider {
+  width: 100%;
+  cursor: pointer;
+  appearance: none;
+  background: transparent;
+}
+
+.slider:focus {
+  outline: none;
+}
+
+.slider::-webkit-slider-runnable-track {
+  height: 1px;
+  border-radius: 9999px;
+  background: #d4d4d8;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  margin-top: -6px;
+  border: none;
+  border-radius: 9999px;
+  background: #f97316;
+}
+
+.slider::-moz-range-track {
+  height: 1px;
+  border-radius: 9999px;
+  background: #d4d4d8;
+}
+
+.slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border: none;
+  border-radius: 9999px;
+  background: #f97316;
+}

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-item.tsx
@@ -3,6 +3,7 @@
 import { Heart, MessageCircle, UserRound } from 'lucide-react';
 
 import { useAuthStore } from '@/entities/auth';
+import { toHttpsUrl } from '@/shared/lib/to-https-url';
 import { cn } from '@/shared/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 
@@ -67,7 +68,7 @@ export function MeetingCommentItem({
         <div className="flex gap-2">
           {/* ── 아바타 ── */}
           <Avatar className="size-10 shrink-0 md:size-[54px]">
-            <AvatarImage src={author.profileUrl ?? undefined} alt={author.nickname} />
+            <AvatarImage src={toHttpsUrl(author.profileUrl)} alt={author.nickname} />
             <AvatarFallback className="text-sosoeat-orange-600">
               <UserRound className="size-6" />
             </AvatarFallback>

--- a/src/widgets/mypage/ui/user-card/user-card.tsx
+++ b/src/widgets/mypage/ui/user-card/user-card.tsx
@@ -7,6 +7,7 @@ import dynamic from 'next/dynamic';
 import { Calendar, Mail, Pencil } from 'lucide-react';
 
 import type { EditProfileModalProps } from '@/features/profile-edit';
+import { toHttpsUrl } from '@/shared/lib/to-https-url';
 import { useModal } from '@/shared/lib/use-modal';
 import { cn } from '@/shared/lib/utils';
 import { Avatar, AvatarImage } from '@/shared/ui/avatar';
@@ -43,7 +44,7 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
         <CardHeader>
           <div className="flex items-center gap-6 md:hidden">
             <Avatar className="h-20.75 w-20.75 shrink-0 border-2 border-white">
-              <AvatarImage src={localImageUrl || '/images/basic-profile.svg'} />
+              <AvatarImage src={toHttpsUrl(localImageUrl) || '/images/basic-profile.svg'} />
             </Avatar>
             <div className="flex flex-col gap-1">
               <div className="flex items-center py-1">
@@ -67,7 +68,7 @@ export function UserCard({ name, joinedAt, email, imageUrl, className }: UserCar
 
           <div className="hidden items-center gap-6 md:flex">
             <Avatar className="h-42.25 w-42.25 shrink-0">
-              <AvatarImage src={localImageUrl || '/images/basic-profile.svg'} />
+              <AvatarImage src={toHttpsUrl(localImageUrl) || '/images/basic-profile.svg'} />
             </Avatar>
             <div className="flex flex-col gap-1">
               <CardTitle className="w-full text-[28px] font-bold">{localName}</CardTitle>

--- a/src/widgets/navigation-bar/ui/nav-actions/nav-actions.tsx
+++ b/src/widgets/navigation-bar/ui/nav-actions/nav-actions.tsx
@@ -8,6 +8,7 @@ import { Plus } from 'lucide-react';
 
 import { AuthUser } from '@/entities/auth';
 import { MeetingCreateModalProps, useMeetingCreateTrigger } from '@/features/meeting-create';
+import { toHttpsUrl } from '@/shared/lib/to-https-url';
 import { Button } from '@/shared/ui/button';
 import {
   DropdownMenu,
@@ -67,7 +68,7 @@ export function NavActions({ user, onLogout, initialUnreadCount = 0 }: NavAction
             suppressHydrationWarning
           >
             <Image
-              src={user.image || '/images/basic-profile.svg'}
+              src={toHttpsUrl(user.image) || '/images/basic-profile.svg'}
               alt={user.name}
               width={32}
               height={32}


### PR DESCRIPTION
  📌 유형 (Type)

  - Fix (버그 수정): 버그 수정

  📝 변경 사항 (Changes)

  - 카카오 CDN이 HTTP URL로 이미지를 제공하여 next/image 검증 실패 및 브라우저 mixed content 문제 발생
  - src/shared/lib/to-https-url.ts 유틸 함수 추가 — http:// URL을 https://로 변환
  - 외부 이미지 URL을 next/image에 넘기는 모든 컴포넌트에 적용
    - nav-actions.tsx (네비게이션 바 프로필)
    - user-card.tsx (마이페이지 유저 카드)
    - profile-image-editor.tsx (프로필 이미지 편집)
    - meeting-comment-item.tsx (모임 댓글 작성자)
    - notification-item.thumbnail.tsx (알림 썸네일)
  - next.config.ts remotePatterns에서 http 카카오 CDN 항목 제거 (유틸 변환으로 불필요)

  🧪 테스트 방법 (How to Test)

  1. 카카오 계정으로 로그인합니다.
  2. 네비게이션 바, 마이페이지, 모임 상세 댓글 영역에서 프로필 이미지가 정상 출력되는지 확인합니다.
  3. 브라우저 콘솔에 Invalid src prop 에러 또는 mixed content 경고가 없는지 확인합니다.

  🚨 기타 참고 사항 (Notes)

  - DB에는 기존 HTTP URL이 그대로 저장되어 있으나, 렌더링 시점에 변환하므로 데이터 마이그레이션 불필요
  - 카카오 외 다른 소셜 로그인(구글 등)은 기존에 HTTPS URL을 제공하므로 영향 없음