### PR TITLE
[Style]: 상세 페이지 액션 버튼 디자인 개선

### DIFF
--- a/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
@@ -28,15 +28,35 @@ export function ActionButton({ config, category, onClick, pending }: ActionButto
     );
   }
 
-  const className =
-    config.variant === 'primary'
-      ? actionButtonVariants({ category })
-      : outlineButtonVariants({ category });
+  if (config.variant === 'outline') {
+    return (
+      <Button
+        variant="ghost"
+        style={{
+          borderColor:
+            category === 'groupEat'
+              ? 'var(--color-sosoeat-orange-800)'
+              : 'var(--color-sosoeat-blue-800)',
+        }}
+        className={cn(
+          'cursor-pointer disabled:cursor-not-allowed',
+          outlineButtonVariants({ category })
+        )}
+        onClick={onClick}
+        disabled={!!pending}
+      >
+        {config.label}
+      </Button>
+    );
+  }
 
   return (
     <Button
       variant="ghost"
-      className={cn('cursor-pointer disabled:cursor-not-allowed', className)}
+      className={cn(
+        'cursor-pointer disabled:cursor-not-allowed',
+        actionButtonVariants({ category })
+      )}
       onClick={onClick}
       disabled={!!pending}
     >

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/_components/action-button.tsx
@@ -35,7 +35,7 @@ export function ActionButton({ config, category, onClick, pending }: ActionButto
         style={{
           borderColor:
             category === 'groupEat'
-              ? 'var(--color-sosoeat-orange-800)'
+              ? 'var(--color-sosoeat-orange-700)'
               : 'var(--color-sosoeat-blue-800)',
         }}
         className={cn(

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
@@ -32,14 +32,14 @@ export const actionButtonVariants = cva(
 
 /** 흰 버튼 (참여 취소하기 / 공유하기) */
 export const outlineButtonVariants = cva(
-  'ring-0 h-full w-full rounded-2xl bg-white text-sm md:text-base lg:text-xl shadow-inner focus-visible:ring-0 focus-visible:border-transparent',
+  'ring-0 h-full w-full rounded-2xl border-2 bg-white text-sm md:text-base lg:text-xl focus-visible:ring-0 focus-visible:border-transparent',
   {
     variants: {
       category: {
         groupEat:
-          'ring-1 text-sosoeat-orange-700 hover:bg-sosoeat-orange-100 hover:text-sosoeat-orange-700',
+          'text-sosoeat-orange-700 hover:bg-white hover:text-sosoeat-orange-700 hover:shadow-[inset_0_0_10px_1px_rgba(0,0,0,0.15)]',
         groupBuy:
-          'ring-1 text-sosoeat-blue-700 hover:bg-sosoeat-blue-50 hover:text-sosoeat-blue-700',
+          'text-sosoeat-blue-700 hover:bg-white hover:text-sosoeat-blue-700 hover:shadow-[inset_0_0_10px_1px_rgba(0,0,0,0.15)]',
       },
     },
   }

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/meeting-detail-card.constants.ts
@@ -21,8 +21,10 @@ export const actionButtonVariants = cva(
   {
     variants: {
       category: {
-        groupEat: 'bg-sosoeat-orange-600 text-white hover:bg-sosoeat-orange-700 hover:text-white',
-        groupBuy: 'bg-sosoeat-blue-600 text-white hover:bg-sosoeat-blue-700 hover:text-white',
+        groupEat:
+          'bg-sosoeat-orange-600 text-white hover:bg-sosoeat-orange-700 hover:text-sosoeat-orange-100 hover:shadow-[inset_0_0_10px_1px_rgba(0,0,0,0.15)]',
+        groupBuy:
+          'bg-sosoeat-blue-600 text-white hover:bg-sosoeat-blue-700 hover:text-white hover:shadow-[inset_0_0_10px_1px_rgba(0,0,0,0.15)]',
       },
     },
   }


### PR DESCRIPTION
### 📌 유형 (Type)                                                                                                     
                                                                                                                         
  다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.                                                              
                                                                                                                         
  - [ ] **Feat (기능):** 새로운 기능 추가                                                                                
  - [ ] **Fix (버그 수정):** 버그 수정
  - [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변화 없음)                                                         
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)                                                                
  - [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)                                          
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등                                                      
                                                                                                                         
  ### 📝 변경 사항 (Changes)                                                                                             
                                                                                                                         
  - closes #384                                                                                                          
  - 상세 페이지 primary/outline 액션 버튼의 hover 상태 및 기본 디자인이 시안과 불일치하여 수정했습니다.
  - primary 버튼(참여하기 / 모임 확정하기) hover 시 색상 및 inset shadow를 추가했습니다.                                 
  - outline 버튼(참여 취소하기 / 공유하기)의 border를 `ring-1`에서 `border-2` + 카테고리별 색상 토큰으로 교체했습니다.   
  - `ActionButton` 컴포넌트에서 outline variant를 별도 분기로 분리하여 border color를 inline style로 처리했습니다.       
                                                                                                                         
  ### 🧪 테스트 방법 (How to Test)                                                                                       
                                                                                                                         
  1. 같이먹기(groupEat) 모임 상세 페이지로 이동합니다.                                                                   
  2. **참여하기** 버튼에 hover 시 bg `orange-700`, 텍스트 `orange-100`, inset shadow가 적용되는지 확인합니다.
  3. **참여 취소하기** 버튼에 `orange-800` border(2px)가 기본 상태에서 표시되는지 확인합니다.                            
  4. 참여 취소하기 버튼 hover 시 bg white 유지, inset shadow가 나타나는지 확인합니다.                                    
  5. 공동구매(groupBuy) 모임 상세 페이지에서 위 항목을 blue 계열로 동일하게 확인합니다.                                  
  6. **모집 마감(disabled)** 버튼 스타일이 기존과 동일한지 확인합니다.                                                   
                                                                                                                         
  ### 📸 스크린샷 또는 영상 (Optional)                                                                                   
  **groupEat(같이 먹기)**                                                                                                                       
<img width="512" height="393" alt="image" src="https://github.com/user-attachments/assets/8df44e2a-15a6-4691-a427-4d3e590c748e" />

  **groupBuy(공동구매)**
  
<img width="512" height="376" alt="image" src="https://github.com/user-attachments/assets/fad422c7-c74c-4393-ab20-fb0555b57872" />                                                                      
                
  ### 🚨 기타 참고 사항 (Notes) 