### PR TITLE
[Style]: 모임 상세 댓글 입력창 아바타 및 패딩 정렬          

### DIFF
--- a/src/shared/ui/comment-input/comment-input.tsx
+++ b/src/shared/ui/comment-input/comment-input.tsx
@@ -50,7 +50,7 @@ export function CommentInput({
   return (
     <div className={cn('flex items-center gap-3 sm:gap-4', className)}>
       {showAvatar ? (
-        <Avatar size="default" className="h-[54px] w-[54px] shrink-0">
+        <Avatar size="default" className="size-10 shrink-0 md:size-[54px]">
           <AvatarImage src={currentUserImageUrl} alt={currentUserName} />
           <AvatarFallback className="text-sm font-semibold">
             {currentUserName.slice(0, 1)}

--- a/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-comment-section/meeting-comment-section.tsx
@@ -78,7 +78,7 @@ export function MeetingCommentSection({
         </div>
       </ScrollArea>
 
-      <div className="mt-4 rounded-[24px] px-6 py-4">
+      <div className="mt-4 rounded-[24px] px-4 py-4">
         <CommentInput
           value={commentText}
           onChange={setCommentText}


### PR DESCRIPTION
### 📌 유형 (Type)                                                                                              
                                          
  - [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)                                   
                                                                                                                  
  ### 📝 변경 사항 (Changes)                                                                                      
                                                                                                                  
  - 관련 이슈: #397                                                                                               
  - 댓글 아이템 아바타(`px-4`)와 댓글 입력창 wrapper(`px-6`) 패딩이 달라 아바타 좌측 위치가 맞지 않는 문제를      
  수정했습니다.                               
  - 모바일에서 댓글 입력창 아바타 크기가 고정(`54px`)되어 댓글 아이템 아바타(`40px`)와 달랐던 문제를 반응형으로   
  통일했습니다.                               
                                                                                                                  
  ### 🧪 테스트 방법 (How to Test)            
                                                                                                                  
  1. 로컬 환경에서 앱을 실행합니다.           
  2. 모임 상세 페이지(`/meetings/:id`)로 이동합니다.                                                              
  3. 댓글 목록 아바타와 입력창 아바타의 좌측 위치가 일치하는지 확인합니다.
  4. 모바일(768px 미만)에서 입력창 아바타가 `40px`로 줄어드는지 확인합니다.                                       
                                              
  ### 📸 스크린샷 또는 영상 (Optional)                                                                            
                                                                                                                  
  | 변경 전 (Before) | 변경 후 (After) |                                                                          
  | :--------------: | :-------------: |                                                                          
  |                  |                 |                                                                          
                                                                                                                  