### PR TITLE
[Fix]: 검색어 초기화 시 이전 캐시 결과 flash 현상 수정

### DIFF
--- a/src/widgets/search/model/use-search-page.ts
+++ b/src/widgets/search/model/use-search-page.ts
@@ -188,6 +188,8 @@ const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | nu
     setSortOrder(sortOrder);
   };
 
+  const isSearchPending = inputValue !== searchQuery;
+
   return {
     meetingData,
     handleRegionChange,
@@ -208,6 +210,7 @@ const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | nu
     isFetchingNextPage,
     inputValue,
     handleSearchQueryChange,
+    isSearchPending,
   };
 };
 

--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -51,6 +51,7 @@ export default function SearchPage({
     fetchNextPage,
     inputValue,
     handleSearchQueryChange,
+    isSearchPending,
   } = useSearchPage(initialData);
 
   useEffect(() => {
@@ -75,7 +76,7 @@ export default function SearchPage({
           onRegionChange={handleRegionChange}
           onSortChange={handleSortChange}
         />
-        {isLoading ? (
+        {isLoading || isSearchPending ? (
           <SearchSkeleton />
         ) : isError ? (
           <div className="flex min-h-80 w-full items-center justify-center rounded-2xl border border-[#F3F4F6] bg-white px-6 py-12 text-center">


### PR DESCRIPTION
## PR 제목: [Fix]: 검색어 초기화 시 이전 캐시 결과 flash 현상 수정

### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

closes #401

- 검색창에 검색어를 입력 후 지울 때, 이전에 캐시된 전체 목록 결과가 순간 flash되는 버그 수정
- **원인:** `inputValue`(즉시 반영) vs `searchQuery`(500ms debounce 후 URL 반영) 사이의 gap에서 TanStack Query가 캐시된 결과를 즉시 노출하는 stale-while-revalidate 동작
- **해결:** `isSearchPending = inputValue !== searchQuery` 상태를 추가하여, debounce 대기 중에도 `SearchSkeleton`을 표시

**변경 파일:**
- `src/widgets/search/model/use-search-page.ts` — `isSearchPending` 계산 및 반환
- `src/widgets/search/ui/search-page/search-page.tsx` — `isLoading || isSearchPending` 조건으로 skeleton 표시

### 🧪 테스트 방법 (How to Test)

1. 개발 서버 실행 후 `/search` 페이지 접속
2. 검색창에 검색어 입력 → 필터링된 결과 확인
3. 검색어 전체 삭제
4. 이전 결과가 flash되지 않고 skeleton이 바로 표시된 후 전체 목록이 로드되는지 확인

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**