### PR TITLE
[Style]: how-to-use 섹션 아이콘 박스 및 텍스트 색상 스텝별 개별 적용

### DIFF
--- a/src/widgets/home/ui/how-to-use-section/how-to-use-section.tsx
+++ b/src/widgets/home/ui/how-to-use-section/how-to-use-section.tsx
@@ -2,18 +2,24 @@ const STEPS = [
   {
     step: 'STEP 01',
     icon: '🔍',
+    bgColor: 'bg-[#FF6B2B]/[8.2%]',
+    textColor: 'text-[#FF6B2B]',
     title: '모임 탐색',
     description: '원하는 음식이나 식재료로 모임을 검색하고, 내 동네의 모임을 찾아보세요.',
   },
   {
     step: 'STEP 02',
     icon: '🤝',
+    bgColor: 'bg-[#8B5CF6]/[8.2%]',
+    textColor: 'text-[#8B5CF6]',
     title: '참여 신청',
     description: '마음에 드는 모임에 참여 버튼을 눌러 신청하면 끝! 모임장과 연락해요.',
   },
   {
     step: 'STEP 03',
     icon: '🎉',
+    bgColor: 'bg-[#059669]/[8.2%]',
+    textColor: 'text-[#059669]',
     title: '함께 즐기기',
     description: '함께 맛있는 음식을 먹거나, 식재료를 나눠 스마트하게 절약해요.',
   },
@@ -31,15 +37,17 @@ export function HowToUseSection() {
         </div>
 
         <div className="flex w-full flex-col items-center gap-6 md:flex-row md:justify-center md:gap-[11px]">
-          {STEPS.map(({ step, icon, title, description }) => (
+          {STEPS.map(({ step, icon, bgColor, textColor, title, description }) => (
             <div
               key={step}
               className="flex flex-col items-center gap-2 text-center md:flex-1 md:gap-[11px] lg:min-h-[207px] lg:w-[250px] lg:flex-none lg:justify-center"
             >
-              <div className="bg-sosoeat-orange-100 flex h-12 w-12 items-center justify-center rounded-[14px] text-2xl shadow md:h-14 md:w-14 md:rounded-[20px] md:text-3xl lg:h-16 lg:w-16 lg:rounded-[25px] lg:text-3xl">
+              <div
+                className={`${bgColor} flex h-12 w-12 items-center justify-center rounded-[14px] text-2xl shadow md:h-14 md:w-14 md:rounded-[20px] md:text-3xl lg:h-16 lg:w-16 lg:rounded-[25px] lg:text-3xl`}
+              >
                 {icon}
               </div>
-              <span className="text-xs font-semibold tracking-widest text-orange-400">{step}</span>
+              <span className={`text-xs font-semibold tracking-widest ${textColor}`}>{step}</span>
               <p className="text-sm font-bold break-keep text-gray-900 md:text-base">{title}</p>
               <p className="text-xs leading-relaxed break-keep text-gray-400 md:text-sm">
                 {description}


### PR DESCRIPTION
 ### 📌 유형 (Type)                                                                          
                                                                                              
  - [ ] **Feat (기능):** 새로운 기능 추가                                                     
  - [ ] **Fix (버그 수정):** 버그 수정                                                        
  - [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)                              
  - [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)                                     
  - [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)               
  - [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등
                                                                                              
  ### 📝 변경 사항 (Changes)
                                                                                              
  - 홈 화면 '소소잇, 어떻게 사용하나요?' 섹션의 아이콘 박스 배경색을 스텝별로 다르게          
  적용했습니다.
  - STEPS 배열에 `bgColor`, `textColor` 필드를 추가하여 각 스텝의 색상을 개별 관리합니다.     
    - STEP 01: `#FF6B2B` (8.2% 불투명도 배경 / 텍스트)                                        
    - STEP 02: `#8B5CF6` (8.2% 불투명도 배경 / 텍스트)                                        
    - STEP 03: `#059669` (8.2% 불투명도 배경 / 텍스트)                                        
                                                                                              
  ### 🧪 테스트 방법 (How to Test)                                                            
                  
  1. 로컬 환경에서 앱을 실행합니다.                                                           
  2. 홈 화면(`/home`)으로 이동합니다.
  3. '소소잇, 어떻게 사용하나요?' 섹션의 각 스텝 아이콘 박스와 STEP 텍스트가 서로 다른
  색상으로 표시되는지 확인합니다.                                                             
   
  ### 📸 스크린샷 또는 영상 (Optional)                                                        
  
<img width="819" height="253" alt="image" src="https://github.com/user-attachments/assets/d726c593-dab2-481a-bea6-817a06bd2214" />

                  
  ### 🚨 기타 참고 사항 (Notes)

  - [ ] 색상 값은 `STEPS` 배열 상단에서 `bgColor` / `textColor` 필드만 수정하면 쉽게 변경     
  가능합니다.
  - color 하나로 줄이고 inline style로 처리하는 방식도 고려했으나, 프로젝트 전반이 Tailwind 기반이라 스타일 방식이 섞이는 것을 피하고자 bgColor / textColor 풀 클래스명을 유지했습니다. Tailwind JIT는 소스 내 완성된 문자열을 인식하므로 동작에 문제없습니다.