### PR TITLE
[Refactor]: 알림 패널 트리거 분리 및 네비게이션 바 UI 개선

### DIFF
--- a/src/features/notifications/index.ts
+++ b/src/features/notifications/index.ts
@@ -1,3 +1,6 @@
 export { formatNotificationMetaRelativeTime } from './lib/format-notification-meta-time';
+export { useUnreadCount } from './model/notification.queries';
 export { useNotificationReadActions } from './model/use-notification-read-actions';
 export { Notification } from './ui/notification/notification';
+export { NotificationPanel } from './ui/notification/notification-panel/notification-panel';
+export { NotificationTrigger } from './ui/notification/notification-trigger/notification-trigger';

--- a/src/features/notifications/ui/notification/notification-panel/notification-panel.test.tsx
+++ b/src/features/notifications/ui/notification/notification-panel/notification-panel.test.tsx
@@ -73,6 +73,19 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
+const renderWithClient = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+const renderOpenPanel = (overrides: Partial<Parameters<typeof NotificationPanel>[0]> = {}) => {
+  const onOpenChange = jest.fn();
+  renderWithClient(<NotificationPanel open={true} onOpenChange={onOpenChange} {...overrides} />);
+  return { onOpenChange };
+};
+
 const MAX_WIDTH_QUERY = '(max-width: 767px)';
 
 function mockMatchMedia(matchesNarrow: boolean) {
@@ -88,23 +101,8 @@ function mockMatchMedia(matchesNarrow: boolean) {
   });
 }
 
-const renderWithClient = (ui: React.ReactElement) => {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
-};
-
-const openPanel = async () => {
-  const user = userEvent.setup();
-  await user.click(screen.getByRole('button', { name: '알림 열기' }));
-  await screen.findByRole('heading', { name: '알림 내역' });
-  return user;
-};
-
 beforeEach(() => {
   mockMatchMedia(false);
-  jest.clearAllMocks();
   (useNotificationReadActions as jest.Mock).mockReturnValue({
     markAllAsRead: jest.fn(),
     markAsRead: jest.fn(),
@@ -116,80 +114,67 @@ beforeEach(() => {
 });
 
 describe('NotificationPanel', () => {
-  it('트리거 버튼이 렌더된다', () => {
-    renderWithClient(<NotificationPanel unreadCount={1} />);
-    expect(screen.getByRole('button', { name: '알림 열기' })).toBeInTheDocument();
-  });
-
-  it('트리거 클릭 시 제목과 모두 읽기 버튼을 렌더한다', async () => {
-    renderWithClient(<NotificationPanel unreadCount={1} />);
-    await openPanel();
+  it('열린 상태에서 제목과 모두 읽기 버튼을 렌더한다', () => {
+    renderOpenPanel({ unreadCount: 1 });
 
     expect(screen.getByRole('heading', { name: '알림 내역' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '모두 읽기' })).toBeInTheDocument();
   });
 
-  it('로딩 중일 때 로더를 렌더한다', async () => {
+  it('로딩 중일 때 로더를 렌더한다', () => {
     (useNotificationInfiniteList as jest.Mock).mockReturnValue(mockReturn({ isPending: true }));
-    renderWithClient(<NotificationPanel />);
-    await openPanel();
+    renderOpenPanel();
 
     expect(document.querySelector('.loader')).toBeInTheDocument();
   });
 
-  it('오류 발생 시 오류 메시지를 렌더한다', async () => {
+  it('오류 발생 시 오류 메시지를 렌더한다', () => {
     (useNotificationInfiniteList as jest.Mock).mockReturnValue(
       mockReturn({ error: new Error('API 오류') })
     );
-    renderWithClient(<NotificationPanel />);
-    await openPanel();
+    renderOpenPanel();
 
     expect(screen.getByText('알림을 불러오는 중 오류가 발생했습니다.')).toBeInTheDocument();
   });
 
-  it('마지막 페이지에 도달하면 "모든 알림을 불러왔어요" 메시지를 렌더한다', async () => {
+  it('마지막 페이지에 도달하면 "모든 알림을 불러왔어요" 메시지를 렌더한다', () => {
     (useNotificationInfiniteList as jest.Mock).mockReturnValue(
       mockReturn({ data: { pages: [{ data: mockData }] } })
     );
-    renderWithClient(<NotificationPanel unreadCount={1} />);
-    await openPanel();
+    renderOpenPanel({ unreadCount: 1 });
 
     expect(screen.getByText('모든 알림을 불러왔어요')).toBeInTheDocument();
   });
 
-  it('다음 페이지가 있을 때 "모든 알림을 불러왔어요" 메시지를 렌더하지 않는다', async () => {
+  it('다음 페이지가 있을 때 "모든 알림을 불러왔어요" 메시지를 렌더하지 않는다', () => {
     (useNotificationInfiniteList as jest.Mock).mockReturnValue(
       mockReturn({ hasNextPage: true, data: { pages: [{ data: mockData }] } })
     );
-    renderWithClient(<NotificationPanel unreadCount={1} />);
-    await openPanel();
+    renderOpenPanel({ unreadCount: 1 });
 
     expect(screen.queryByText('모든 알림을 불러왔어요')).not.toBeInTheDocument();
   });
 
-  it('알림이 없을 때 "알림이 없어요" 메시지를 렌더한다', async () => {
-    renderWithClient(<NotificationPanel />);
-    await openPanel();
+  it('알림이 없을 때 "알림이 없어요" 메시지를 렌더한다', () => {
+    renderOpenPanel();
 
     expect(screen.getByText('알림이 없어요')).toBeInTheDocument();
   });
 
-  it('닫기 버튼 클릭 시 패널이 닫힌다 (PC)', async () => {
-    renderWithClient(<NotificationPanel />);
-    const user = await openPanel();
+  it('닫기 버튼 클릭 시 onOpenChange(false)를 호출한다 (PC)', async () => {
+    const { onOpenChange } = renderOpenPanel();
+    const user = userEvent.setup();
 
     await user.click(screen.getByRole('button', { name: '알림 닫기' }));
-    expect(screen.queryByRole('heading', { name: '알림 내역' })).not.toBeInTheDocument();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('닫기 버튼 클릭 시 패널이 닫힌다 (모바일)', async () => {
+  it('닫기 버튼 클릭 시 onOpenChange(false)를 호출한다 (모바일)', async () => {
     mockMatchMedia(true);
-    renderWithClient(<NotificationPanel />);
+    const { onOpenChange } = renderOpenPanel();
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: '알림 열기' }));
-    await screen.findByRole('dialog');
 
     await user.click(screen.getByRole('button', { name: '알림 닫기' }));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
+++ b/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import { Dialog as DialogPrimitive } from 'radix-ui';
 
@@ -17,10 +16,7 @@ import {
   NOTIFICATION_TABS,
   type NotificationTab,
 } from '../../../lib/notification-view.utils';
-import {
-  prefetchNotificationInfiniteList,
-  useNotificationInfiniteList,
-} from '../../../model/notification.queries';
+import { useNotificationInfiniteList } from '../../../model/notification.queries';
 import { useNotificationReadActions } from '../../../model/use-notification-read-actions';
 import { NotificationItem } from '../notification-item/notification-item';
 
@@ -81,18 +77,18 @@ const NotificationPanelContent = ({
   const labelRefs = useRef<(HTMLSpanElement | null)[]>([]);
   const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 });
 
-  const updateIndicator = () => {
-    const activeIndex = NOTIFICATION_TABS.findIndex((t) => t.key === activeTab);
-    const btn = tabRefs.current[activeIndex];
-    const label = labelRefs.current[activeIndex];
-    if (!btn || !label) return;
-    setIndicatorStyle({
-      left: label.offsetLeft,
-      width: label.offsetWidth,
-    });
-  };
-
   useEffect(() => {
+    const updateIndicator = () => {
+      const activeIndex = NOTIFICATION_TABS.findIndex((t) => t.key === activeTab);
+      const btn = tabRefs.current[activeIndex];
+      const label = labelRefs.current[activeIndex];
+      if (!btn || !label) return;
+      setIndicatorStyle({
+        left: label.offsetLeft,
+        width: label.offsetWidth,
+      });
+    };
+
     updateIndicator();
 
     const observer = new ResizeObserver(updateIndicator);
@@ -100,7 +96,6 @@ const NotificationPanelContent = ({
       if (el) observer.observe(el);
     });
     return () => observer.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
 
   const showBadge = unreadCount != null && unreadCount > 0;
@@ -269,21 +264,7 @@ interface NotificationPanelProps {
 
 export const NotificationPanel = ({ unreadCount, open, onOpenChange }: NotificationPanelProps) => {
   const titleId = React.useId();
-  const queryClient = useQueryClient();
   const isMobile = useIsMobile();
-
-  const handleOpen = (nextOpen: boolean) => {
-    if (nextOpen) {
-      void prefetchNotificationInfiniteList(queryClient, { size: PAGE_SIZE });
-    }
-    onOpenChange(nextOpen);
-  };
-
-  useEffect(() => {
-    if (!isMobile && open) {
-      void prefetchNotificationInfiniteList(queryClient, { size: PAGE_SIZE });
-    }
-  }, [isMobile, open, queryClient]);
 
   const panelContent = (
     <NotificationPanelContent
@@ -300,7 +281,7 @@ export const NotificationPanel = ({ unreadCount, open, onOpenChange }: Notificat
         {open && (
           <div className="fixed inset-0 z-40 bg-black/40" onClick={() => onOpenChange(false)} />
         )}
-        <DialogPrimitive.Root open={open} onOpenChange={handleOpen} modal={false}>
+        <DialogPrimitive.Root open={open} onOpenChange={onOpenChange} modal={false}>
           <DialogPrimitive.Portal>
             <DialogPrimitive.Content
               aria-describedby={undefined}

--- a/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
+++ b/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
@@ -23,7 +23,6 @@ import {
 } from '../../../model/notification.queries';
 import { useNotificationReadActions } from '../../../model/use-notification-read-actions';
 import { NotificationItem } from '../notification-item/notification-item';
-import { NotificationTrigger } from '../notification-trigger/notification-trigger';
 
 const PAGE_SIZE = 5;
 
@@ -78,27 +77,28 @@ const NotificationPanelContent = ({
 
   const [activeTab, setActiveTab] = useState<NotificationTab>('all');
   const list = filterNotificationsByTab(allList, activeTab);
-  const tabContainerRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const labelRefs = useRef<(HTMLSpanElement | null)[]>([]);
   const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 });
 
   const updateIndicator = () => {
-    const container = tabContainerRef.current;
     const activeIndex = NOTIFICATION_TABS.findIndex((t) => t.key === activeTab);
     const btn = tabRefs.current[activeIndex];
-    if (!container || !btn) return;
-    const containerRect = container.getBoundingClientRect();
-    const btnRect = btn.getBoundingClientRect();
+    const label = labelRefs.current[activeIndex];
+    if (!btn || !label) return;
     setIndicatorStyle({
-      left: btnRect.left - containerRect.left + 8, // px-2 = 8px
-      width: btnRect.width - 16, // 좌우 px-2 제외
+      left: btn.offsetLeft + label.offsetLeft,
+      width: label.offsetWidth,
     });
   };
 
   useEffect(() => {
     updateIndicator();
+
     const observer = new ResizeObserver(updateIndicator);
-    if (tabContainerRef.current) observer.observe(tabContainerRef.current);
+    tabRefs.current.forEach((el) => {
+      if (el) observer.observe(el);
+    });
     return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
@@ -149,7 +149,6 @@ const NotificationPanelContent = ({
               onClick={() => {
                 if (showBadge) void markAllAsRead();
               }}
-              aria-label="모두 읽기"
             >
               모두 읽기
             </button>
@@ -166,7 +165,7 @@ const NotificationPanelContent = ({
       </div>
 
       <div className="mt-4 flex shrink-0 flex-row items-end justify-between border-b border-gray-100 px-4">
-        <div ref={tabContainerRef} className="relative flex flex-row gap-1">
+        <div className="relative flex flex-row gap-1">
           {NOTIFICATION_TABS.map(({ key, label }, index) => (
             <button
               key={key}
@@ -184,9 +183,14 @@ const NotificationPanelContent = ({
                 setActiveTab(key);
                 setConfirmDelete(false);
               }}
-              aria-label="알림 읽기 버튼"
             >
-              {label}
+              <span
+                ref={(el) => {
+                  labelRefs.current[index] = el;
+                }}
+              >
+                {label}
+              </span>
             </button>
           ))}
           <span
@@ -221,7 +225,6 @@ const NotificationPanelContent = ({
               type="button"
               className="text-sosoeat-gray-500 hover:text-destructive cursor-pointer px-2 pb-3 text-sm font-semibold transition-colors"
               onClick={() => setConfirmDelete(true)}
-              aria-label="전체 삭제 버튼"
             >
               전체 삭제
             </button>
@@ -259,13 +262,13 @@ const NotificationPanelContent = ({
 };
 
 interface NotificationPanelProps {
-  triggerClassName?: string;
   unreadCount?: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-export const NotificationPanel = ({ triggerClassName, unreadCount }: NotificationPanelProps) => {
+export const NotificationPanel = ({ unreadCount, open, onOpenChange }: NotificationPanelProps) => {
   const titleId = React.useId();
-  const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
 
@@ -273,14 +276,14 @@ export const NotificationPanel = ({ triggerClassName, unreadCount }: Notificatio
     if (nextOpen) {
       void prefetchNotificationInfiniteList(queryClient, { size: PAGE_SIZE });
     }
-    setOpen(nextOpen);
+    onOpenChange(nextOpen);
   };
 
   const panelContent = (
     <NotificationPanelContent
       titleId={titleId}
       unreadCount={unreadCount}
-      onClose={() => setOpen(false)}
+      onClose={() => onOpenChange(false)}
       isMobile={isMobile}
     />
   );
@@ -288,18 +291,14 @@ export const NotificationPanel = ({ triggerClassName, unreadCount }: Notificatio
   if (isMobile) {
     return (
       <>
-        {open && <div className="fixed inset-0 z-40 bg-black/40" onClick={() => setOpen(false)} />}
+        {open && (
+          <div className="fixed inset-0 z-40 bg-black/40" onClick={() => onOpenChange(false)} />
+        )}
         <DialogPrimitive.Root open={open} onOpenChange={handleOpen} modal={false}>
-          <DialogPrimitive.Trigger asChild>
-            <NotificationTrigger
-              className={triggerClassName}
-              unreadCount={unreadCount ?? 0}
-              data-notification-trigger
-            />
-          </DialogPrimitive.Trigger>
           <DialogPrimitive.Portal>
             <DialogPrimitive.Content
               aria-describedby={undefined}
+              aria-labelledby={titleId}
               className={MOBILE_PANEL_CLASS}
               onInteractOutside={(e) => {
                 const target = e.target as HTMLElement;
@@ -307,7 +306,7 @@ export const NotificationPanel = ({ triggerClassName, unreadCount }: Notificatio
                   e.preventDefault();
                   return;
                 }
-                setOpen(false);
+                onOpenChange(false);
               }}
             >
               <DialogPrimitive.Title className="sr-only">알림</DialogPrimitive.Title>
@@ -321,20 +320,9 @@ export const NotificationPanel = ({ triggerClassName, unreadCount }: Notificatio
 
   // PC: 트리거 버튼 아래에 드롭다운
   return (
-    <div className="relative">
-      <NotificationTrigger
-        className={triggerClassName}
-        unreadCount={unreadCount ?? 0}
-        onClick={() => handleOpen(!open)}
-        data-notification-trigger
-        aria-label="알림 열기"
-      />
-      {open && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <div className={DESKTOP_PANEL_CLASS}>{panelContent}</div>
-        </>
-      )}
-    </div>
+    <>
+      {open && <div className="fixed inset-0 z-40" onClick={() => onOpenChange(false)} />}
+      <div className={DESKTOP_PANEL_CLASS}>{panelContent}</div>
+    </>
   );
 };

--- a/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
+++ b/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
@@ -87,7 +87,7 @@ const NotificationPanelContent = ({
     const label = labelRefs.current[activeIndex];
     if (!btn || !label) return;
     setIndicatorStyle({
-      left: btn.offsetLeft + label.offsetLeft,
+      left: label.offsetLeft,
       width: label.offsetWidth,
     });
   };
@@ -279,6 +279,12 @@ export const NotificationPanel = ({ unreadCount, open, onOpenChange }: Notificat
     onOpenChange(nextOpen);
   };
 
+  useEffect(() => {
+    if (!isMobile && open) {
+      void prefetchNotificationInfiniteList(queryClient, { size: PAGE_SIZE });
+    }
+  }, [isMobile, open, queryClient]);
+
   const panelContent = (
     <NotificationPanelContent
       titleId={titleId}
@@ -321,8 +327,12 @@ export const NotificationPanel = ({ unreadCount, open, onOpenChange }: Notificat
   // PC: 트리거 버튼 아래에 드롭다운
   return (
     <>
-      {open && <div className="fixed inset-0 z-40" onClick={() => onOpenChange(false)} />}
-      <div className={DESKTOP_PANEL_CLASS}>{panelContent}</div>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => onOpenChange(false)} />
+          <div className={DESKTOP_PANEL_CLASS}>{panelContent}</div>
+        </>
+      )}
     </>
   );
 };

--- a/src/features/notifications/ui/notification/notification-trigger/notification-trigger.tsx
+++ b/src/features/notifications/ui/notification/notification-trigger/notification-trigger.tsx
@@ -17,7 +17,7 @@ export const NotificationTrigger = React.forwardRef<HTMLButtonElement, Notificat
         ref={ref}
         type={type}
         className={cn(
-          'relative inline-flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center overflow-visible rounded-[14px] border-0 bg-transparent p-0',
+          'relative inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center overflow-visible rounded-[14px] border-0 bg-transparent p-0',
           className
         )}
         {...props}
@@ -26,7 +26,7 @@ export const NotificationTrigger = React.forwardRef<HTMLButtonElement, Notificat
         <Bell
           className={cn(
             unreadCount > 0 ? 'text-sosoeat-orange-600' : 'text-sosoeat-gray-600',
-            'absolute top-[10px] left-[10px] size-5'
+            'size-6'
           )}
           strokeWidth={1.5}
           aria-hidden="true"

--- a/src/features/notifications/ui/notification/notification.stories.tsx
+++ b/src/features/notifications/ui/notification/notification.stories.tsx
@@ -56,5 +56,5 @@ const meta: Meta<typeof NotificationComponent> = {
 export default meta;
 
 export const Default: StoryObj<typeof NotificationComponent> = {
-  render: () => <NotificationComponent triggerClassName="" />,
+  render: () => <NotificationComponent open={true} onOpenChange={() => {}} />,
 };

--- a/src/features/notifications/ui/notification/notification.test.tsx
+++ b/src/features/notifications/ui/notification/notification.test.tsx
@@ -4,7 +4,6 @@ import { useInView } from 'react-intersection-observer';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import type { Notification } from '@/shared/types/generated-client';
 
@@ -115,46 +114,30 @@ describe('Notification', () => {
     (useNotificationInfiniteList as jest.Mock).mockReturnValue(mockInfiniteReturn({}));
   });
 
-  it('알림 열기 트리거가 표시된다', async () => {
-    renderWithClient(<Nt />);
-    expect(await screen.findByRole('button', { name: '알림 열기' })).toBeInTheDocument();
-  });
-
-  it('triggerClassName이 트리거 버튼에 적용된다', async () => {
-    renderWithClient(<Nt triggerClassName="trigger-test-class" />);
-    expect(await screen.findByRole('button', { name: '알림 열기' })).toHaveClass(
-      'trigger-test-class'
-    );
-  });
-
   it('initialUnreadCount가 useUnreadCount에 전달된다', () => {
-    renderWithClient(<Nt initialUnreadCount={5} />);
+    renderWithClient(<Nt initialUnreadCount={5} open={false} onOpenChange={jest.fn()} />);
     expect(useUnreadCount).toHaveBeenCalledWith(5);
   });
 
-  it('트리거 클릭 시 알림 내역과 목록이 보인다 (PC)', async () => {
-    const user = userEvent.setup();
+  it('open=true일 때 알림 내역과 목록이 보인다 (PC)', async () => {
     (useNotificationInfiniteList as jest.Mock).mockReturnValue(
       mockInfiniteReturn({ data: { pages: [{ data: testNotifications }] } })
     );
 
-    renderWithClient(<Nt />);
-    await user.click(await screen.findByRole('button', { name: '알림 열기' }));
+    renderWithClient(<Nt open={true} onOpenChange={jest.fn()} />);
 
     expect(await screen.findByRole('heading', { name: '알림 내역' })).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: '모두 읽기' })).toBeInTheDocument();
     expect(await screen.findByText('모임 확정')).toBeInTheDocument();
   });
 
-  it('트리거 클릭 시 알림 내역과 목록이 보인다 (모바일)', async () => {
+  it('open=true일 때 알림 내역과 목록이 보인다 (모바일)', async () => {
     mockMatchMedia(true);
-    const user = userEvent.setup();
     (useNotificationInfiniteList as jest.Mock).mockReturnValue(
       mockInfiniteReturn({ data: { pages: [{ data: testNotifications }] } })
     );
 
-    renderWithClient(<Nt />);
-    await user.click(await screen.findByRole('button', { name: '알림 열기' }));
+    renderWithClient(<Nt open={true} onOpenChange={jest.fn()} />);
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: '알림 내역' })).toBeInTheDocument();

--- a/src/features/notifications/ui/notification/notification.tsx
+++ b/src/features/notifications/ui/notification/notification.tsx
@@ -5,15 +5,13 @@ import { useUnreadCount } from '../../model/notification.queries';
 import { NotificationPanel } from './notification-panel/notification-panel';
 
 interface NotificationProps {
-  triggerClassName?: string;
   initialUnreadCount?: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-export const Notification = ({
-  triggerClassName = '',
-  initialUnreadCount = 0,
-}: NotificationProps) => {
+export const Notification = ({ initialUnreadCount = 0, open, onOpenChange }: NotificationProps) => {
   const { data: unreadCount = 0 } = useUnreadCount(initialUnreadCount);
 
-  return <NotificationPanel triggerClassName={triggerClassName} unreadCount={unreadCount} />;
+  return <NotificationPanel unreadCount={unreadCount} open={open} onOpenChange={onOpenChange} />;
 };

--- a/src/widgets/navigation-bar/ui/mobile-sheet/mobile-sheet.tsx
+++ b/src/widgets/navigation-bar/ui/mobile-sheet/mobile-sheet.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useState } from 'react';
 
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 
 import { LogOut, Menu, User } from 'lucide-react';
 
 import { AuthUser } from '@/entities/auth';
-import { MeetingCreateModal, useMeetingCreateTrigger } from '@/features/meeting-create';
+import type { MeetingCreateModalProps } from '@/features/meeting-create';
+import { useMeetingCreateTrigger } from '@/features/meeting-create';
 import { cn } from '@/shared/lib/utils';
 import { CountingBadge } from '@/shared/ui/counting-badge/counting-badge';
 import {
@@ -21,6 +23,11 @@ import {
 } from '@/shared/ui/sheet';
 
 import { getIsActive, getNavHref, NAV_ITEMS } from '../../lib/nav.constants';
+
+const MeetingCreateModal = dynamic<MeetingCreateModalProps>(
+  () => import('@/features/meeting-create').then((mod) => mod.MeetingCreateModal),
+  { ssr: false }
+);
 
 interface MobileSheetProps {
   user: AuthUser | null;

--- a/src/widgets/navigation-bar/ui/mobile-sheet/mobile-sheet.tsx
+++ b/src/widgets/navigation-bar/ui/mobile-sheet/mobile-sheet.tsx
@@ -2,14 +2,13 @@
 
 import { useEffect, useState } from 'react';
 
-import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { Plus } from 'lucide-react';
+import { LogOut, Menu, User } from 'lucide-react';
 
 import { AuthUser } from '@/entities/auth';
-import { MeetingCreateModalProps, useMeetingCreateTrigger } from '@/features/meeting-create';
+import { MeetingCreateModal, useMeetingCreateTrigger } from '@/features/meeting-create';
 import { cn } from '@/shared/lib/utils';
 import { CountingBadge } from '@/shared/ui/counting-badge/counting-badge';
 import {
@@ -22,11 +21,6 @@ import {
 } from '@/shared/ui/sheet';
 
 import { getIsActive, getNavHref, NAV_ITEMS } from '../../lib/nav.constants';
-
-const MeetingCreateModal = dynamic<MeetingCreateModalProps>(
-  () => import('@/features/meeting-create').then((mod) => mod.MeetingCreateModal),
-  { ssr: false }
-);
 
 interface MobileSheetProps {
   user: AuthUser | null;
@@ -59,8 +53,8 @@ export function MobileSheet({
     <>
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
-          <button className="p-1 md:hidden" aria-label="메뉴 열기" suppressHydrationWarning>
-            <Image src="/icons/icon-hamburger.png" alt="메뉴" width={24} height={24} />
+          <button className="p-1 md:hidden" aria-label="메뉴 열기">
+            <Menu className="text-sosoeat-gray-600 size-6" strokeWidth={1.5} />
           </button>
         </SheetTrigger>
         <SheetContent side="right" className="flex w-64 flex-col gap-0 rounded-l-[24px] p-0">
@@ -117,7 +111,7 @@ export function MobileSheet({
           )}
 
           {/* 메뉴 섹션 */}
-          <div className="flex flex-col px-4 pt-5">
+          <div className="flex flex-col px-4 py-5">
             <p className="mb-1 px-3 text-xs font-semibold text-gray-400">메뉴</p>
             {NAV_ITEMS.map((item) => {
               const isActive = getIsActive(item, pathname);
@@ -159,16 +153,18 @@ export function MobileSheet({
               <SheetClose asChild>
                 <Link
                   href="/mypage"
-                  className="hover:text-sosoeat-orange-600 flex h-11 items-center rounded-md px-3 text-sm font-medium text-gray-600 transition-colors"
+                  className="hover:text-sosoeat-orange-600 flex h-11 items-center gap-3 rounded-md px-3 text-sm font-medium text-gray-600 transition-colors"
                 >
+                  <User className="size-4 shrink-0" />
                   마이페이지
                 </Link>
               </SheetClose>
               <SheetClose asChild>
                 <button
                   onClick={onLogout}
-                  className="text-destructive flex h-11 items-center rounded-md px-3 text-sm font-medium transition-colors hover:opacity-70"
+                  className="text-destructive flex h-11 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors hover:opacity-70"
                 >
+                  <LogOut className="size-4 shrink-0" />
                   로그아웃
                 </button>
               </SheetClose>
@@ -185,7 +181,7 @@ export function MobileSheet({
                   handleOpen();
                 }}
               >
-                <Plus className="size-4" strokeWidth={2.5} />
+                <Image src="/icons/icon-createGroup.png" alt="" width={16} height={16} />
                 모임 만들기
               </button>
             </SheetClose>

--- a/src/widgets/navigation-bar/ui/nav-actions/nav-actions.tsx
+++ b/src/widgets/navigation-bar/ui/nav-actions/nav-actions.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import { AuthUser } from '@/entities/auth';
 import { MeetingCreateModalProps, useMeetingCreateTrigger } from '@/features/meeting-create';
 import { NotificationTrigger, useUnreadCount } from '@/features/notifications';
+import { toHttpsUrl } from '@/shared/lib/to-https-url';
 import { Button } from '@/shared/ui/button';
 import {
   DropdownMenu,
@@ -83,7 +84,7 @@ export function NavActions({ user, onLogout, initialUnreadCount = 0 }: NavAction
             suppressHydrationWarning
           >
             <Image
-              src={user.image || '/images/basic-profile.svg'}
+              src={toHttpsUrl(user.image) || '/images/basic-profile.svg'}
               alt={user.name}
               width={32}
               height={32}

--- a/src/widgets/navigation-bar/ui/nav-actions/nav-actions.tsx
+++ b/src/widgets/navigation-bar/ui/nav-actions/nav-actions.tsx
@@ -1,14 +1,14 @@
 'use client';
 
+import { useState } from 'react';
+
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { Plus } from 'lucide-react';
-
 import { AuthUser } from '@/entities/auth';
 import { MeetingCreateModalProps, useMeetingCreateTrigger } from '@/features/meeting-create';
-import { toHttpsUrl } from '@/shared/lib/to-https-url';
+import { NotificationTrigger, useUnreadCount } from '@/features/notifications';
 import { Button } from '@/shared/ui/button';
 import {
   DropdownMenu,
@@ -22,11 +22,10 @@ const MeetingCreateModal = dynamic<MeetingCreateModalProps>(
   { ssr: false }
 );
 
-const Notification = dynamic(
-  () => import('@/features/notifications').then((mod) => mod.Notification),
+const NotificationPanel = dynamic(
+  () => import('@/features/notifications').then((mod) => mod.NotificationPanel),
   { ssr: false }
 );
-
 interface NavActionsProps {
   user: AuthUser | null;
   onLogout: () => void;
@@ -35,6 +34,8 @@ interface NavActionsProps {
 
 export function NavActions({ user, onLogout, initialUnreadCount = 0 }: NavActionsProps) {
   const { handleOpen, isOpen, close, createMeeting } = useMeetingCreateTrigger();
+  const [notificationOpen, setNotificationOpen] = useState(false);
+  const { data: unreadCount = 0 } = useUnreadCount(initialUnreadCount);
 
   if (!user) {
     return (
@@ -51,14 +52,28 @@ export function NavActions({ user, onLogout, initialUnreadCount = 0 }: NavAction
     <>
       <Button
         size="lg"
-        className="bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 hidden cursor-pointer items-center justify-center gap-1 rounded-xl px-4 py-2 font-medium text-white md:mr-1 md:flex"
+        className="bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 hidden items-center justify-center gap-1 rounded-xl px-4 py-2 font-medium text-white md:mr-1 md:flex"
         onClick={handleOpen}
       >
-        <Plus className="size-4" strokeWidth={2.5} />
+        <Image src="/icons/icon-createGroup.png" alt="" width={16} height={16} />
         모임 만들기
       </Button>
 
-      <Notification initialUnreadCount={initialUnreadCount} />
+      <div className="relative flex items-center">
+        <NotificationTrigger
+          unreadCount={unreadCount}
+          onClick={() => setNotificationOpen((prev) => !prev)}
+          data-notification-trigger
+          aria-label="알림 열기"
+        />
+        {notificationOpen && (
+          <NotificationPanel
+            unreadCount={unreadCount}
+            open={notificationOpen}
+            onOpenChange={setNotificationOpen}
+          />
+        )}
+      </div>
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -68,26 +83,22 @@ export function NavActions({ user, onLogout, initialUnreadCount = 0 }: NavAction
             suppressHydrationWarning
           >
             <Image
-              src={toHttpsUrl(user.image) || '/images/basic-profile.svg'}
+              src={user.image || '/images/basic-profile.svg'}
               alt={user.name}
               width={32}
               height={32}
               className="bg-sosoeat-gray-200 size-8 shrink-0 rounded-full object-cover"
-              onError={(event) => {
-                event.currentTarget.src = '/images/basic-profile.svg';
+              onError={(e) => {
+                e.currentTarget.src = '/images/basic-profile.svg';
               }}
             />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem className="h-10 cursor-pointer pl-2" asChild>
+          <DropdownMenuItem className="h-10" asChild>
             <Link href="/mypage">마이페이지</Link>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            className="h-10 cursor-pointer pl-2"
-            variant="destructive"
-            onClick={onLogout}
-          >
+          <DropdownMenuItem className="h-10" variant="destructive" onClick={onLogout}>
             로그아웃
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/widgets/navigation-bar/ui/navigation-bar/navigation-bar.test.tsx
+++ b/src/widgets/navigation-bar/ui/navigation-bar/navigation-bar.test.tsx
@@ -15,7 +15,19 @@ jest.mock('next/navigation', () => ({
 }));
 
 jest.mock('@/features/notifications', () => ({
-  Notification: () => <button aria-label="알림 열기">알림</button>,
+  NotificationTrigger: ({
+    onClick,
+    'aria-label': ariaLabel,
+  }: {
+    onClick: () => void;
+    'aria-label'?: string;
+  }) => (
+    <button aria-label={ariaLabel ?? '알림 열기'} onClick={onClick}>
+      알림
+    </button>
+  ),
+  NotificationPanel: () => null,
+  useUnreadCount: jest.fn().mockReturnValue({ data: 0 }),
 }));
 
 const mockPush = jest.fn();

--- a/src/widgets/sosotalk/ui/sosotalk-filter-bar/sosotalk-filter-bar.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-filter-bar/sosotalk-filter-bar.tsx
@@ -55,7 +55,7 @@ export const SosoTalkFilterBar = ({
                 type="button"
                 onClick={() => onTabChange(tab.value)}
                 className={cn(
-                  'inline-flex h-8 items-center text-xl leading-none font-semibold transition-colors',
+                  'inline-flex h-8 cursor-pointer items-center text-xl leading-none font-semibold transition-colors',
                   isActive
                     ? 'text-sosoeat-orange-600 font-bold'
                     : 'text-sosoeat-gray-900 hover:text-sosoeat-orange-600'
@@ -78,7 +78,7 @@ export const SosoTalkFilterBar = ({
                 type="button"
                 onClick={() => onSortChange(option.value)}
                 className={cn(
-                  'relative inline-flex h-8 items-center pl-3 text-base leading-none font-semibold transition-colors',
+                  'relative inline-flex h-8 cursor-pointer items-center pl-3 text-base leading-none font-semibold transition-colors',
                   isActive
                     ? 'text-sosoeat-gray-900'
                     : 'text-sosoeat-gray-500 hover:text-sosoeat-gray-900'
@@ -102,7 +102,7 @@ export const SosoTalkFilterBar = ({
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              className="text-sosoeat-gray-900 inline-flex h-8 items-center gap-1 text-base leading-none font-medium md:hidden"
+              className="text-sosoeat-gray-900 inline-flex h-8 cursor-pointer items-center gap-1 text-base leading-none font-medium md:hidden"
               aria-label="정렬 옵션 열기"
             >
               <span>{selectedSortOption.label}</span>


### PR DESCRIPTION
  ### 📌 유형 (Type)

  - [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
  - [x] **Fix (버그 수정):** 버그 수정

  ### 📝 변경 사항 (Changes)

  - `NotificationPanel`이 내부적으로 트리거를 직접 렌더하던 구조에서, `open` /
  `onOpenChange` props로 외부 제어하도록 변경
  - `NotificationTrigger`, `NotificationPanel`, `useUnreadCount`를 `features/notifications`
   public index에서 export하여 외부 조합 가능하게 개선
  - `NavActions`에서 `notificationOpen` 상태를 직접 관리하며 트리거와 패널을 조합
  - `MobileSheet` UI 개선: 햄버거 → lucide `Menu` 아이콘, 마이페이지/로그아웃 항목에 아이콘
   추가, 모임 만들기 버튼 아이콘 교체

  ### 🧪 테스트 방법 (How to Test)

  1. 로컬 환경에서 앱 실행
  2. PC에서 알림 벨 아이콘 클릭 → 드롭다운 패널이 열리는지 확인
  3. 모바일에서 알림 벨 아이콘 클릭 → 모바일 시트 형태로 열리는지 확인
  4. 모바일에서 햄버거 메뉴 열기 → 새 아이콘 및 마이페이지/로그아웃 아이콘 확인

  ### 🚨 기타 참고 사항 (Notes)

  - [ ] `NotificationPanel`의 open 상태를 `NavActions`가 소유하므로, 외부 클릭 닫기 로직이
  `NavActions` 레벨에서 동작함