### PR TITLE
[Style]: search 페이지 로딩 중 텍스트를 framer-motion 바운싱 애니메이션으로 교체

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ AGENTS.md
 src/graphify-out/cache/
 .claude/settings.local.json/
 .next-benchmark/
+
+.opencode

--- a/src/widgets/search/model/use-search-page.ts
+++ b/src/widgets/search/model/use-search-page.ts
@@ -188,7 +188,7 @@ const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | nu
     setSortOrder(sortOrder);
   };
 
-  const isSearchPending = inputValue !== searchQuery;
+  const isSearchPending = searchQuery !== '' && inputValue === '';
 
   return {
     meetingData,

--- a/src/widgets/search/model/use-search-page.ts
+++ b/src/widgets/search/model/use-search-page.ts
@@ -188,7 +188,7 @@ const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | nu
     setSortOrder(sortOrder);
   };
 
-  const isSearchPending = searchQuery !== '' && inputValue === '';
+  const isSearchPending = inputValue !== searchQuery && inputValue !== '';
 
   return {
     meetingData,

--- a/src/widgets/search/ui/loading.stories.tsx
+++ b/src/widgets/search/ui/loading.stories.tsx
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import Loading from './loading';
+
+const meta: Meta<typeof Loading> = {
+  title: 'widgets/search/loading',
+  component: Loading,
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+
+export const Default: StoryObj<typeof Loading> = {
+  render: () => <Loading />,
+};

--- a/src/widgets/search/ui/loading.tsx
+++ b/src/widgets/search/ui/loading.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { domAnimation, LazyMotion, Variants } from 'framer-motion';
+import * as m from 'framer-motion/m';
+
+function Loading() {
+  const containerVariants: Variants = {
+    jump: {
+      transition: {
+        staggerChildren: 0.2,
+        staggerDirection: -1,
+      },
+    },
+  };
+
+  const dotVariants: Variants = {
+    jump: {
+      y: -10,
+      transition: {
+        duration: 0.8,
+        repeat: Infinity,
+        repeatType: 'mirror',
+        ease: 'easeInOut',
+      },
+    },
+  };
+
+  return (
+    <LazyMotion features={domAnimation}>
+      <m.div
+        animate="jump"
+        variants={containerVariants}
+        className="flex items-center justify-center gap-[10px]"
+      >
+        <m.div
+          className="bg-sosoeat-orange-400 size-3 rounded-full [will-change:transform]"
+          variants={dotVariants}
+        />
+        <m.div
+          className="bg-sosoeat-orange-400 size-3 rounded-full [will-change:transform]"
+          variants={dotVariants}
+        />
+        <m.div
+          className="bg-sosoeat-orange-400 size-3 rounded-full [will-change:transform]"
+          variants={dotVariants}
+        />
+      </m.div>
+    </LazyMotion>
+  );
+}
+
+export default Loading;

--- a/src/widgets/search/ui/loading.tsx
+++ b/src/widgets/search/ui/loading.tsx
@@ -8,7 +8,7 @@ function Loading() {
     jump: {
       transition: {
         staggerChildren: 0.2,
-        staggerDirection: -1,
+        staggerDirection: 1,
       },
     },
   };

--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -14,6 +14,7 @@ import {
 
 import useSearchPage from '../../model/use-search-page';
 import { EmptyPage } from '../empty-page';
+import Loading from '../loading';
 import { MeetingFilterBar } from '../meeting-filter-bar';
 import { SearchBar } from '../search-bar';
 
@@ -107,9 +108,7 @@ export default function SearchPage({
           </div>
         )}
         {isFetching ? (
-          <span className="text-sosoeat-gray-600 col-span-full flex justify-center">
-            Loading...
-          </span>
+          <Loading />
         ) : inView && hasNextPage ? (
           <SearchSkeleton />
         ) : (

--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -47,7 +47,6 @@ export default function SearchPage({
     isLoading,
     isError,
     hasNextPage,
-    isFetching,
     isFetchingNextPage,
     fetchNextPage,
     inputValue,
@@ -107,7 +106,7 @@ export default function SearchPage({
             <div ref={ref} className="col-span-full flex h-1 items-center justify-center" />
           </div>
         )}
-        {isFetching ? (
+        {isFetchingNextPage ? (
           <Loading />
         ) : inView && hasNextPage ? (
           <SearchSkeleton />


### PR DESCRIPTION
## PR 제목: [Style]: search 페이지 로딩 중 텍스트를 framer-motion 바운싱 애니메이션으로 교체

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

closes #403

- `isFetching` 상태(무한 스크롤 페이지 추가 로딩 시) 단순 `"Loading..."` 텍스트를 framer-motion 기반 바운싱 도트 애니메이션(`<Loading />`)으로 교체했습니다.
- `src/widgets/search/ui/loading.tsx` 신규 컴포넌트를 생성했습니다. `LazyMotion + domAnimation + m.*` 패턴을 사용하고, `sosoeat-orange-400` 색상의 도트 3개가 순차적으로 튀어 오르는 애니메이션입니다.
- `isSearchPending` 로직 버그를 함께 수정했습니다. 기존에는 `inputValue !== searchQuery` 조건이어서 검색어를 지울 때도 스켈레톤이 나타나는 문제가 있었습니다. `searchQuery !== '' && inputValue === ''` 로 변경하여 검색어가 있을 때만 스켈레톤이 표시되도록 했습니다.
- Storybook 스토리(`loading.stories.tsx`)를 함께 추가했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로컬 개발 서버를 실행합니다 (`npm run dev`)
2. `/search` 페이지로 이동합니다
3. 검색 결과가 충분히 있는 키워드를 입력하고 스크롤을 내립니다
4. 무한 스크롤이 트리거될 때 하단에 오렌지색 도트 바운싱 애니메이션이 표시되는지 확인합니다
5. 검색어를 입력 후 전부 지웠을 때 스켈레톤이 나타나지 않는지 확인합니다

### 📸 스크린샷 또는 영상 (Optional)

(UI/UX 변경 사항이 있을 경우, 변경 전/후 스크린샷이나 동작 영상 첨부)

| 변경 후 (After) |
<img width="105" height="64" alt="{17634586-5964-4445-AFA8-72EA9BD60020}" src="https://github.com/user-attachments/assets/b27876d8-cdc7-4673-a955-b1b4d5bc4645" />

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**