### PR TITLE
[Fix]: 마이페이지 진입 시 하트 비활성화 버그

### DIFF
--- a/src/features/favorites/model/favorites.mutations.ts
+++ b/src/features/favorites/model/favorites.mutations.ts
@@ -52,6 +52,15 @@ export const useFavoriteMeeting = (initialIsFavorited: boolean, meetingId: numbe
   const committedRef = useRef(initialIsFavorited);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPendingRef = useRef(false);
+  const hasUserInteractedRef = useRef(false);
+
+  // 사용자가 아직 상호작용하지 않은 상태에서 initialIsFavorited가 변경되면 캐시를 동기화
+  useEffect(() => {
+    if (!hasUserInteractedRef.current) {
+      queryClient.setQueryData(favoriteKeys.status(meetingId), initialIsFavorited);
+      committedRef.current = initialIsFavorited;
+    }
+  }, [initialIsFavorited, meetingId, queryClient]);
 
   const sendRequest = (targetState: boolean) => {
     isPendingRef.current = true;
@@ -82,6 +91,7 @@ export const useFavoriteMeeting = (initialIsFavorited: boolean, meetingId: numbe
       return;
     }
 
+    hasUserInteractedRef.current = true;
     const nextLocalState = !queryClient.getQueryData<boolean>(favoriteKeys.status(meetingId));
     queryClient.setQueryData(favoriteKeys.status(meetingId), nextLocalState);
 

--- a/src/features/favorites/model/favorites.mutations.ts
+++ b/src/features/favorites/model/favorites.mutations.ts
@@ -54,6 +54,12 @@ export const useFavoriteMeeting = (initialIsFavorited: boolean, meetingId: numbe
   const isPendingRef = useRef(false);
   const hasUserInteractedRef = useRef(false);
 
+  // meetingId가 변경되면 상호작용 상태를 초기화 (컴포넌트 재사용 대응)
+  useEffect(() => {
+    hasUserInteractedRef.current = false;
+    committedRef.current = initialIsFavorited;
+  }, [meetingId]);
+
   // 사용자가 아직 상호작용하지 않은 상태에서 initialIsFavorited가 변경되면 캐시를 동기화
   useEffect(() => {
     if (!hasUserInteractedRef.current) {


### PR DESCRIPTION
## [Fix]: 마이페이지 진입 시 하트 비활성화 버그

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- 마이페이지 첫 진입 시 "나의 모임" 탭 하트 버튼이 비활성화되는 버그를 수정했습니다.
- useFavoriteMeeting에 hasUserInteractedRef 추가하여 사용자가 하트를 누르기 전이라면 늦게 도착한 favoriteQuery 값으로 캐시를 동기화하도록 변경하였습니다.

### 🧪 테스트 방법 (How to Test)

1. npm run dev 후 서버 최초 실행 상태에서 /mypage 진입합니다.
2. "나의 모임" 탭에서 찜한 모임의 하트가 즉시 활성화되는지 확인합니다.
3. 하트 클릭 시 낙관적 UI(즉시 토글)가 정상 동작하는지 확인합니다.
