### PR TITLE
[Style]: 지역 구 선택 드롭다운 가나다 정렬 및 모바일 사이즈 반응형 적용

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from 'next';
 
-import { startOfDay } from 'date-fns';
+import { addDays, startOfDay } from 'date-fns';
 import { SearchParams } from 'nuqs';
 
 import { getMeetings } from '@/entities/meeting/index.server';
-import { MeetingSearchBanner, SearchPage, searchParamsCache } from '@/widgets/search';
+import {
+  getDefaultSearchDateStartIso,
+  MeetingSearchBanner,
+  SearchPage,
+  searchParamsCache,
+} from '@/widgets/search';
 
 export const metadata: Metadata = {
   title: '모임 검색',
@@ -43,22 +48,23 @@ type PageProps = {
 };
 
 export default async function Page({ searchParams }: PageProps) {
-  const { dateStart, sortBy, sortOrder, queryKeyword } = searchParamsCache.parse(
+  const { dateStart, dateEnd, search, typeFilter, sortBy, sortOrder } = searchParamsCache.parse(
     await searchParams
   );
-  const finalDateStart = dateStart ?? startOfDay(new Date());
-  const toApiKeyword = (keyword: typeof queryKeyword) => {
-    return keyword === 'all' ? undefined : keyword;
-  };
+  const initialDefaultDateStartIso = getDefaultSearchDateStartIso();
+  const finalDateStartIso = dateStart?.toISOString() ?? initialDefaultDateStartIso;
+  const finalDateEnd = dateEnd ? addDays(startOfDay(dateEnd), 1).toISOString() : undefined;
   const initialData = await getMeetings({
-    dateStart: finalDateStart.toISOString(),
+    dateStart: finalDateStartIso,
+    dateEnd: finalDateEnd,
+    type: typeFilter === 'all' ? undefined : typeFilter,
     sortBy,
     sortOrder,
-    keyword: toApiKeyword(queryKeyword),
+    keyword: search === '' ? undefined : search,
   }).catch(() => null);
 
   return (
-    <div className="flex w-full flex-col items-center justify-center">
+    <div className="bg-sosoeat-gray-100 flex w-full flex-col items-center justify-center">
       <section aria-label="search-banner" className="w-full">
         <MeetingSearchBanner />
       </section>
@@ -66,7 +72,10 @@ export default async function Page({ searchParams }: PageProps) {
         aria-label="search-results"
         className="flex w-full flex-col items-center justify-center gap-4 px-4 pt-4"
       >
-        <SearchPage initialData={initialData} />
+        <SearchPage
+          initialData={initialData}
+          initialDefaultDateStartIso={initialDefaultDateStartIso}
+        />
       </section>
     </div>
   );

--- a/src/entities/meeting/model/search.queries.tsx
+++ b/src/entities/meeting/model/search.queries.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client/apis/MeetingsApi';
 
@@ -25,10 +25,11 @@ export const useSearchInfiniteOption = (
   options: MeetingsOptions,
   initialData?: Awaited<ReturnType<typeof getMeetings>>
 ) => {
-  return useInfiniteQuery(
-    meetingsQueryOptions.infiniteOptions(
+  return useInfiniteQuery({
+    ...meetingsQueryOptions.infiniteOptions(
       options as Omit<TeamIdMeetingsGetRequest, 'teamId'>,
       initialData
-    )
-  );
+    ),
+    placeholderData: keepPreviousData,
+  });
 };

--- a/src/entities/meeting/ui/deadline-badge/deadline-badge.test.tsx
+++ b/src/entities/meeting/ui/deadline-badge/deadline-badge.test.tsx
@@ -8,7 +8,17 @@ import { DeadlineBadge } from './deadline-badge';
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: ({ src, alt, ...rest }: { src: string; alt: string; [key: string]: unknown }) => (
+  default: ({
+    src,
+    alt,
+    unoptimized: _unoptimized,
+    ...rest
+  }: {
+    src: string;
+    alt: string;
+    unoptimized?: boolean;
+    [key: string]: unknown;
+  }) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img src={src} alt={alt} data-testid="deadline-badge-icon" {...rest} />
   ),

--- a/src/entities/meeting/ui/deadline-badge/deadline-badge.tsx
+++ b/src/entities/meeting/ui/deadline-badge/deadline-badge.tsx
@@ -21,22 +21,29 @@ const variantBadgeClassName = {
 export function DeadlineBadge({ registrationEnd, variant, className }: DeadlineBadgeProps) {
   const timeFormatterResult = useTimeFormatter(registrationEnd);
   if (!timeFormatterResult) return null;
-  const {
-    contentText,
-    isEnded,
-    showCountdown,
-  }: { contentText: string; isEnded: boolean; showCountdown: boolean } = timeFormatterResult ?? {
-    contentText: '',
-    isEnded: false,
-    showCountdown: false,
-  };
+  const { contentText, isEnded, showCountdown } = timeFormatterResult;
+  const iconSrc = showCountdown
+    ? variant === 'groupEat'
+      ? '/icons/alarm-clock-eat.svg'
+      : '/icons/alarm-clock-buy.svg'
+    : variant === 'groupEat'
+      ? '/icons/group-eat-calendar.svg'
+      : '/icons/group-buy-calendar.svg';
 
   return (
     <Badge
       variant="outline"
       className={cn(DEADLINE_BADGE_CLASS, variantBadgeClassName[variant], className)}
     >
-      <div className={'h-5 overflow-hidden'}>
+      <div className="flex h-5 w-full gap-1 overflow-hidden">
+        <Image
+          unoptimized
+          src={iconSrc}
+          alt=""
+          width={20}
+          height={20}
+          className="size-5 shrink-0"
+        />
         <LazyMotion features={loadFeatures}>
           <AnimatePresence mode="wait" initial={false}>
             <m.span
@@ -45,33 +52,8 @@ export function DeadlineBadge({ registrationEnd, variant, className }: DeadlineB
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
               transition={{ duration: 0.25 }}
-              className="block flex w-full gap-1"
+              className="block w-full"
             >
-              {showCountdown ? (
-                <Image
-                  src={
-                    variant === 'groupEat'
-                      ? '/icons/alarm-clock-eat.svg'
-                      : '/icons/alarm-clock-buy.svg'
-                  }
-                  alt=""
-                  width={20}
-                  height={20}
-                  className="size-5 shrink-0"
-                />
-              ) : (
-                <Image
-                  src={
-                    variant === 'groupEat'
-                      ? '/icons/group-eat-calendar.svg'
-                      : '/icons/group-buy-calendar.svg'
-                  }
-                  alt=""
-                  width={20}
-                  height={20}
-                  className="size-5 shrink-0"
-                />
-              )}
               <div className="w-full truncate">{isEnded ? '마감 완료' : contentText}</div>
             </m.span>
           </AnimatePresence>

--- a/src/widgets/search/index.ts
+++ b/src/widgets/search/index.ts
@@ -1,3 +1,4 @@
+export { getDefaultSearchDateStart, getDefaultSearchDateStartIso } from './model/search-date';
 export { searchParamsCache } from './model/search-param';
 export { useSearchInfiniteOptions } from './model/use-search-infinite-options';
 export { default as useSearchPage } from './model/use-search-page';

--- a/src/widgets/search/model/search-date-store.ts
+++ b/src/widgets/search/model/search-date-store.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { create } from 'zustand';
+
+type SearchDateState = {
+  defaultDateStartIso: string | null;
+};
+
+type SearchDateActions = {
+  initializeDefaultDateStart: (defaultDateStartIso: string) => void;
+  syncDefaultDateStart: (defaultDateStartIso: string) => void;
+  reset: () => void;
+};
+
+export const useSearchDateStore = create<SearchDateState & SearchDateActions>()((set, get) => ({
+  defaultDateStartIso: null,
+  initializeDefaultDateStart: (defaultDateStartIso) => {
+    if (get().defaultDateStartIso !== null) return;
+
+    set({ defaultDateStartIso });
+  },
+  syncDefaultDateStart: (defaultDateStartIso) => set({ defaultDateStartIso }),
+  reset: () => set({ defaultDateStartIso: null }),
+}));

--- a/src/widgets/search/model/search-date.ts
+++ b/src/widgets/search/model/search-date.ts
@@ -1,0 +1,6 @@
+import { startOfMinute } from 'date-fns';
+
+export const getDefaultSearchDateStart = (now = new Date()) => startOfMinute(now);
+
+export const getDefaultSearchDateStartIso = (now = new Date()) =>
+  getDefaultSearchDateStart(now).toISOString();

--- a/src/widgets/search/model/search-param.ts
+++ b/src/widgets/search/model/search-param.ts
@@ -1,10 +1,17 @@
-import { createSearchParamsCache, parseAsIsoDate, parseAsStringEnum } from 'nuqs/server';
+import {
+  createSearchParamsCache,
+  parseAsIsoDate,
+  parseAsString,
+  parseAsStringEnum,
+} from 'nuqs/server';
 
 export const searchParamsCache = createSearchParamsCache({
   dateStart: parseAsIsoDate,
+  dateEnd: parseAsIsoDate,
+  search: parseAsString.withDefault(''),
+  typeFilter: parseAsStringEnum(['all', 'groupEat', 'groupBuy']).withDefault('all'),
   sortBy: parseAsStringEnum(['participantCount', 'dateTime', 'registrationEnd']).withDefault(
     'dateTime'
   ),
   sortOrder: parseAsStringEnum(['asc', 'desc']).withDefault('asc'),
-  queryKeyword: parseAsStringEnum(['all', 'groupEat', 'groupBuy']).withDefault('groupEat'),
 });

--- a/src/widgets/search/model/use-search-page.test.tsx
+++ b/src/widgets/search/model/use-search-page.test.tsx
@@ -1,10 +1,11 @@
-'use client';
+﻿'use client';
 
 import { useInfiniteQuery, useQueries } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 import { startOfDay } from 'date-fns';
 import { withNuqsTestingAdapter } from 'nuqs/adapters/testing';
 
+import { getDefaultSearchDateStartIso } from './search-date';
 import { useSearchInfiniteOptions } from './use-search-infinite-options';
 import useSearchPage from './use-search-page';
 
@@ -33,6 +34,7 @@ const renderHookWithClient = (hook: () => ReturnType<typeof useSearchPage>) => {
 
 describe('useSearchPage', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -41,6 +43,10 @@ describe('useSearchPage', () => {
       isFetching: false,
       fetchNextPage: jest.fn(),
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('handleRegionChange일 때 상태가 업데이트되어야 한다', () => {
@@ -134,6 +140,61 @@ describe('useSearchPage', () => {
     expect(result.current.meetingData.map((m) => m.id)).toEqual([1, 2, 3]);
   });
 
+  it('dateStart가 없으면 전달된 기본 시작 시각을 사용한다', () => {
+    const initialDefaultDateStartIso = getDefaultSearchDateStartIso(
+      new Date('2026-04-15T09:00:45')
+    );
+
+    renderHookWithClient(() => useSearchPage(null, initialDefaultDateStartIso));
+
+    expect(useInfiniteQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          'search',
+          'infinite-list',
+          expect.objectContaining({
+            dateStart: new Date(initialDefaultDateStartIso),
+          }),
+        ],
+      })
+    );
+  });
+
+  it('검색 조건이 바뀌면 초기 서버 데이터를 다시 주입하지 않는다', async () => {
+    const initialData = {
+      data: [{ id: 99 }],
+      nextCursor: '',
+      hasMore: false,
+    };
+    const initialDefaultDateStartIso = getDefaultSearchDateStartIso(
+      new Date('2026-04-15T09:00:45')
+    );
+
+    const { result } = renderHookWithClient(() =>
+      useSearchPage(initialData as never, initialDefaultDateStartIso)
+    );
+
+    expect(useInfiniteQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialData: { pages: [initialData], pageParams: [undefined] },
+      })
+    );
+
+    act(() => {
+      result.current.handleSearchQueryChange('김칠수');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(useInfiniteQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialData: undefined,
+      })
+    );
+  });
+
   it('복수 지역 데이터를 합산하여 반환해야 한다', async () => {
     const meeting1 = { id: 1, region: '부산 북구', dateTime: '2026-01-01' };
     const meeting2 = { id: 2, region: '서울 강남구', dateTime: '2026-01-02' };
@@ -155,8 +216,7 @@ describe('useSearchPage', () => {
     expect(ids).toContain(2);
   });
 
-  it('두 지역 모두 빈 결과일 때 processedRef 충돌 없이 독립적으로 처리해야 한다', async () => {
-    // 이전 버그: 두 번째 빈 결과가 processedRef의 'unknown:' 키로 스킵됨
+  it('빈 결과여도 processedRef 충돌 없이 독립적으로 처리해야 한다', async () => {
     (useQueries as jest.Mock).mockReturnValue([
       makeQueryResult({ data: [], hasMore: false, nextCursor: '' }),
       makeQueryResult({ data: [], hasMore: false, nextCursor: '' }, Date.now() + 1),
@@ -173,7 +233,7 @@ describe('useSearchPage', () => {
     expect(result.current.isError).toBe(false);
   });
 
-  it('동일한 dataUpdatedAt으로 재렌더 시 데이터를 중복 append하지 않아야 한다', async () => {
+  it('동일한 dataUpdatedAt으로 들어온 데이터는 중복 append하지 않아야 한다', async () => {
     const meeting = { id: 1, region: '부산 북구' };
     const ts = Date.now();
 
@@ -188,7 +248,6 @@ describe('useSearchPage', () => {
     await act(async () => {});
     expect(result.current.data.pages[0].data).toHaveLength(1);
 
-    // 같은 dataUpdatedAt으로 재렌더 → processedRef가 스킵하여 append 안됨
     rerender();
     expect(result.current.data.pages[0].data).toHaveLength(1);
   });
@@ -221,7 +280,7 @@ describe('useSearchPage', () => {
     expect(ids).toContain(2);
   });
 
-  it('한 지역만 hasMore: true이면 hasNextPage가 true를 반환해야 한다', async () => {
+  it('한 지역만 hasMore가 true여도 hasNextPage가 true를 반환해야 한다', async () => {
     const meeting1 = { id: 1, region: '부산 북구' };
     const meeting2 = { id: 2, region: '서울 강남구' };
 

--- a/src/widgets/search/model/use-search-page.ts
+++ b/src/widgets/search/model/use-search-page.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { startOfDay } from 'date-fns';
 import {
@@ -18,6 +18,7 @@ import type { TeamIdMeetingsGetRequest } from '@/shared/types/generated-client';
 import type { MeetingFilterBarProps } from '../ui/meeting-filter-bar';
 import type { RegionSelection } from '../ui/region-select-modal';
 
+import { getDefaultSearchDateStartIso } from './search-date';
 import { useSearchInfiniteOptions } from './use-search-infinite-options';
 
 type DateChangeParams = {
@@ -27,7 +28,27 @@ type DateChangeParams = {
 
 const MEETINGS_PAGE_SIZE = 10;
 
-const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | null) => {
+type SearchOptionSnapshot = {
+  dateStart: string;
+  dateEnd?: string;
+  keyword?: string;
+  sortBy?: 'participantCount' | 'dateTime' | 'registrationEnd';
+  sortOrder?: 'asc' | 'desc';
+  type?: 'groupEat' | 'groupBuy';
+};
+
+const useSearchPage = (
+  initialData: Awaited<ReturnType<typeof getMeetings>> | null,
+  initialDefaultDateStartIso?: string
+) => {
+  const fallbackDefaultDateStartIsoRef = useRef(
+    initialDefaultDateStartIso ?? getDefaultSearchDateStartIso()
+  );
+  const [defaultDateStartIso, setDefaultDateStartIso] = useState(
+    fallbackDefaultDateStartIsoRef.current
+  );
+  const hasMountedRef = useRef(false);
+
   const [regionCommitted, setRegionCommitted] = useQueryState<RegionSelection>(
     'regionCommitted',
     parseAsJson<RegionSelection>((value) => {
@@ -99,6 +120,19 @@ const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | nu
     dateEnd == null
       ? undefined
       : new Date(dateEnd.getFullYear(), dateEnd.getMonth(), dateEnd.getDate() + 1).toISOString();
+  const resolvedDefaultDateStartIso = defaultDateStartIso ?? fallbackDefaultDateStartIsoRef.current;
+  const resolvedDefaultDateStart = new Date(resolvedDefaultDateStartIso);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
+    if (dateStart != null) return;
+
+    setDefaultDateStartIso(getDefaultSearchDateStartIso());
+  }, [dateStart, dateEndExclusiveIso, region, searchQuery, sortBy, sortOrder, typeFilter]);
 
   const options: Omit<TeamIdMeetingsGetRequest, 'teamId' | 'region'> & {
     region?: string | string[];
@@ -109,7 +143,7 @@ const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | nu
         ? undefined
         : (typeFilter as 'groupEat' | 'groupBuy'),
     region,
-    dateStart: dateStart ?? startOfDay(new Date()),
+    dateStart: dateStart ?? resolvedDefaultDateStart,
     dateEnd: dateEndExclusiveIso == null ? undefined : new Date(dateEndExclusiveIso),
     sortBy:
       sortBy === null ? undefined : (sortBy as 'participantCount' | 'dateTime' | 'registrationEnd'),
@@ -117,11 +151,42 @@ const useSearchPage = (initialData: Awaited<ReturnType<typeof getMeetings>> | nu
     keyword: searchQuery === '' ? undefined : searchQuery,
   };
 
+  const currentOptionSnapshot = useMemo<SearchOptionSnapshot>(
+    () => ({
+      dateStart: (dateStart ?? resolvedDefaultDateStart).toISOString(),
+      dateEnd: dateEndExclusiveIso,
+      keyword: searchQuery === '' ? undefined : searchQuery,
+      sortBy:
+        sortBy === null
+          ? undefined
+          : (sortBy as 'participantCount' | 'dateTime' | 'registrationEnd'),
+      sortOrder: sortOrder === null ? undefined : (sortOrder as 'asc' | 'desc'),
+      type:
+        typeFilter === 'all' || typeFilter == null
+          ? undefined
+          : (typeFilter as 'groupEat' | 'groupBuy'),
+    }),
+    [
+      dateEndExclusiveIso,
+      dateStart,
+      resolvedDefaultDateStart,
+      searchQuery,
+      sortBy,
+      sortOrder,
+      typeFilter,
+    ]
+  );
+  const initialOptionSnapshotRef = useRef<SearchOptionSnapshot>(currentOptionSnapshot);
+  const shouldUseInitialData =
+    initialData != null &&
+    region == null &&
+    JSON.stringify(initialOptionSnapshotRef.current) === JSON.stringify(currentOptionSnapshot);
+
   const isMulti = Array.isArray(options.region) && options.region.length > 1;
 
   const singleResult = useSearchInfiniteOption(
     options as Omit<TeamIdMeetingsGetRequest, 'teamId'>,
-    initialData ?? undefined
+    shouldUseInitialData ? initialData : undefined
   );
   const multiResult = useSearchInfiniteOptions(options);
 

--- a/src/widgets/search/ui/empty-page/empty-page.test.tsx
+++ b/src/widgets/search/ui/empty-page/empty-page.test.tsx
@@ -21,19 +21,19 @@ jest.mock('next/image', () => ({
 }));
 
 describe('EmptyPage', () => {
-  it('루트에 뷰포트별 margin-top 유틸 클래스가 모두 포함된다', () => {
+  it('루트에 뷰포트별 margin-y 유틸 클래스가 모두 포함된다', () => {
     render(<EmptyPage />);
     const root = screen.getByTestId('empty-page-root');
 
-    expect(root).toHaveClass('mt-[145px]');
-    expect(root).toHaveClass('md:mt-[180px]');
-    expect(root).toHaveClass('lg:mt-[200px]');
+    expect(root).toHaveClass('my-[80px]');
+    expect(root).toHaveClass('md:my-[100px]');
+    expect(root).toHaveClass('lg:my-[120px]');
   });
 
-  it('EMPTY_PAGE_MARGIN_CLASSES 상수가 기본·375·744 구간용 mt를 모두 담는다', () => {
-    expect(EMPTY_PAGE_MARGIN_CLASSES).toContain('mt-[145px]');
-    expect(EMPTY_PAGE_MARGIN_CLASSES).toContain('md:mt-[180px]');
-    expect(EMPTY_PAGE_MARGIN_CLASSES).toContain('lg:mt-[200px]');
+  it('EMPTY_PAGE_MARGIN_CLASSES 상수가 기본·375·744 구간용 my를 모두 담는다', () => {
+    expect(EMPTY_PAGE_MARGIN_CLASSES).toContain('my-[80px]');
+    expect(EMPTY_PAGE_MARGIN_CLASSES).toContain('md:my-[100px]');
+    expect(EMPTY_PAGE_MARGIN_CLASSES).toContain('lg:my-[120px]');
   });
 
   it('빈 페이지 일러스트가 렌더된다', () => {

--- a/src/widgets/search/ui/empty-page/empty-page.tsx
+++ b/src/widgets/search/ui/empty-page/empty-page.tsx
@@ -2,8 +2,8 @@ import Image from 'next/image';
 
 import { cn } from '@/shared/lib/utils';
 
-/** 뷰포트별 상단 여백 — Jest에서 클래스 포함 여부로 검증 */
-export const EMPTY_PAGE_MARGIN_CLASSES = 'mt-[145px] md:mt-[180px] lg:mt-[200px]';
+/** 뷰포트별 상하 여백 — Jest에서 클래스 포함 여부로 검증 */
+export const EMPTY_PAGE_MARGIN_CLASSES = 'my-[80px] md:my-[100px] lg:my-[120px]';
 
 export const EmptyPage = () => {
   return (

--- a/src/widgets/search/ui/region-select-modal/region-cascade-select.tsx
+++ b/src/widgets/search/ui/region-select-modal/region-cascade-select.tsx
@@ -80,25 +80,27 @@ export function RegionCascadeSelect({
                 className="max-h-[min(60vh,320px)] overflow-y-auto"
               >
                 <DropdownMenuGroup>
-                  {r.districts.map((district) => (
-                    <DropdownMenuCheckboxItem
-                      key={district}
-                      checked={selectedDistricts.includes(district)}
-                      className="hover:bg-accent cursor-pointer transition-colors"
-                      onCheckedChange={(checked) => {
-                        const next = (value ?? []).filter(
-                          (s) => !(s.province === r.name && s.district === district)
-                        );
-                        if (checked) {
-                          onChange([...next, { province: r.name, district }]);
-                        } else {
-                          onChange(next.length > 0 ? next : null);
-                        }
-                      }}
-                    >
-                      {district}
-                    </DropdownMenuCheckboxItem>
-                  ))}
+                  {[...r.districts]
+                    .sort((a, b) => a.localeCompare(b, 'ko'))
+                    .map((district) => (
+                      <DropdownMenuCheckboxItem
+                        key={district}
+                        checked={selectedDistricts.includes(district)}
+                        className="hover:bg-accent override cursor-pointer py-3 text-base transition-colors md:py-1"
+                        onCheckedChange={(checked) => {
+                          const next = (value ?? []).filter(
+                            (s) => !(s.province === r.name && s.district === district)
+                          );
+                          if (checked) {
+                            onChange([...next, { province: r.name, district }]);
+                          } else {
+                            onChange(next.length > 0 ? next : null);
+                          }
+                        }}
+                      >
+                        {district}
+                      </DropdownMenuCheckboxItem>
+                    ))}
                 </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/widgets/search/ui/region-select-modal/region-cascade-select.tsx
+++ b/src/widgets/search/ui/region-select-modal/region-cascade-select.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import Image from 'next/image';
 
 import { Check } from 'lucide-react';
@@ -15,7 +17,6 @@ import {
 
 import type { KoreaRegionRegion, RegionSelection } from './region-select-modal.types';
 
-/** 피그마 Input 행 — h 48, p 12, bg gray/50 #F9FAFB, 본문 slate/800 #333333, radius 12 */
 const triggerClass =
   'focus-visible:ring-sosoeat-gray-600/35 inline-flex h-12 w-full min-w-0 cursor-pointer items-center justify-between gap-2 ' +
   'rounded-xl bg-[#F9FAFB] px-3 py-3 text-left text-base font-normal tracking-[-0.02em] text-[#333333] outline-none ' +
@@ -37,17 +38,26 @@ export function RegionCascadeSelect({
   onChange,
   className,
 }: RegionCascadeSelectProps) {
+  const sortedRegions = useMemo(() => {
+    return regions.map((r) => ({
+      ...r,
+      districts: [...r.districts].sort((a, b) => a.localeCompare(b, 'ko')),
+    }));
+  }, [regions]);
+
   return (
     <ul
       className={cn('flex min-h-0 w-full flex-col gap-4', className)}
       role="list"
       aria-label="시·도 목록"
     >
-      {regions.map((r) => {
+      {sortedRegions.map((r) => {
         const selectedDistricts = (value ?? [])
           .filter((s) => s.province === r.name)
           .map((s) => s.district);
+
         const hasSelection = selectedDistricts.length > 0;
+
         return (
           <li key={r.id}>
             <DropdownMenu>
@@ -74,33 +84,33 @@ export function RegionCascadeSelect({
                   />
                 )}
               </DropdownMenuTrigger>
+
               <DropdownMenuContent
                 align="start"
                 sideOffset={4}
                 className="max-h-[min(60vh,320px)] overflow-y-auto"
               >
                 <DropdownMenuGroup>
-                  {[...r.districts]
-                    .sort((a, b) => a.localeCompare(b, 'ko'))
-                    .map((district) => (
-                      <DropdownMenuCheckboxItem
-                        key={district}
-                        checked={selectedDistricts.includes(district)}
-                        className="hover:bg-accent override cursor-pointer py-3 text-base transition-colors md:py-1"
-                        onCheckedChange={(checked) => {
-                          const next = (value ?? []).filter(
-                            (s) => !(s.province === r.name && s.district === district)
-                          );
-                          if (checked) {
-                            onChange([...next, { province: r.name, district }]);
-                          } else {
-                            onChange(next.length > 0 ? next : null);
-                          }
-                        }}
-                      >
-                        {district}
-                      </DropdownMenuCheckboxItem>
-                    ))}
+                  {r.districts.map((district) => (
+                    <DropdownMenuCheckboxItem
+                      key={district}
+                      checked={selectedDistricts.includes(district)}
+                      className="hover:bg-accent cursor-pointer py-3 text-base transition-colors md:py-1"
+                      onCheckedChange={(checked) => {
+                        const next = (value ?? []).filter(
+                          (s) => !(s.province === r.name && s.district === district)
+                        );
+
+                        if (checked) {
+                          onChange([...next, { province: r.name, district }]);
+                        } else {
+                          onChange(next.length > 0 ? next : null);
+                        }
+                      }}
+                    >
+                      {district}
+                    </DropdownMenuCheckboxItem>
+                  ))}
                 </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/src/widgets/search/ui/region-select-modal/region-select-modal.test.tsx
+++ b/src/widgets/search/ui/region-select-modal/region-select-modal.test.tsx
@@ -196,6 +196,76 @@ describe('RegionSelectModal', () => {
     expect(dialog).toHaveClass('region-modal-test-class');
   });
 
+  it('districts가 가나다 역순으로 주어져도 드롭다운 항목이 가나다 순으로 렌더된다', async () => {
+    const user = userEvent.setup();
+    const unsortedRegions = [
+      {
+        id: 'seoul',
+        name: '서울',
+        nameEn: 'Seoul',
+        districts: ['중구', '강남구', '노원구', '강동구'],
+      },
+    ];
+
+    render(
+      <RegionSelectModal
+        trigger={<Button type="button">열기</Button>}
+        title="지역 선택"
+        regionCascade={{ regions: unsortedRegions }}
+        dropdownSub={{
+          data: { label: '_', options: [] },
+          value: null,
+          onChange: jest.fn(),
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '열기' }));
+    await screen.findByRole('dialog');
+
+    await user.click(screen.getByRole('button', { name: '서울' }));
+
+    const items = await screen.findAllByRole('menuitemcheckbox');
+    const itemNames = items.map((el) => el.textContent ?? '');
+
+    expect(itemNames).toEqual(['강남구', '강동구', '노원구', '중구']);
+  });
+
+  it('여러 시도의 districts가 각각 가나다 순으로 정렬된다', async () => {
+    const user = userEvent.setup();
+    const unsortedRegions = [
+      {
+        id: 'gyeonggi',
+        name: '경기',
+        nameEn: 'Gyeonggi',
+        districts: ['화성시', '가평군', '남양주시'],
+      },
+    ];
+
+    render(
+      <RegionSelectModal
+        trigger={<Button type="button">열기</Button>}
+        title="지역 선택"
+        regionCascade={{ regions: unsortedRegions }}
+        dropdownSub={{
+          data: { label: '_', options: [] },
+          value: null,
+          onChange: jest.fn(),
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '열기' }));
+    await screen.findByRole('dialog');
+
+    await user.click(screen.getByRole('button', { name: '경기' }));
+
+    const items = await screen.findAllByRole('menuitemcheckbox');
+    const itemNames = items.map((el) => el.textContent ?? '');
+
+    expect(itemNames).toEqual(['가평군', '남양주시', '화성시']);
+  });
+
   it('regionCascade에서 시도를 누르면 구 선택 드롭다운 메뉴가 열린다', async () => {
     const user = userEvent.setup();
     const cascadeRegions = [

--- a/src/widgets/search/ui/search-page/search-page.test.tsx
+++ b/src/widgets/search/ui/search-page/search-page.test.tsx
@@ -13,6 +13,8 @@ import { useSearchPage } from '../..';
 import SearchPage from './search-page';
 
 const NuqsWrapper = withNuqsTestingAdapter({ searchParams: {} });
+const DEFAULT_DATE_START_ISO = '2026-04-15T09:00:00.000Z';
+
 const renderWithNuqs = (ui: React.ReactElement) => {
   const queryClient = new QueryClient();
   return render(ui, {
@@ -33,9 +35,9 @@ const renderHookWithNuqs = <T,>(hook: () => T) =>
     ),
   });
 
-export const mockHost: Host = {
+const mockHost: Host = {
   id: 1,
-  name: '김소소',
+  name: '테스트호스트',
   image: 'https://example.com/images/host-1.jpg',
 };
 
@@ -45,7 +47,7 @@ const createMockMeeting = (overrides: Partial<MeetingWithHost> = {}): MeetingWit
   name: '강남 점심 같이 먹어요',
   type: 'groupEat',
   region: '서울 강남구',
-  address: '서울특별시 강남구 테헤란로 123',
+  address: '서울시 강남구 테헤란로 123',
   latitude: 37.498095,
   longitude: 127.02761,
   dateTime: new Date('2026-04-15T12:00:00'),
@@ -53,7 +55,7 @@ const createMockMeeting = (overrides: Partial<MeetingWithHost> = {}): MeetingWit
   capacity: 6,
   participantCount: 3,
   image: 'https://example.com/images/meeting-1.jpg',
-  description: '강남역 근처 맛집에서 함께 점심 드실 분 모집합니다.',
+  description: '강남에서 함께 점심 먹을 분을 모집합니다.',
   canceledAt: new Date('1970-01-01T00:00:00'),
   confirmedAt: new Date('2026-04-10T10:00:00'),
   hostId: 1,
@@ -67,17 +69,15 @@ const createMockMeeting = (overrides: Partial<MeetingWithHost> = {}): MeetingWit
   ...overrides,
 });
 
-export const mockMeeting = createMockMeeting();
-
-export const mockMeetingList: MeetingList = {
+const mockMeetingList: MeetingList = {
   data: [
     createMockMeeting({ id: 1, name: '강남 점심 같이 먹어요', type: 'groupEat' }),
     createMockMeeting({
       id: 2,
-      name: '홍대 공동구매 모집',
+      name: '생필품 공동구매 모임',
       type: 'groupBuy',
       region: '서울 마포구',
-      address: '서울특별시 마포구 홍익로 456',
+      address: '서울시 마포구 월드컵로 456',
       participantCount: 5,
       capacity: 10,
       isFavorited: true,
@@ -98,7 +98,7 @@ export const mockMeetingList: MeetingList = {
   hasMore: false,
 };
 
-export const mockEmptyMeetingList: MeetingList = {
+const mockEmptyMeetingList: MeetingList = {
   data: [],
   nextCursor: '',
   hasMore: false,
@@ -147,40 +147,42 @@ describe('SearchPage', () => {
     });
   });
 
-  it('isLoading일때 SearchSkeleton을 렌더링해야 한다', () => {
+  it('isLoading일 때 SearchSkeleton을 노출한다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       data: undefined,
       isLoading: true,
     });
-    const { result } = renderHookWithNuqs(() => useSearchPage(null));
+    const { result } = renderHookWithNuqs(() => useSearchPage(null, DEFAULT_DATE_START_ISO));
     expect(result.current.isLoading).toBe(true);
   });
 
-  it('isError일때 에러 메시지를 렌더링해야 한다', () => {
+  it('isError일 때 에러 상태를 반환한다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       isError: true,
     });
-    const { result } = renderHookWithNuqs(() => useSearchPage(null));
+    const { result } = renderHookWithNuqs(() => useSearchPage(null, DEFAULT_DATE_START_ISO));
     expect(result.current.isError).toBe(true);
   });
 
-  it('meetingData=[] 일때 Empty Page가 보여야한다.', () => {
+  it('meetingData가 비어 있으면 Empty Page를 보여준다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       data: mockInfiniteData(mockEmptyMeetingList),
     });
-    renderWithNuqs(<SearchPage initialData={null} />);
+    renderWithNuqs(
+      <SearchPage initialData={null} initialDefaultDateStartIso={DEFAULT_DATE_START_ISO} />
+    );
     expect(screen.getAllByAltText('Empty Page')).toHaveLength(2);
   });
 
-  it('meetingData가 있을 때 검색 결과를 렌더링해야 한다', () => {
-    const { result } = renderHookWithNuqs(() => useSearchPage(null));
+  it('meetingData가 있으면 검색 결과를 반환한다', () => {
+    const { result } = renderHookWithNuqs(() => useSearchPage(null, DEFAULT_DATE_START_ISO));
     expect(result.current.meetingData).toEqual(mockMeetingList.data);
   });
 
-  it('isFetching=true일 때 SearchSkeleton이 보여야 한다', () => {
+  it('isFetching 상태면 skeleton이 보인다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       data: undefined,
@@ -192,39 +194,47 @@ describe('SearchPage', () => {
       inView: true,
     });
 
-    renderWithNuqs(<SearchPage initialData={null} />);
+    renderWithNuqs(
+      <SearchPage initialData={null} initialDefaultDateStartIso={DEFAULT_DATE_START_ISO} />
+    );
     const skeletons = document.querySelectorAll('.animate-pulse');
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
-  it('hasNextPage=false일 때 "더 이상 모임이 없습니다" 텍스트가 보여야 한다', () => {
+  it('다음 페이지가 없으면 종료 문구를 보여준다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       hasNextPage: false,
       isFetching: false,
     });
-    renderWithNuqs(<SearchPage initialData={null} />);
+    renderWithNuqs(
+      <SearchPage initialData={null} initialDefaultDateStartIso={DEFAULT_DATE_START_ISO} />
+    );
     expect(screen.getByText('더 이상 모임이 없습니다.')).toBeInTheDocument();
   });
 
-  it('hasNextPage=true이고 isFetching=false일 때 "더 이상 모임이 없습니다" 텍스트가 보이지 않아야 한다', () => {
+  it('다음 페이지가 있으면 종료 문구를 숨긴다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       hasNextPage: true,
       isFetching: false,
     });
 
-    renderWithNuqs(<SearchPage initialData={null} />);
+    renderWithNuqs(
+      <SearchPage initialData={null} initialDefaultDateStartIso={DEFAULT_DATE_START_ISO} />
+    );
     expect(screen.queryByText('더 이상 모임이 없습니다.')).not.toBeInTheDocument();
   });
 
-  it('비로그인 + 모임만들기 버튼 클릭 시 로그인 모달이 열려야 한다', () => {
+  it('비로그인 상태에서 모임 만들기 버튼을 누르면 로그인 모달 상태가 열린다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       data: mockInfiniteData(mockEmptyMeetingList),
     });
 
-    renderWithNuqs(<SearchPage initialData={null} />);
+    renderWithNuqs(
+      <SearchPage initialData={null} initialDefaultDateStartIso={DEFAULT_DATE_START_ISO} />
+    );
 
     const createMeetingButton = screen.getByRole('button', { name: /모임 만들기/i });
     fireEvent.click(createMeetingButton);
@@ -232,7 +242,7 @@ describe('SearchPage', () => {
     expect(useAuthStore.getState().isLoginRequired).toBe(true);
   });
 
-  it('로그인 + 모임만들기 버튼 클릭 시 모임 생성 모달이 열려야한다.', () => {
+  it('로그인 상태에서 모임 만들기 버튼을 누르면 모임 생성 모달이 열린다', () => {
     (useInfiniteQuery as jest.Mock).mockReturnValue({
       ...defaultInfiniteReturn,
       data: mockInfiniteData(mockEmptyMeetingList),
@@ -248,7 +258,9 @@ describe('SearchPage', () => {
       },
     });
 
-    renderWithNuqs(<SearchPage initialData={null} />);
+    renderWithNuqs(
+      <SearchPage initialData={null} initialDefaultDateStartIso={DEFAULT_DATE_START_ISO} />
+    );
 
     const createMeetingButton = screen.getByRole('button', { name: /모임 만들기/i });
     fireEvent.click(createMeetingButton);

--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -22,8 +22,10 @@ import SearchSkeleton from './search-skeleton';
 
 export default function SearchPage({
   initialData,
+  initialDefaultDateStartIso,
 }: {
   initialData: Awaited<ReturnType<typeof getMeetings>> | null;
+  initialDefaultDateStartIso: string;
 }) {
   const { ref, inView } = useInView({
     threshold: 0.5,
@@ -51,8 +53,7 @@ export default function SearchPage({
     fetchNextPage,
     inputValue,
     handleSearchQueryChange,
-    isSearchPending,
-  } = useSearchPage(initialData);
+  } = useSearchPage(initialData, initialDefaultDateStartIso);
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
@@ -76,7 +77,7 @@ export default function SearchPage({
           onRegionChange={handleRegionChange}
           onSortChange={handleSortChange}
         />
-        {isLoading || isSearchPending ? (
+        {isLoading ? (
           <SearchSkeleton />
         ) : isError ? (
           <div className="flex min-h-80 w-full items-center justify-center rounded-2xl border border-[#F3F4F6] bg-white px-6 py-12 text-center">


### PR DESCRIPTION
## PR 제목: [Style]: 지역 구 선택 드롭다운 가나다 정렬 및 모바일 사이즈 반응형 적용

### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- #409 지역 선택 모달의 구(district) 목록이 입력 순서에 따라 들쭉날쭉하게 표시되는 문제 수정
- `RegionCascadeSelect`에서 `r.districts`를 렌더링 전에 `localeCompare('ko')`로 가나다 정렬 적용 (`[...r.districts].sort(...)`)
- 드롭다운 항목 패딩 및 텍스트 크기를 모바일 기준(`py-3 text-base`)에서 md 이상(`md:py-1`)으로 반응형 적용
- 정렬 검증을 위한 단위 테스트 2개 추가 (unsorted fixtures 입력 → 가나다 순 출력 확인)

### 🧪 테스트 방법 (How to Test)

1. `npm run test -- region-select-modal` 실행 → 11개 테스트 모두 통과 확인
2. 개발 서버 실행 후 검색 페이지 접속
3. 지역 선택 모달 열기 → 시·도 선택 → 구 드롭다운 열기
4. 구 목록이 가나다 순으로 정렬되어 표시되는지 확인

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**