### PR TITLE
[Refactor]: 추천 모임 필터링을 클라이언트에서 백엔드로 이전

### DIFF
--- a/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
@@ -8,12 +8,11 @@ interface Props {
 
 export async function MeetingRecommendedFetcher({ meetingId }: Props) {
   const meeting = await getMeetingById(meetingId);
-  const meetingList = await getMeetings({ region: meeting.region, size: 4 }).catch(() => ({
-    data: [],
-  }));
+  const meetingList = await getMeetings({
+    region: meeting.region,
+    dateStart: new Date().toISOString(),
+    size: 5,
+  }).catch(() => ({ data: [] }));
 
-  const now = new Date();
-  const futureMeetings = meetingList.data.filter((m) => new Date(m.dateTime) > now);
-
-  return <MeetingRecommendedSection meetings={futureMeetings} currentMeetingId={meetingId} />;
+  return <MeetingRecommendedSection meetings={meetingList.data} currentMeetingId={meetingId} />;
 }

--- a/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
+++ b/src/app/meetings/[id]/_components/meeting-recommended-fetcher.tsx
@@ -6,11 +6,17 @@ interface Props {
   meetingId: number;
 }
 
+function getCurrentMinuteISOString() {
+  const now = new Date();
+  now.setSeconds(0, 0);
+  return now.toISOString();
+}
+
 export async function MeetingRecommendedFetcher({ meetingId }: Props) {
   const meeting = await getMeetingById(meetingId);
   const meetingList = await getMeetings({
     region: meeting.region,
-    dateStart: new Date().toISOString(),
+    dateStart: getCurrentMinuteISOString(),
     size: 5,
   }).catch(() => ({ data: [] }));
 

--- a/src/widgets/meeting-detail/ui/meeting-recommended-section/meeting-recommended-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-recommended-section/meeting-recommended-section.tsx
@@ -12,7 +12,7 @@ export function MeetingRecommendedSection({
   meetings,
   currentMeetingId,
 }: MeetingRecommendedSectionProps) {
-  const recommendedMeetings = meetings.filter((m) => m.id !== currentMeetingId);
+  const recommendedMeetings = meetings.filter((m) => m.id !== currentMeetingId).slice(0, 4);
 
   if (recommendedMeetings.length === 0) return null;
 


### PR DESCRIPTION
  ### 📌 유형 (Type)                                                                                                                                           
                                                                                                                                                               
  - [x] **Feat (기능):** 새로운 기능 추가                                                                                                                      
                                                                                                                                                               
  ### 📝 변경 사항 (Changes)                                                                                                                                   
                                                                                                                                                               
  - 추천 모임 목록을 불러올 때 클라이언트에서 지난 모임을 필터링하던 방식을 백엔드 `dateStart` 파라미터로 이전했습니다. (#367)                                 
  - `size: 4 → 5`로 변경하여 현재 모임 제외 후에도 최대 4개가 보장되도록 했습니다.                                                                             
  - `MeetingRecommendedSection`에 `.slice(0, 4)` 추가로 최대 노출 수를 제한했습니다.                                                                           
                                                                                                                                                               
  ### 🧪 테스트 방법 (How to Test)                                                                                                                             
                                                                                                                                                               
  1. 모임 상세 페이지(`/meetings/:id`)로 이동합니다.                                                                                                           
  2. 하단 "이런 모임은 어때요?" 섹션에서 지난 모임이 노출되지 않는지 확인합니다.
  3. 추천 모임이 최대 4개까지만 노출되는지 확인합니다.                                                                                                         
                                                                                                                                                               
  ### 📸 스크린샷 또는 영상 (Optional)                                                                                                                         
                                                                                                                                                               
  | 변경 전 (Before) | 변경 후 (After) |                                                                                                                       
  | :--------------: | :-------------: |
  |                  |                 |

  ### 🚨 기타 참고 사항 (Notes)

  - [ ] `React.cache`로 감싸진 `getMeetingById`를 재사용하므로 추가 네트워크 요청 없음                                                                         