### PR TITLE
[Feat]: 마이페이지 빈 탭 스크롤 방지

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -30,7 +30,7 @@ export default async function MyPage() {
   ]);
 
   return (
-    <div className="bg-sosoeat-gray-100 min-h-screen">
+    <div className="bg-sosoeat-gray-100 flex flex-1 flex-col overflow-y-auto">
       <div className="relative flex justify-center">
         <UserCard
           name={user?.name ?? ''}

--- a/src/widgets/mypage/ui/count-card/count-card.tsx
+++ b/src/widgets/mypage/ui/count-card/count-card.tsx
@@ -34,10 +34,14 @@ export function CountCard({ count, variant = 'meeting', className, href }: Count
   );
 
   if (href) {
-    return <Link href={href}>{card}</Link>;
+    return (
+      <Link href={href} className="max-w-85 min-w-0 flex-1">
+        {card}
+      </Link>
+    );
   }
 
-  return card;
+  return <div className="max-w-85 min-w-0 flex-1">{card}</div>;
 }
 
 export function FavoriteCountCard({ initialCount }: { initialCount: number }) {

--- a/src/widgets/mypage/ui/count-card/count-card.tsx
+++ b/src/widgets/mypage/ui/count-card/count-card.tsx
@@ -35,13 +35,13 @@ export function CountCard({ count, variant = 'meeting', className, href }: Count
 
   if (href) {
     return (
-      <Link href={href} className="max-w-85 min-w-0 flex-1">
+      <Link href={href} className="hidden max-w-85 min-w-0 flex-1 md:flex">
         {card}
       </Link>
     );
   }
 
-  return <div className="max-w-85 min-w-0 flex-1">{card}</div>;
+  return <div className="hidden max-w-85 min-w-0 flex-1 md:flex">{card}</div>;
 }
 
 export function FavoriteCountCard({ initialCount }: { initialCount: number }) {

--- a/src/widgets/mypage/ui/count-card/count-card.variants.ts
+++ b/src/widgets/mypage/ui/count-card/count-card.variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const cardVariants = cva(
-  'hidden md:flex flex-col gap-1 rounded-2xl text-center ring-0 h-20 w-85',
+  'hidden md:flex flex-col gap-1 rounded-2xl text-center ring-0 h-20 w-full',
   {
     variants: {
       variant: {

--- a/src/widgets/mypage/ui/count-card/count-card.variants.ts
+++ b/src/widgets/mypage/ui/count-card/count-card.variants.ts
@@ -1,20 +1,17 @@
 import { cva } from 'class-variance-authority';
 
-export const cardVariants = cva(
-  'hidden md:flex flex-col gap-1 rounded-2xl text-center ring-0 h-20 w-full',
-  {
-    variants: {
-      variant: {
-        meeting: 'bg-sosoeat-orange-100',
-        favorite: 'bg-[#FFF0F0]',
-        post: 'bg-sosoeat-blue-50',
-      },
+export const cardVariants = cva('flex flex-col gap-1 rounded-2xl text-center ring-0 h-20 w-full', {
+  variants: {
+    variant: {
+      meeting: 'bg-sosoeat-orange-100',
+      favorite: 'bg-[#FFF0F0]',
+      post: 'bg-sosoeat-blue-50',
     },
-    defaultVariants: {
-      variant: 'meeting',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: 'meeting',
+  },
+});
 
 export const countVariants = cva('text-base leading-6 font-black', {
   variants: {

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs-empty.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs-empty.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export function MeetingTabsEmpty() {
   return (
-    <div className="flex flex-col items-center justify-center py-40 max-sm:text-center">
+    <div className="flex flex-1 flex-col items-center justify-center max-sm:text-center">
       <div className="relative mb-4 h-[120px] w-[217px] opacity-50">
         <Image
           src="/images/empty-page.svg"

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
@@ -45,18 +45,14 @@ export function MeetingTabs() {
 
   return (
     <Tabs
-      className="mx-auto w-full max-w-285 p-6"
+      className="mx-auto flex w-full max-w-285 flex-1 flex-col p-6"
       value={activeTab}
       onValueChange={(v) => setActiveTab(v as TabValue)}
     >
       <MeetingTabsList />
 
       {MYPAGE_TABS.map((tab) => (
-        <TabsContent
-          key={tab.value}
-          value={tab.value}
-          className="w-full items-center justify-center"
-        >
+        <TabsContent key={tab.value} value={tab.value} className="flex w-full flex-1 flex-col">
           {isLoading ? (
             <div className="py-40 text-center text-sm text-gray-400">불러오는 중...</div>
           ) : cards.length === 0 ? (

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
@@ -54,7 +54,9 @@ export function MeetingTabs() {
       {MYPAGE_TABS.map((tab) => (
         <TabsContent key={tab.value} value={tab.value} className="flex w-full flex-1 flex-col">
           {isLoading ? (
-            <div className="py-40 text-center text-sm text-gray-400">불러오는 중...</div>
+            <div className="flex flex-1 items-center justify-center text-sm text-gray-400">
+              불러오는 중...
+            </div>
           ) : cards.length === 0 ? (
             <MeetingTabsEmpty />
           ) : (


### PR DESCRIPTION
## PR 제목: [Type]: 짧고 간결한 설명 (예: [Fix]: 로그인 버튼 버그 수정)

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [x] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

**마이페이지 빈 탭 스크롤 방지 및 푸터 고정**

- page.tsx 외부 래퍼를 flex-1 overflow-y-auto로 변경해 스크롤을 page div 내부로 한정
- MeetingTabs, TabsContent에 flex-1 flex-col 추가
- MeetingTabsEmpty의 py-40 제거, flex-1로 남은 공간 채움
- 
### 🧪 테스트 방법 (How to Test)

1. npm run dev 후 /mypage 진입합니다.
2. 모임 카드가 없는 탭 진입 시 스크롤바 없고 푸터가 스크롤 없이 보이는지 확인합니다.
3. 모임 카드가 있는 탭에서 스크롤 정상 동작 확인합니다.

### 📸 스크린샷 또는 영상 (Optional)

<img width="1244" height="845" alt="image" src="https://github.com/user-attachments/assets/74afb881-39e1-449d-8d66-31770b72318d" />