### PR TITLE
feat: 소소톡 목록 무한 스크롤 추가

### DIFF
--- a/src/entities/post/model/post.queries.test.tsx
+++ b/src/entities/post/model/post.queries.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type InfiniteData, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 import {
@@ -104,6 +104,14 @@ const createPostList = (): GetSosoTalkPostListResponse => ({
   hasMore: false,
 });
 
+const createInfinitePostList = (): InfiniteData<
+  GetSosoTalkPostListResponse,
+  string | undefined
+> => ({
+  pages: [createPostList()],
+  pageParams: [undefined],
+});
+
 const createDeferred = <T,>() => {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -146,6 +154,10 @@ describe('sosotalk like mutations', () => {
     const { queryClient, wrapper } = createWrapper();
     queryClient.setQueryData(sosotalkQueryKeys.postDetail(POST_ID), createPostDetail());
     queryClient.setQueryData(sosotalkQueryKeys.postList(LIST_PARAMS), createPostList());
+    queryClient.setQueryData(
+      sosotalkQueryKeys.postInfiniteList(LIST_PARAMS),
+      createInfinitePostList()
+    );
 
     const { result } = renderHook(() => useCreateSosoTalkPostLike(), { wrapper });
 
@@ -168,6 +180,13 @@ describe('sosotalk like mutations', () => {
       queryClient.getQueryData<GetSosoTalkPostListResponse>(sosotalkQueryKeys.postList(LIST_PARAMS))
     ).toMatchObject({
       data: [expect.objectContaining({ id: POST_ID, likeCount: 5 })],
+    });
+    expect(
+      queryClient.getQueryData<InfiniteData<GetSosoTalkPostListResponse, string | undefined>>(
+        sosotalkQueryKeys.postInfiniteList(LIST_PARAMS)
+      )
+    ).toMatchObject({
+      pages: [{ data: [expect.objectContaining({ id: POST_ID, likeCount: 5 })] }],
     });
 
     deferred.resolve({});
@@ -195,6 +214,10 @@ describe('sosotalk like mutations', () => {
 
     queryClient.setQueryData(sosotalkQueryKeys.postDetail(POST_ID), likedDetail);
     queryClient.setQueryData(sosotalkQueryKeys.postList(LIST_PARAMS), likedList);
+    queryClient.setQueryData(sosotalkQueryKeys.postInfiniteList(LIST_PARAMS), {
+      pages: [likedList],
+      pageParams: [undefined],
+    } satisfies InfiniteData<GetSosoTalkPostListResponse, string | undefined>);
 
     const { result } = renderHook(() => useDeleteSosoTalkPostLike(), { wrapper });
 
@@ -212,6 +235,13 @@ describe('sosotalk like mutations', () => {
       queryClient.getQueryData<GetSosoTalkPostListResponse>(sosotalkQueryKeys.postList(LIST_PARAMS))
     ).toMatchObject({
       data: [expect.objectContaining({ id: POST_ID, likeCount: 5 })],
+    });
+    expect(
+      queryClient.getQueryData<InfiniteData<GetSosoTalkPostListResponse, string | undefined>>(
+        sosotalkQueryKeys.postInfiniteList(LIST_PARAMS)
+      )
+    ).toMatchObject({
+      pages: [{ data: [expect.objectContaining({ id: POST_ID, likeCount: 5 })] }],
     });
   });
 });

--- a/src/entities/post/model/post.queries.ts
+++ b/src/entities/post/model/post.queries.ts
@@ -1,4 +1,10 @@
-import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  queryOptions,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {
   createSosoTalkComment,
@@ -34,6 +40,8 @@ const SOSOTALK_QUERY_GC_TIME = 1000 * 60 * 10;
 export const sosotalkQueryKeys = {
   all: ['sosotalk'] as const,
   postList: (params?: GetSosoTalkPostListParams) => ['sosotalk-post-list', params] as const,
+  postInfiniteList: (params?: GetSosoTalkPostListParams) =>
+    ['sosotalk-post-infinite-list', params] as const,
   postDetail: (postId?: number) => ['sosotalk-post-detail', postId] as const,
 };
 
@@ -69,10 +77,34 @@ export const useGetSosoTalkPostList = (
   initialData?: GetSosoTalkPostListResponse
 ) => useQuery(sosotalkPostListQueryOptions(params, initialData));
 
+const sosotalkPostInfiniteListQueryOptions = (
+  params?: GetSosoTalkPostListParams,
+  initialData?: GetSosoTalkPostListResponse
+) => ({
+  queryKey: sosotalkQueryKeys.postInfiniteList(params),
+  queryFn: ({ pageParam }: { pageParam?: string }) =>
+    getSosoTalkPostList({
+      ...params,
+      cursor: pageParam,
+    }),
+  initialPageParam: undefined as string | undefined,
+  getNextPageParam: (lastPage: GetSosoTalkPostListResponse) =>
+    lastPage.hasMore ? lastPage.nextCursor : undefined,
+  initialData: initialData ? { pages: [initialData], pageParams: [undefined] } : undefined,
+  staleTime: SOSOTALK_QUERY_STALE_TIME,
+  gcTime: SOSOTALK_QUERY_GC_TIME,
+});
+
+export const useGetSosoTalkPostInfiniteList = (
+  params?: GetSosoTalkPostListParams,
+  initialData?: GetSosoTalkPostListResponse
+) => useInfiniteQuery(sosotalkPostInfiniteListQueryOptions(params, initialData));
+
 export const useGetSosoTalkPostDetail = (postId?: number) =>
   useQuery(sosotalkPostDetailQueryOptions(postId));
 
 const SOSOTALK_POST_LIST_QUERY_PREFIX = ['sosotalk-post-list'] as const;
+const SOSOTALK_POST_INFINITE_LIST_QUERY_PREFIX = ['sosotalk-post-infinite-list'] as const;
 
 type SosoTalkLikeMutationContext = {
   previousDetail?: GetSosoTalkPostDetailResponse;
@@ -119,7 +151,10 @@ const updateSosoTalkPostListLikeCache = (
 };
 
 const invalidateSosoTalkListQueries = (queryClient: ReturnType<typeof useQueryClient>) =>
-  queryClient.invalidateQueries({ queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX });
+  Promise.all([
+    queryClient.invalidateQueries({ queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX }),
+    queryClient.invalidateQueries({ queryKey: SOSOTALK_POST_INFINITE_LIST_QUERY_PREFIX }),
+  ]);
 
 const updateSosoTalkCommentLikeCache = (
   comments: SosoTalkComment[],

--- a/src/entities/post/model/post.queries.ts
+++ b/src/entities/post/model/post.queries.ts
@@ -1,4 +1,5 @@
 import {
+  type InfiniteData,
   queryOptions,
   useInfiniteQuery,
   useMutation,
@@ -109,6 +110,12 @@ const SOSOTALK_POST_INFINITE_LIST_QUERY_PREFIX = ['sosotalk-post-infinite-list']
 type SosoTalkLikeMutationContext = {
   previousDetail?: GetSosoTalkPostDetailResponse;
   previousLists: Array<readonly [readonly unknown[], GetSosoTalkPostListResponse | undefined]>;
+  previousInfiniteLists: Array<
+    readonly [
+      readonly unknown[],
+      InfiniteData<GetSosoTalkPostListResponse, string | undefined> | undefined,
+    ]
+  >;
 };
 
 const updateSosoTalkPostDetailLikeCache = (
@@ -150,6 +157,23 @@ const updateSosoTalkPostListLikeCache = (
   };
 };
 
+const updateSosoTalkPostInfiniteListLikeCache = (
+  previousList: InfiniteData<GetSosoTalkPostListResponse, string | undefined> | undefined,
+  postId: number,
+  likeDiff: number
+): InfiniteData<GetSosoTalkPostListResponse, string | undefined> | undefined => {
+  if (!previousList) {
+    return previousList;
+  }
+
+  return {
+    ...previousList,
+    pages: previousList.pages.map(
+      (page) => updateSosoTalkPostListLikeCache(page, postId, likeDiff)!
+    ),
+  };
+};
+
 const invalidateSosoTalkListQueries = (queryClient: ReturnType<typeof useQueryClient>) =>
   Promise.all([
     queryClient.invalidateQueries({ queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX }),
@@ -187,6 +211,10 @@ const restoreSosoTalkLikeCache = (
   context?.previousLists.forEach(([queryKey, previousList]) => {
     queryClient.setQueryData(queryKey, previousList);
   });
+
+  context?.previousInfiniteLists.forEach(([queryKey, previousList]) => {
+    queryClient.setQueryData(queryKey, previousList);
+  });
 };
 
 const createSosoTalkLikeMutation = (
@@ -202,6 +230,7 @@ const createSosoTalkLikeMutation = (
         await Promise.all([
           queryClient.cancelQueries({ queryKey: sosotalkQueryKeys.postDetail(postId) }),
           queryClient.cancelQueries({ queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX }),
+          queryClient.cancelQueries({ queryKey: SOSOTALK_POST_INFINITE_LIST_QUERY_PREFIX }),
         ]);
 
         const previousDetail = queryClient.getQueryData<GetSosoTalkPostDetailResponse>(
@@ -209,6 +238,11 @@ const createSosoTalkLikeMutation = (
         );
         const previousLists = queryClient.getQueriesData<GetSosoTalkPostListResponse>({
           queryKey: SOSOTALK_POST_LIST_QUERY_PREFIX,
+        });
+        const previousInfiniteLists = queryClient.getQueriesData<
+          InfiniteData<GetSosoTalkPostListResponse, string | undefined>
+        >({
+          queryKey: SOSOTALK_POST_INFINITE_LIST_QUERY_PREFIX,
         });
 
         queryClient.setQueryData<GetSosoTalkPostDetailResponse>(
@@ -220,10 +254,16 @@ const createSosoTalkLikeMutation = (
           (currentList) =>
             updateSosoTalkPostListLikeCache(currentList, postId, nextIsLiked ? 1 : -1)
         );
+        queryClient.setQueriesData<InfiniteData<GetSosoTalkPostListResponse, string | undefined>>(
+          { queryKey: SOSOTALK_POST_INFINITE_LIST_QUERY_PREFIX },
+          (currentList) =>
+            updateSosoTalkPostInfiniteListLikeCache(currentList, postId, nextIsLiked ? 1 : -1)
+        );
 
         return {
           previousDetail,
           previousLists,
+          previousInfiniteLists,
         };
       },
       onError: (_error, postId, context) => {

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.test.ts
@@ -6,7 +6,7 @@ describe('createSosoTalkMainPageQueryParams', () => {
       type: 'best',
       sortBy: 'commentCount',
       sortOrder: 'desc',
-      size: 10,
+      size: 12,
     });
   });
 
@@ -15,7 +15,7 @@ describe('createSosoTalkMainPageQueryParams', () => {
       type: 'all',
       sortBy: 'createdAt',
       sortOrder: 'desc',
-      size: 10,
+      size: 12,
     });
   });
 
@@ -24,7 +24,7 @@ describe('createSosoTalkMainPageQueryParams', () => {
       type: 'all',
       sortBy: 'likeCount',
       sortOrder: 'desc',
-      size: 10,
+      size: 12,
     });
   });
 });

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/sosotalk-main-page.utils.ts
@@ -19,6 +19,6 @@ export function createSosoTalkMainPageQueryParams(
     type: activeTab === 'popular' ? 'best' : 'all',
     sortBy: SORT_BY_MAP[activeSort] ?? 'createdAt',
     sortOrder: 'desc',
-    size: 10,
+    size: 12,
   };
 }

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 
 import type { GetSosoTalkPostListResponse } from '@/entities/post';
-import { mapPostToSosoTalkCardItem, useGetSosoTalkPostList } from '@/entities/post';
+import { mapPostToSosoTalkCardItem, useGetSosoTalkPostInfiniteList } from '@/entities/post';
 
 import { useSosoTalkMainPage } from './use-sosotalk-main-page';
 
@@ -16,11 +16,11 @@ jest.mock('nuqs', () => ({
 
 jest.mock('@/entities/post', () => ({
   mapPostToSosoTalkCardItem: jest.fn(),
-  useGetSosoTalkPostList: jest.fn(),
+  useGetSosoTalkPostInfiniteList: jest.fn(),
 }));
 
 const mockUseQueryState = jest.requireMock('nuqs').useQueryState as jest.Mock;
-const mockUseGetSosoTalkPostList = useGetSosoTalkPostList as jest.Mock;
+const mockUseGetSosoTalkPostInfiniteList = useGetSosoTalkPostInfiniteList as jest.Mock;
 const mockMapPostToSosoTalkCardItem = mapPostToSosoTalkCardItem as jest.Mock;
 
 const initialData: GetSosoTalkPostListResponse = {
@@ -53,8 +53,11 @@ describe('useSosoTalkMainPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseGetSosoTalkPostList.mockReturnValue({
-      data: initialData,
+    mockUseGetSosoTalkPostInfiniteList.mockReturnValue({
+      data: { pages: [initialData] },
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
       isLoading: false,
       isError: false,
     });
@@ -74,7 +77,7 @@ describe('useSosoTalkMainPage', () => {
       })
     );
 
-    expect(mockUseGetSosoTalkPostList).toHaveBeenCalledWith(
+    expect(mockUseGetSosoTalkPostInfiniteList).toHaveBeenCalledWith(
       {
         type: 'all',
         sortBy: 'createdAt',
@@ -98,7 +101,7 @@ describe('useSosoTalkMainPage', () => {
       })
     );
 
-    expect(mockUseGetSosoTalkPostList).toHaveBeenCalledWith(
+    expect(mockUseGetSosoTalkPostInfiniteList).toHaveBeenCalledWith(
       {
         type: 'best',
         sortBy: 'likeCount',

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts
@@ -82,7 +82,7 @@ describe('useSosoTalkMainPage', () => {
         type: 'all',
         sortBy: 'createdAt',
         sortOrder: 'desc',
-        size: 10,
+        size: 12,
       },
       initialData
     );
@@ -106,7 +106,7 @@ describe('useSosoTalkMainPage', () => {
         type: 'best',
         sortBy: 'likeCount',
         sortOrder: 'desc',
-        size: 10,
+        size: 12,
       },
       undefined
     );

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.ts
@@ -1,11 +1,9 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import { parseAsStringLiteral, useQueryState } from 'nuqs';
 
 import type { GetSosoTalkPostListResponse } from '@/entities/post';
-import { mapPostToSosoTalkCardItem, useGetSosoTalkPostList } from '@/entities/post';
+import { mapPostToSosoTalkCardItem, useGetSosoTalkPostInfiniteList } from '@/entities/post';
 
 import type {
   SosoTalkSortValue,
@@ -38,21 +36,19 @@ export function useSosoTalkMainPage({
       .withOptions({ history: 'push' })
   );
 
-  const queryParams = useMemo(
-    () => createSosoTalkMainPageQueryParams(activeTab, activeSort),
-    [activeSort, activeTab]
-  );
+  const queryParams = createSosoTalkMainPageQueryParams(activeTab, activeSort);
   const shouldUseInitialData = activeTab === initialTab && activeSort === initialSort;
-  const { data, isLoading, isError } = useGetSosoTalkPostList(
-    queryParams,
-    shouldUseInitialData ? initialData : undefined
-  );
-  const posts = useMemo(() => data?.data.map(mapPostToSosoTalkCardItem) ?? [], [data]);
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGetSosoTalkPostInfiniteList(queryParams, shouldUseInitialData ? initialData : undefined);
+  const posts = data?.pages.flatMap((page) => page.data).map(mapPostToSosoTalkCardItem) ?? [];
 
   return {
     activeSort,
     activeTab,
+    fetchNextPage,
+    hasNextPage,
     isError,
+    isFetchingNextPage,
     isLoading,
     posts,
     setActiveSort: (value: SosoTalkSortValue) => void setActiveSort(value),

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
@@ -5,6 +5,13 @@ import { SosoTalkMainPage } from './sosotalk-main-page';
 const mockUseSosoTalkMainPage = jest.fn();
 const mockFilterBar = jest.fn();
 
+jest.mock('react-intersection-observer', () => ({
+  useInView: () => ({
+    ref: jest.fn(),
+    inView: false,
+  }),
+}));
+
 jest.mock('./model', () => ({
   useSosoTalkMainPage: () => mockUseSosoTalkMainPage(),
 }));
@@ -34,7 +41,10 @@ describe('SosoTalkMainPage', () => {
     mockUseSosoTalkMainPage.mockReturnValue({
       activeSort: 'latest',
       activeTab: 'all',
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
       isError: false,
+      isFetchingNextPage: false,
       isLoading: false,
       posts: [],
       setActiveSort: jest.fn(),
@@ -46,11 +56,14 @@ describe('SosoTalkMainPage', () => {
     jest.clearAllMocks();
   });
 
-  it('로딩 중에는 로딩 문구를 보여준다', () => {
+  it('로딩 중이면 로딩 문구를 보여준다', () => {
     mockUseSosoTalkMainPage.mockReturnValue({
       activeSort: 'latest',
       activeTab: 'all',
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
       isError: false,
+      isFetchingNextPage: false,
       isLoading: true,
       posts: [],
       setActiveSort: jest.fn(),
@@ -66,7 +79,10 @@ describe('SosoTalkMainPage', () => {
     mockUseSosoTalkMainPage.mockReturnValue({
       activeSort: 'latest',
       activeTab: 'all',
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
       isError: true,
+      isFetchingNextPage: false,
       isLoading: false,
       posts: [],
       setActiveSort: jest.fn(),
@@ -90,7 +106,10 @@ describe('SosoTalkMainPage', () => {
     mockUseSosoTalkMainPage.mockReturnValue({
       activeSort: 'likes',
       activeTab: 'popular',
+      fetchNextPage: jest.fn(),
+      hasNextPage: true,
       isError: false,
+      isFetchingNextPage: false,
       isLoading: false,
       posts: [
         { id: 1, title: '첫 번째 글' },
@@ -113,5 +132,43 @@ describe('SosoTalkMainPage', () => {
         activeTab: 'popular',
       })
     );
+  });
+
+  it('다음 페이지를 불러오는 중이면 안내 문구를 보여준다', () => {
+    mockUseSosoTalkMainPage.mockReturnValue({
+      activeSort: 'latest',
+      activeTab: 'all',
+      fetchNextPage: jest.fn(),
+      hasNextPage: true,
+      isError: false,
+      isFetchingNextPage: true,
+      isLoading: false,
+      posts: [{ id: 1, title: '첫 번째 글' }],
+      setActiveSort: jest.fn(),
+      setActiveTab: jest.fn(),
+    });
+
+    render(<SosoTalkMainPage />);
+
+    expect(screen.getByText('게시글을 더 불러오는 중이에요.')).toBeInTheDocument();
+  });
+
+  it('마지막 페이지면 완료 문구를 보여준다', () => {
+    mockUseSosoTalkMainPage.mockReturnValue({
+      activeSort: 'latest',
+      activeTab: 'all',
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isError: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+      posts: [{ id: 1, title: '첫 번째 글' }],
+      setActiveSort: jest.fn(),
+      setActiveTab: jest.fn(),
+    });
+
+    render(<SosoTalkMainPage />);
+
+    expect(screen.getByText('모든 게시글을 불러왔어요.')).toBeInTheDocument();
   });
 });

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+
 import Link from 'next/link';
 
 import { Plus } from 'lucide-react';
@@ -30,8 +33,28 @@ export const SosoTalkMainPage = ({
   initialTab,
   initialSort,
 }: SosoTalkMainPageProps) => {
-  const { activeSort, activeTab, isError, isLoading, posts, setActiveSort, setActiveTab } =
-    useSosoTalkMainPage({ initialData, initialTab, initialSort });
+  const { ref, inView } = useInView({
+    threshold: 0.5,
+    root: null,
+  });
+  const {
+    activeSort,
+    activeTab,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+    isFetchingNextPage,
+    isLoading,
+    posts,
+    setActiveSort,
+    setActiveTab,
+  } = useSosoTalkMainPage({ initialData, initialTab, initialSort });
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, inView, isFetchingNextPage]);
 
   return (
     <div className={cn('bg-background min-h-screen w-full bg-[#f9f9f9] pb-24 md:pb-28', className)}>
@@ -64,11 +87,28 @@ export const SosoTalkMainPage = ({
             {!isLoading && !isError ? (
               <>
                 {posts.length > 0 ? (
-                  <div className="grid grid-cols-1 justify-items-center gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:justify-items-stretch">
-                    {posts.map((post) => (
-                      <SosoTalkCard key={post.id} {...post} />
-                    ))}
-                  </div>
+                  <>
+                    <div className="grid grid-cols-1 justify-items-center gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:justify-items-stretch">
+                      {posts.map((post) => (
+                        <SosoTalkCard key={post.id} {...post} />
+                      ))}
+                    </div>
+                    <div ref={ref} className="flex h-1 items-center justify-center" />
+                    {isFetchingNextPage ? (
+                      <div className="flex py-8">
+                        <p className="text-sosoeat-gray-500 mx-auto text-sm">
+                          게시글을 더 불러오는 중이에요.
+                        </p>
+                      </div>
+                    ) : null}
+                    {!hasNextPage ? (
+                      <div className="flex py-8">
+                        <p className="text-sosoeat-gray-400 mx-auto text-sm">
+                          모든 게시글을 불러왔어요.
+                        </p>
+                      </div>
+                    ) : null}
+                  </>
                 ) : (
                   <div className="flex min-h-[240px] items-center justify-center">
                     <p className="text-sosoeat-gray-400 text-sm">아직 등록된 게시글이 없어요.</p>

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
@@ -103,7 +103,7 @@ export const SosoTalkMainPage = ({
                     ) : null}
                     {!hasNextPage ? (
                       <div className="flex py-8">
-                        <p className="text-sosoeat-gray-400 mx-auto text-sm">
+                        <p className="text-sosoeat-gray-500 mx-auto text-sm">
                           모든 게시글을 불러왔어요.
                         </p>
                       </div>


### PR DESCRIPTION
md
## 작업 내용
- 소소톡 목록 조회를 커서 기반 무한 스크롤로 변경
- `useInfiniteQuery`를 사용해 다음 페이지를 이어서 불러오도록 구현
- 메인 페이지 하단 sentinel 진입 시 다음 게시글을 자동 요청하도록 적용
- 마지막 페이지/추가 로딩 상태 UI 문구 추가
- 관련 훅 및 화면 테스트 수정

## 변경 이유
- 기존에는 소소톡 게시글이 최대 10개까지만 노출되고 있어 더 많은 게시글을 볼 수 없었음
- 게시글 목록 성격상 숫자 페이지네이션보다 무한 스크롤 UX가 더 자연스럽다고 판단

## 테스트
- `npm test -- --runInBand src/widgets/sosotalk/ui/sosotalk-main-page/model/use-sosotalk-main-page.test.ts src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx src/entities/post/model/post.queries.test.tsx`
- `npm run type-check`

## 참고
- 게시글 목록 API의 `nextCursor`, `hasMore`를 사용해 구현
- 원격 브랜치: `feature/sosotalk-infinite-scroll`
```