### PR TITLE
[Feat]: 모임 상세 공유하기 기능 추가

### DIFF
--- a/src/widgets/meeting-detail/ui/meeting-detail-card/_components/meeting-share-modal.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/_components/meeting-share-modal.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import Image from 'next/image';
+import Script from 'next/script';
+
+import { Copy, Share2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/dialog';
+
+interface KakaoSharePayload {
+  objectType: 'feed';
+  content: {
+    title: string;
+    description: string;
+    imageUrl: string;
+    link: {
+      mobileWebUrl: string;
+      webUrl: string;
+    };
+  };
+  buttons: Array<{
+    title: string;
+    link: {
+      mobileWebUrl: string;
+      webUrl: string;
+    };
+  }>;
+}
+
+interface KakaoSdk {
+  init: (appKey: string) => void;
+  isInitialized: () => boolean;
+  Share: {
+    sendDefault: (payload: KakaoSharePayload) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    Kakao?: KakaoSdk;
+  }
+}
+
+interface MeetingShareModalProps {
+  open: boolean;
+  title: string;
+  url: string;
+  imageUrl?: string;
+  onClose: () => void;
+  onCopy: () => void | Promise<void>;
+}
+
+const KAKAO_JS_KEY = process.env.NEXT_PUBLIC_KAKAO_JS_KEY;
+
+const toAbsoluteImageUrl = (imageUrl?: string) => {
+  const path = imageUrl || '/images/logo.svg';
+
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+
+  if (typeof window === 'undefined') return path;
+
+  return `${window.location.origin}${path.startsWith('/') ? '' : '/'}${path}`;
+};
+
+export function MeetingShareModal({
+  open,
+  title,
+  url,
+  imageUrl,
+  onClose,
+  onCopy,
+}: MeetingShareModalProps) {
+  const initializeKakao = () => {
+    if (!KAKAO_JS_KEY || typeof window === 'undefined' || !window.Kakao) {
+      return;
+    }
+
+    if (!window.Kakao.isInitialized()) {
+      window.Kakao.init(KAKAO_JS_KEY);
+    }
+  };
+
+  const handleKakaoShare = () => {
+    if (!window.Kakao) {
+      toast.error('카카오톡 공유 중 문제가 생겼어요. 다시 시도해 주세요.');
+      return;
+    }
+
+    window.Kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title,
+        description: '소소잇 모임을 확인해 보세요.',
+        imageUrl: toAbsoluteImageUrl(imageUrl),
+        link: {
+          mobileWebUrl: url,
+          webUrl: url,
+        },
+      },
+      buttons: [
+        {
+          title: '모임 보기',
+          link: {
+            mobileWebUrl: url,
+            webUrl: url,
+          },
+        },
+      ],
+    });
+  };
+
+  return (
+    <>
+      {KAKAO_JS_KEY ? (
+        <Script
+          src="https://developers.kakao.com/sdk/js/kakao.min.js"
+          strategy="afterInteractive"
+          onLoad={initializeKakao}
+        />
+      ) : null}
+
+      <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+        <DialogContent className="max-w-[calc(100%-2rem)] rounded-[24px] px-6 py-6 sm:max-w-md sm:px-7 [&_[data-slot='dialog-close']]:top-4 [&_[data-slot='dialog-close']]:right-4">
+          <DialogHeader className="gap-3">
+            <div className="bg-sosoeat-orange-100 text-sosoeat-orange-700 inline-flex h-11 w-11 items-center justify-center rounded-full">
+              <Share2 className="h-5 w-5" />
+            </div>
+            <DialogTitle className="text-sosoeat-gray-900 text-xl font-semibold">
+              모임 공유하기
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              카카오톡 또는 링크 복사로 모임을 공유할 수 있는 모달입니다.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="bg-sosoeat-gray-100 rounded-2xl px-4 py-3">
+              <p className="text-sosoeat-gray-900 line-clamp-2 text-sm font-semibold">{title}</p>
+              <p className="text-sosoeat-gray-500 mt-1 truncate text-sm">{url}</p>
+            </div>
+          </div>
+
+          <div className="mt-2 flex flex-wrap justify-end gap-2">
+            {KAKAO_JS_KEY ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-full border-[#FEE500] bg-[#FEE500] text-[#191919] hover:bg-[#f6dd00]"
+                onClick={handleKakaoShare}
+              >
+                <Image src="/icons/kakao-icon.svg" alt="" width={18} height={18} aria-hidden />
+                카카오톡 공유
+              </Button>
+            ) : null}
+            <Button className="rounded-full" onClick={() => void onCopy()}>
+              <Copy className="h-4 w-4" />
+              링크 복사
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/widgets/meeting-detail/ui/meeting-detail-card/hooks/use-meeting-share.ts
+++ b/src/widgets/meeting-detail/ui/meeting-detail-card/hooks/use-meeting-share.ts
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+
+import { toast } from 'sonner';
+
+import { writeClipboardText } from '@/shared/lib/write-clipboard-text';
+
+const MOBILE_SHARE_USER_AGENT = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
+
+interface UseMeetingShareParams {
+  title: string;
+  imageUrl?: string;
+}
+
+export function useMeetingShare({ title, imageUrl }: UseMeetingShareParams) {
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+
+  const shareUrl = typeof window === 'undefined' ? '' : window.location.href;
+
+  const handleShareClick = async () => {
+    if (typeof window === 'undefined') return;
+
+    const shareData = {
+      title,
+      text: `소소잇 모임 - ${title}`,
+      url: window.location.href,
+    };
+
+    const canUseNativeShare =
+      typeof navigator.share === 'function' &&
+      MOBILE_SHARE_USER_AGENT.test(window.navigator.userAgent);
+
+    if (!canUseNativeShare) {
+      setIsShareModalOpen(true);
+      return;
+    }
+
+    try {
+      await navigator.share(shareData);
+      toast.success('공유를 완료했어요.');
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+      toast.error('공유 중 문제가 생겼어요. 다시 시도해 주세요.');
+    }
+  };
+
+  const handleCancelShare = () => {
+    setIsShareModalOpen(false);
+  };
+
+  const handleCopyShareLink = async () => {
+    if (!shareUrl) return;
+
+    try {
+      await writeClipboardText(shareUrl);
+      toast.success('링크를 복사했어요.');
+      setIsShareModalOpen(false);
+    } catch {
+      toast.error('링크 복사 중 문제가 생겼어요. 다시 시도해 주세요.');
+    }
+  };
+
+  return {
+    isShareModalOpen,
+    shareUrl,
+    shareTitle: title,
+    shareImageUrl: imageUrl,
+    handleShareClick,
+    handleCancelShare,
+    handleCopyShareLink,
+  };
+}

--- a/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-hero-section/meeting-hero-section.tsx
@@ -19,11 +19,20 @@ import {
   useMeetingDetail,
 } from '../../model/meeting-detail.queries';
 import { MeetingDetailCard } from '../meeting-detail-card';
+import { useMeetingShare } from '../meeting-detail-card/hooks/use-meeting-share';
 
 import { useMeetingRole } from './hooks/use-meeting-role';
 
 const MeetingEditModal = dynamic(() =>
   import('@/features/meeting-edit').then((m) => m.MeetingEditModal)
+);
+
+const MeetingShareModal = dynamic(
+  () =>
+    import('../meeting-detail-card/_components/meeting-share-modal').then(
+      (m) => m.MeetingShareModal
+    ),
+  { ssr: false }
 );
 
 interface MeetingHeroSectionProps {
@@ -38,6 +47,15 @@ export function MeetingHeroSection({ meetingId }: MeetingHeroSectionProps) {
 
   const { role, status } = useMeetingRole(meeting);
   const { isOpen: isEditOpen, open: openEdit, close: closeEdit } = useModal();
+  const {
+    isShareModalOpen,
+    shareUrl,
+    shareTitle,
+    shareImageUrl,
+    handleShareClick,
+    handleCancelShare,
+    handleCopyShareLink,
+  } = useMeetingShare({ title: meeting.name, imageUrl: meeting.image });
 
   const refreshPageAndMeetingCache = () => {
     void queryClient.invalidateQueries({
@@ -69,9 +87,7 @@ export function MeetingHeroSection({ meetingId }: MeetingHeroSectionProps) {
       ? {
           role: 'host' as const,
           onConfirm: () => confirmMutation.mutate(),
-          onShare: () => {
-            navigator.clipboard.writeText(window.location.href);
-          },
+          onShare: handleShareClick,
           onEdit: openEdit,
           onDelete: () => deleteMutation.mutate(),
           isActionPending,
@@ -119,6 +135,15 @@ export function MeetingHeroSection({ meetingId }: MeetingHeroSectionProps) {
           onSuccess={refreshPageAndMeetingCache}
         />
       )}
+
+      <MeetingShareModal
+        open={isShareModalOpen}
+        title={shareTitle}
+        url={shareUrl}
+        imageUrl={shareImageUrl}
+        onClose={handleCancelShare}
+        onCopy={handleCopyShareLink}
+      />
     </>
   );
 }


### PR DESCRIPTION
  ### 📌 유형 (Type)                                                                                                                                           
                                                                                                                                                               
  - [x] **Feat (기능):** 새로운 기능 추가                                                                                                                      
                                                                                                                                                               
  ### 📝 변경 사항 (Changes)                                                                                                                                   
                                                                                                                                                               
  - 모임 상세 페이지에서 호스트가 모임 확정 후 공유하기 버튼 클릭 시 공유 모달이 열립니다. (#419)                                                              
  - `MeetingShareModal` 컴포넌트 추가 (카카오톡 공유 + 링크 복사)
  - `useMeetingShare` 훅 추가 (모바일: 네이티브 공유 / PC: 모달)                                                                                               
  - `MeetingHeroSection`에서 훅 연결 및 `onShare` 콜백으로 `MeetingDetailCard`에 전달                                                                          
  - `next/dynamic`으로 `MeetingShareModal` 코드 스플리팅 적용                                                                                                  
                                                                                                                                                               
  ### 🧪 테스트 방법 (How to Test)                                                                                                                             
                  
  1. 호스트 계정으로 로그인 후 확정된 모임 상세 페이지로 이동합니다.                                                                                           
  2. "공유하기" 버튼을 클릭합니다.
  3. **PC**: 공유 모달이 열리고 카카오톡 공유 / 링크 복사 버튼이 정상 동작하는지 확인합니다.                                                                   
  4. **모바일**: 네이티브 공유 시트가 열리는지 확인합니다.                                                                                                     
  5. 카카오톡 공유 후 링크 클릭 시 해당 모임 페이지로 이동하는지 확인합니다.                                                                                   
                                                                                                                                                               
  ### 📸 스크린샷 또는 영상 (Optional)                                                                                                                         
                                                                                                                                                               
  | 변경 전 (Before) | 변경 후 (After) |                                                                                                                       
  | :--------------: | :-------------: |
  |                  |                 |                                                                                                                       
   
  ### 🚨 기타 참고 사항 (Notes)                                                                                                                                
                  
  - [ ] 카카오 개발자 콘솔에 배포 도메인이 등록되어 있어야 카카오톡 공유가 정상 동작합니다.                                                                    
  - [ ] `SosoTalkShareModal`과 동일한 패턴으로 구현했습니다.