### PR TITLE
[Feat]: 검색어 최소 2글자 Zod 유효성 검사 추가

### DIFF
--- a/src/widgets/search/model/use-search-page.test.tsx
+++ b/src/widgets/search/model/use-search-page.test.tsx
@@ -195,6 +195,50 @@ describe('useSearchPage', () => {
     );
   });
 
+  it('1글자 입력 시 searchError가 반환된다', () => {
+    const { result } = renderHookWithClient(() => useSearchPage(null));
+
+    act(() => {
+      result.current.handleSearchQueryChange('김');
+    });
+
+    expect(result.current.searchError).toBe('2글자 이상 입력해주세요');
+  });
+
+  it('2글자 이상 입력 시 searchError가 undefined다', () => {
+    const { result } = renderHookWithClient(() => useSearchPage(null));
+
+    act(() => {
+      result.current.handleSearchQueryChange('김칠');
+    });
+
+    expect(result.current.searchError).toBeUndefined();
+  });
+
+  it('0글자일 때 searchError가 undefined다', () => {
+    const { result } = renderHookWithClient(() => useSearchPage(null));
+
+    expect(result.current.searchError).toBeUndefined();
+  });
+
+  it('1글자 입력 후 600ms 경과해도 API keyword가 전달되지 않는다', async () => {
+    const { result } = renderHookWithClient(() => useSearchPage(null));
+
+    act(() => {
+      result.current.handleSearchQueryChange('김');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(useInfiniteQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryKey: ['search', 'infinite-list', expect.objectContaining({ keyword: undefined })],
+      })
+    );
+  });
+
   it('복수 지역 데이터를 합산하여 반환해야 한다', async () => {
     const meeting1 = { id: 1, region: '부산 북구', dateTime: '2026-01-01' };
     const meeting2 = { id: 2, region: '서울 강남구', dateTime: '2026-01-02' };

--- a/src/widgets/search/model/use-search-page.ts
+++ b/src/widgets/search/model/use-search-page.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { startOfDay } from 'date-fns';
 import {
@@ -10,6 +10,7 @@ import {
   parseAsStringLiteral,
   useQueryState,
 } from 'nuqs';
+import { z } from 'zod';
 
 import { useSearchInfiniteOption } from '@/entities/meeting';
 import type { getMeetings } from '@/entities/meeting/index.server';
@@ -41,13 +42,9 @@ const useSearchPage = (
   initialData: Awaited<ReturnType<typeof getMeetings>> | null,
   initialDefaultDateStartIso?: string
 ) => {
-  const fallbackDefaultDateStartIsoRef = useRef(
-    initialDefaultDateStartIso ?? getDefaultSearchDateStartIso()
+  const [defaultDateStartIso] = useState(
+    () => initialDefaultDateStartIso ?? getDefaultSearchDateStartIso()
   );
-  const [defaultDateStartIso, setDefaultDateStartIso] = useState(
-    fallbackDefaultDateStartIsoRef.current
-  );
-  const hasMountedRef = useRef(false);
 
   const [regionCommitted, setRegionCommitted] = useQueryState<RegionSelection>(
     'regionCommitted',
@@ -120,19 +117,8 @@ const useSearchPage = (
     dateEnd == null
       ? undefined
       : new Date(dateEnd.getFullYear(), dateEnd.getMonth(), dateEnd.getDate() + 1).toISOString();
-  const resolvedDefaultDateStartIso = defaultDateStartIso ?? fallbackDefaultDateStartIsoRef.current;
+  const resolvedDefaultDateStartIso = defaultDateStartIso;
   const resolvedDefaultDateStart = new Date(resolvedDefaultDateStartIso);
-
-  useEffect(() => {
-    if (!hasMountedRef.current) {
-      hasMountedRef.current = true;
-      return;
-    }
-
-    if (dateStart != null) return;
-
-    setDefaultDateStartIso(getDefaultSearchDateStartIso());
-  }, [dateStart, dateEndExclusiveIso, region, searchQuery, sortBy, sortOrder, typeFilter]);
 
   const options: Omit<TeamIdMeetingsGetRequest, 'teamId' | 'region'> & {
     region?: string | string[];
@@ -176,11 +162,11 @@ const useSearchPage = (
       typeFilter,
     ]
   );
-  const initialOptionSnapshotRef = useRef<SearchOptionSnapshot>(currentOptionSnapshot);
+  const [initialOptionSnapshot] = useState<SearchOptionSnapshot>(() => currentOptionSnapshot);
   const shouldUseInitialData =
     initialData != null &&
     region == null &&
-    JSON.stringify(initialOptionSnapshotRef.current) === JSON.stringify(currentOptionSnapshot);
+    JSON.stringify(initialOptionSnapshot) === JSON.stringify(currentOptionSnapshot);
 
   const isMulti = Array.isArray(options.region) && options.region.length > 1;
 
@@ -206,10 +192,14 @@ const useSearchPage = (
   const handleSearchQueryChange = (e: string) => {
     setInputValue(e);
   };
+  const searchError = inputValue.length === 1 ? '2글자 이상 입력해주세요' : undefined;
 
   useEffect(() => {
+    const searchQueryZod = z.string().min(2);
+    const result = searchQueryZod.safeParse(inputValue);
+
     const delayDebounce = setTimeout(() => {
-      if (inputValue !== searchQuery) {
+      if (inputValue === '' || result.success) {
         setSearchQuery(inputValue);
       }
     }, 500);
@@ -217,7 +207,7 @@ const useSearchPage = (
     return () => clearTimeout(delayDebounce);
 
     // debounce 효과를 위해 searchQuery 의존성에서 제외 (불필요한 재실행 방지)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [inputValue, setSearchQuery]);
 
   const handleTypeFilterChange = (value: 'all' | 'groupEat' | 'groupBuy') => {
@@ -276,6 +266,7 @@ const useSearchPage = (
     inputValue,
     handleSearchQueryChange,
     isSearchPending,
+    searchError,
   };
 };
 

--- a/src/widgets/search/ui/search-bar/search-bar.test.tsx
+++ b/src/widgets/search/ui/search-bar/search-bar.test.tsx
@@ -56,4 +56,16 @@ describe('SearchBar', () => {
     expect(onChangeSpy).toHaveBeenCalled();
     expect(onChangeSpy).toHaveBeenLastCalledWith('테스트');
   });
+
+  it('error prop이 있으면 에러 메시지가 표시된다', () => {
+    render(<SearchBar value="" onChange={() => {}} error="2글자 이상 입력해주세요" />);
+
+    expect(screen.getByText('2글자 이상 입력해주세요')).toBeInTheDocument();
+  });
+
+  it('error prop이 없으면 에러 메시지가 표시되지 않는다', () => {
+    render(<SearchBar value="" onChange={() => {}} />);
+
+    expect(screen.queryByText('2글자 이상 입력해주세요')).not.toBeInTheDocument();
+  });
 });

--- a/src/widgets/search/ui/search-bar/search-bar.tsx
+++ b/src/widgets/search/ui/search-bar/search-bar.tsx
@@ -25,6 +25,7 @@ export const SearchBar = ({
   value,
   onChange,
   placeholder = '모임 검색 (제목, 태그, 지역 등)',
+  error,
   className,
 }: SearchBarProps) => {
   return (
@@ -45,6 +46,7 @@ export const SearchBar = ({
           aria-label={placeholder}
         />
       </div>
+      {error && <p className="mt-1 pl-10 text-xs text-red-400/70">{error}</p>}
     </div>
   );
 };

--- a/src/widgets/search/ui/search-bar/search-bar.types.ts
+++ b/src/widgets/search/ui/search-bar/search-bar.types.ts
@@ -4,4 +4,5 @@ export interface SearchBarProps {
   placeholder?: string;
   /** 루트 컨테이너에 합쳐진다 */
   className?: string;
+  error?: string;
 }

--- a/src/widgets/search/ui/search-page/search-page.tsx
+++ b/src/widgets/search/ui/search-page/search-page.tsx
@@ -53,6 +53,7 @@ export default function SearchPage({
     fetchNextPage,
     inputValue,
     handleSearchQueryChange,
+    searchError,
   } = useSearchPage(initialData, initialDefaultDateStartIso);
 
   useEffect(() => {
@@ -64,7 +65,7 @@ export default function SearchPage({
   return (
     <div className="w-full max-w-[1140px]">
       <div className="flex w-full flex-col gap-4 px-4 md:px-0">
-        <SearchBar onChange={handleSearchQueryChange} value={inputValue} />
+        <SearchBar onChange={handleSearchQueryChange} value={inputValue} error={searchError} />
         <MeetingFilterBar
           sortBy={sortBy}
           sortOrder={sortOrder}


### PR DESCRIPTION
## PR 제목: [Feat]: 검색어 최소 2글자 Zod 유효성 검사 추가

### 📌 유형 (Type)

- [x] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

- #417 검색어 1글자 입력 시 API가 호출되어 불필요한 요청이 발생하는 문제 개선
- `use-search-page.ts`에 `z.string().min(2)` Zod 스키마 적용 — 1글자 입력 시 debounce 후에도 `setSearchQuery` 실행 안 함
- `SearchBar`에 `error?: string` prop 추가 — 1글자 입력 시 "2글자 이상 입력해주세요" 메시지 인라인 표시
- 0글자(전체 삭제) 시 에러 없이 검색 초기화 유지
- 기존 `fallbackDefaultDateStartIsoRef` ref 패턴을 `useState` lazy initializer로 교체 (React ref lint 규칙 대응)

### 🧪 테스트 방법 (How to Test)

1. 개발 서버 실행 후 `/search` 페이지 접속
2. 검색창에 글자 1개 입력 → "2글자 이상 입력해주세요" 메시지 표시 확인
3. 글자 2개 이상 입력 → 에러 메시지 사라지고 검색 실행 확인
4. 전체 삭제(0글자) → 에러 메시지 없음 확인

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|  (첨부 예정)  |  (첨부 예정)  |

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**