### PR TITLE
 [Bug]: 마이페이지 탭에서 하트 버튼 클릭 시 버그 발생 

### DIFF
--- a/src/entities/favorites/api/favorites.api.ts
+++ b/src/entities/favorites/api/favorites.api.ts
@@ -4,11 +4,25 @@ import { FavoriteList } from '@/shared/types/generated-client';
 
 export const favoritesApi = {
   async fetchList(): Promise<FavoriteList> {
-    const res = await fetchClient.get('/favorites');
-    return parseResponse<FavoriteList>(
-      res,
-      '찜 목록을 불러오는 중 문제가 생겼어요. 다시 시도해 주세요.'
-    );
+    const allData: FavoriteList['data'] = [];
+    let cursor: string | undefined;
+    let pageCount = 0;
+    const MAX_PAGES = 50;
+
+    while (pageCount < MAX_PAGES) {
+      const url = cursor ? `/favorites?cursor=${cursor}` : '/favorites';
+      const res = await fetchClient.get(url);
+      const page = await parseResponse<FavoriteList>(
+        res,
+        '찜 목록을 불러오는 중 문제가 생겼어요. 다시 시도해 주세요.'
+      );
+      allData.push(...page.data);
+      pageCount++;
+      if (!page.hasMore) break;
+      cursor = page.nextCursor;
+    }
+
+    return { data: allData, nextCursor: '', hasMore: false };
   },
 
   async favoritePost(meetingId: number): Promise<void> {

--- a/src/entities/favorites/api/favorites.api.ts
+++ b/src/entities/favorites/api/favorites.api.ts
@@ -9,8 +9,8 @@ export const favoritesApi = {
     let pageCount = 0;
     const MAX_PAGES = 50;
 
-    while (pageCount < MAX_PAGES) {
-      const url = cursor ? `/favorites?cursor=${cursor}` : '/favorites';
+    while (true) {
+      const url = cursor ? `/favorites?cursor=${encodeURIComponent(cursor)}` : '/favorites';
       const res = await fetchClient.get(url);
       const page = await parseResponse<FavoriteList>(
         res,
@@ -18,7 +18,7 @@ export const favoritesApi = {
       );
       allData.push(...page.data);
       pageCount++;
-      if (!page.hasMore) break;
+      if (!page.hasMore || !page.nextCursor || pageCount >= MAX_PAGES) break;
       cursor = page.nextCursor;
     }
 

--- a/src/features/favorites/model/favorites.mutations.ts
+++ b/src/features/favorites/model/favorites.mutations.ts
@@ -16,7 +16,10 @@ export const useToggleFavorite = () => {
     mutationFn: ({ meetingId, isFavorited }: { meetingId: number; isFavorited: boolean }) =>
       isFavorited ? favoritesApi.favoritePost(meetingId) : favoritesApi.favoriteDelete(meetingId),
     onMutate: async ({ meetingId, isFavorited }) => {
-      await queryClient.cancelQueries({ queryKey: favoriteKeys.count() });
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: favoriteKeys.count() }),
+        queryClient.cancelQueries({ queryKey: favoriteKeys.list() }),
+      ]);
       const previousCount = queryClient.getQueryData<number>(favoriteKeys.count());
       queryClient.setQueryData(favoriteKeys.count(), (prev: number = 0) =>
         isFavorited ? prev + 1 : Math.max(0, prev - 1)
@@ -25,6 +28,7 @@ export const useToggleFavorite = () => {
     },
     onError: (_err, _vars, context) => {
       queryClient.setQueryData(favoriteKeys.count(), context?.previousCount);
+      queryClient.invalidateQueries({ queryKey: favoriteKeys.list() });
     },
     onSuccess: () => {
       return Promise.all([
@@ -85,6 +89,7 @@ export const useFavoriteMeeting = (initialIsFavorited: boolean, meetingId: numbe
         },
         onError: () => {
           isPendingRef.current = false;
+          hasUserInteractedRef.current = false;
           queryClient.setQueryData(favoriteKeys.status(meetingId), committedRef.current);
         },
       }

--- a/src/widgets/mypage/api/mypage.api.ts
+++ b/src/widgets/mypage/api/mypage.api.ts
@@ -11,14 +11,20 @@ export type UserMeetingsResponseWithImage = Omit<UserMeetingsResponse, 'data'> &
 };
 
 export const mypageApi = {
-  fetchJoinedMeetings: async (): Promise<UserMeetingsResponse> => {
-    const res = await fetchClient.get('/users/me/meetings?type=joined');
+  fetchJoinedMeetings: async (cursor?: string): Promise<UserMeetingsResponseWithImage> => {
+    const url = cursor
+      ? `/users/me/meetings?type=joined&cursor=${encodeURIComponent(cursor)}`
+      : '/users/me/meetings?type=joined';
+    const res = await fetchClient.get(url);
     if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
     return res.json();
   },
 
-  fetchCreatedMeetings: async (): Promise<UserMeetingsResponseWithImage> => {
-    const res = await fetchClient.get('/users/me/meetings?type=created');
+  fetchCreatedMeetings: async (cursor?: string): Promise<UserMeetingsResponseWithImage> => {
+    const url = cursor
+      ? `/users/me/meetings?type=created&cursor=${encodeURIComponent(cursor)}`
+      : '/users/me/meetings?type=created';
+    const res = await fetchClient.get(url);
     if (!res.ok) return { data: [], nextCursor: '', hasMore: false };
     return res.json();
   },

--- a/src/widgets/mypage/model/mypage.constants.ts
+++ b/src/widgets/mypage/model/mypage.constants.ts
@@ -1,6 +1,7 @@
 import type { TabList } from './mypage.types';
 
 export const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
+export const TEN_MINUTES_IN_MS = 1000 * 60 * 10;
 
 export const MYPAGE_TABS: TabList[] = [
   { value: 'all', label: '나의 모임' },

--- a/src/widgets/mypage/model/mypage.queries.ts
+++ b/src/widgets/mypage/model/mypage.queries.ts
@@ -1,24 +1,30 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { useFavoriteList } from '@/entities/favorites';
 import { meetingKeys } from '@/entities/meeting';
 
 import { mypageApi } from '../api/mypage.api';
 
-import { FIVE_MINUTES_IN_MS } from './mypage.constants';
+import { FIVE_MINUTES_IN_MS, TEN_MINUTES_IN_MS } from './mypage.constants';
 
 export const useJoinedMeetings = () =>
-  useQuery({
+  useInfiniteQuery({
     queryKey: meetingKeys.joined(),
-    queryFn: mypageApi.fetchJoinedMeetings,
+    queryFn: ({ pageParam }) => mypageApi.fetchJoinedMeetings(pageParam),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextCursor : undefined),
     staleTime: FIVE_MINUTES_IN_MS,
+    gcTime: TEN_MINUTES_IN_MS,
   });
 
 export const useCreatedMeetings = () =>
-  useQuery({
+  useInfiniteQuery({
     queryKey: meetingKeys.my(),
-    queryFn: mypageApi.fetchCreatedMeetings,
+    queryFn: ({ pageParam }) => mypageApi.fetchCreatedMeetings(pageParam),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextCursor : undefined),
     staleTime: FIVE_MINUTES_IN_MS,
+    gcTime: TEN_MINUTES_IN_MS,
   });
 
 export { useFavoriteList as useFavoriteMeetings };

--- a/src/widgets/mypage/model/use-meeting-tabs.ts
+++ b/src/widgets/mypage/model/use-meeting-tabs.ts
@@ -13,11 +13,20 @@ export function useMeetingTabs(activeTab: TabValue) {
 
   const cards = useMemo(() => {
     const favoritedIds = new Set(favoriteQuery.data?.data.map((f) => f.meeting.id) ?? []);
+
     if (activeTab === 'all' && joinedQuery.data) {
-      return toUserMeetingCards(joinedQuery.data, favoritedIds);
+      const allMeetings = joinedQuery.data.pages.flatMap((page) => page.data);
+      return toUserMeetingCards(
+        { data: allMeetings, nextCursor: '', hasMore: false },
+        favoritedIds
+      );
     }
     if (activeTab === 'created' && createdQuery.data) {
-      return toUserMeetingCards(createdQuery.data, favoritedIds);
+      const allMeetings = createdQuery.data.pages.flatMap((page) => page.data);
+      return toUserMeetingCards(
+        { data: allMeetings, nextCursor: '', hasMore: false },
+        favoritedIds
+      );
     }
     if (activeTab === 'favorite' && favoriteQuery.data) {
       return toFavoriteMeetingCards(favoriteQuery.data);
@@ -30,5 +39,24 @@ export function useMeetingTabs(activeTab: TabValue) {
     (activeTab === 'created' && createdQuery.isLoading) ||
     (activeTab === 'favorite' && favoriteQuery.isLoading);
 
-  return { cards, isLoading };
+  const hasNextPage =
+    activeTab === 'all'
+      ? (joinedQuery.hasNextPage ?? false)
+      : activeTab === 'created'
+        ? (createdQuery.hasNextPage ?? false)
+        : false;
+
+  const isFetchingNextPage =
+    activeTab === 'all'
+      ? joinedQuery.isFetchingNextPage
+      : activeTab === 'created'
+        ? createdQuery.isFetchingNextPage
+        : false;
+
+  const fetchNextPage = () => {
+    if (activeTab === 'all') joinedQuery.fetchNextPage();
+    else if (activeTab === 'created') createdQuery.fetchNextPage();
+  };
+
+  return { cards, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage };
 }

--- a/src/widgets/mypage/ui/count-card/count-card.tsx
+++ b/src/widgets/mypage/ui/count-card/count-card.tsx
@@ -6,8 +6,6 @@ import { useFavoritesCount } from '@/entities/favorites';
 import { cn } from '@/shared/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
 
-import { useJoinedMeetings } from '../../model/mypage.queries';
-
 import { CountCardProps } from './count-card.types';
 import { cardVariants, countVariants } from './count-card.variants';
 
@@ -50,9 +48,7 @@ export function FavoriteCountCard({ initialCount }: { initialCount: number }) {
 }
 
 export function MeetingCountCard({ initialCount }: { initialCount: number }) {
-  const { data } = useJoinedMeetings();
-  const count = data?.data.length ?? initialCount;
-  return <CountCard variant="meeting" count={count} href="/mypage?tab=all" />;
+  return <CountCard variant="meeting" count={initialCount} href="/mypage?tab=all" />;
 }
 
 export function PostCountCard({ initialCount }: { initialCount: number }) {

--- a/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
+++ b/src/widgets/mypage/ui/meeting-tabs/meeting-tabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -39,9 +39,31 @@ export function MeetingTabs() {
     });
   };
 
-  const { cards: fetchedCards, isLoading } = useMeetingTabs(activeTab);
+  const {
+    cards: fetchedCards,
+    isLoading,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useMeetingTabs(activeTab);
 
   const cards = fetchedCards ?? [];
+
+  const observerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = observerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, activeTab]);
 
   return (
     <Tabs
@@ -64,6 +86,14 @@ export function MeetingTabs() {
               {cards.map((card) => (
                 <MyPageCard key={card.meetingId} {...card} href={`/meetings/${card.meetingId}`} />
               ))}
+            </div>
+          )}
+
+          {tab.value === activeTab && (
+            <div ref={observerRef} className="py-2">
+              {isFetchingNextPage && (
+                <p className="py-4 text-center text-sm text-gray-400">불러오는 중...</p>
+              )}
             </div>
           )}
         </TabsContent>


### PR DESCRIPTION
## [Bug]: 마이페이지 탭에서 하트 버튼 클릭 시 버그 발생 

### 📌 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

**버그 수정**

- 찜 목록 API가 첫 페이지만 반환해 오래된 찜 항목이 isFavorited: false로 표시되던 문제를 수정했습니다. fetchList()에서 hasMore가 false가 될 때까지 전체 페이지를 순회하도록 변경했습니다.
- 하트 API 에러(409 등) 발생 시 favoriteKeys.list() invalidate와 hasUserInteractedRef 초기화가 누락되어 카드 상태가 고정되던 문제를 수정했습니다.
- onMutate에서 진행 중인 favoriteKeys.list() 쿼리를 취소하지 않아 낙관적 UI가 덮어씌워지던 문제를 수정했습니다.


### 🧪 테스트 방법 (How to Test)

1. npm run dev 후 마이페이지로 진입합니다.
2. 전체/내가 만든 모임 탭 — 스크롤을 내려 다음 페이지가 자동으로 로드되는지 확인합니다.
3. 오래 전에 찜한 모임이 포함된 탭에서 하트 버튼이 올바르게 채워져 있는지 확인합니다.
4. 하트 버튼 클릭 후 409 에러 없이 정상 토글되는지 확인합니다.
5. 하트 해제 후 해당 카드의 상태가 올바르게 복구되는지 확인합니다.

### 🚨 기타 참고 사항 (Notes)

- [ ] 찜한 모임 탭은 favoritedIds 구성을 위해 전체 데이터를 로드하므로 무한스크롤 미적용입니다.
