### PR TITLE
[Fix]: 비로그인 사용자의 소소톡 작성 접근을 로그인 모달로 가드

### DIFF
--- a/src/entities/auth/model/auth-store.ts
+++ b/src/entities/auth/model/auth-store.ts
@@ -69,10 +69,10 @@ export const useAuthStore = create<AuthStore>()((set) => ({
 
   setInitialized: (val: boolean) => set({ isInitialized: val }),
   setLoginRequired: (val: boolean) =>
-    set({
+    set((state) => ({
       isLoginRequired: val,
-      loginRequiredCallbackUrl: val ? useAuthStore.getState().loginRequiredCallbackUrl : null,
-    }),
+      loginRequiredCallbackUrl: val ? state.loginRequiredCallbackUrl : null,
+    })),
   openLoginRequired: (callbackUrl?: string) =>
     set({
       isLoginRequired: true,

--- a/src/entities/auth/model/auth-store.ts
+++ b/src/entities/auth/model/auth-store.ts
@@ -7,6 +7,7 @@ interface AuthState {
   user: AuthUser | null;
   isInitialized: boolean;
   isLoginRequired: boolean;
+  loginRequiredCallbackUrl: string | null;
   isSessionExpired: boolean;
 }
 
@@ -16,6 +17,7 @@ interface AuthActions {
   initialize: (user: AuthUser | null) => void;
   setInitialized: (val: boolean) => void;
   setLoginRequired: (val: boolean) => void;
+  openLoginRequired: (callbackUrl?: string) => void;
   setSessionExpired: (val: boolean) => void;
   /**
    * 401 응답 시 인증 상태에 따라 세션만료(로그인) 또는 로그인필요 모달을 띄웁니다.
@@ -36,6 +38,7 @@ export const useAuthStore = create<AuthStore>()((set) => ({
   user: null,
   isInitialized: false,
   isLoginRequired: false,
+  loginRequiredCallbackUrl: null,
   isSessionExpired: false,
 
   // Actions
@@ -47,7 +50,13 @@ export const useAuthStore = create<AuthStore>()((set) => ({
   },
 
   logout: () => {
-    set({ isAuthenticated: false, user: null, isLoginRequired: false, isSessionExpired: false });
+    set({
+      isAuthenticated: false,
+      user: null,
+      isLoginRequired: false,
+      loginRequiredCallbackUrl: null,
+      isSessionExpired: false,
+    });
   },
 
   initialize: (user: AuthUser | null) => {
@@ -59,7 +68,16 @@ export const useAuthStore = create<AuthStore>()((set) => ({
   },
 
   setInitialized: (val: boolean) => set({ isInitialized: val }),
-  setLoginRequired: (val: boolean) => set({ isLoginRequired: val }),
+  setLoginRequired: (val: boolean) =>
+    set({
+      isLoginRequired: val,
+      loginRequiredCallbackUrl: val ? useAuthStore.getState().loginRequiredCallbackUrl : null,
+    }),
+  openLoginRequired: (callbackUrl?: string) =>
+    set({
+      isLoginRequired: true,
+      loginRequiredCallbackUrl: callbackUrl ?? null,
+    }),
   setSessionExpired: (val: boolean) => set({ isSessionExpired: val }),
 
   handleAuthError: () => {
@@ -67,7 +85,7 @@ export const useAuthStore = create<AuthStore>()((set) => ({
     if (state.isAuthenticated) {
       set({ isSessionExpired: true });
     } else {
-      set({ isLoginRequired: true });
+      set({ isLoginRequired: true, loginRequiredCallbackUrl: null });
     }
   },
 }));

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment node */
+
+import { NextRequest } from 'next/server';
+
+import { config, proxy } from './proxy';
+
+describe('proxy', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('redirects unauthenticated users away from the sosotalk write page', async () => {
+    const request = new NextRequest('http://localhost:3000/sosotalk/write');
+
+    const response = await proxy(request);
+
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/login?callbackUrl=%2Fsosotalk%2Fwrite'
+    );
+  });
+
+  it('preserves query params in callbackUrl for sosotalk edit routes', async () => {
+    const request = new NextRequest('http://localhost:3000/sosotalk/write?postId=12');
+
+    const response = await proxy(request);
+
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/login?callbackUrl=%2Fsosotalk%2Fwrite%3FpostId%3D12'
+    );
+  });
+
+  it('refreshes access tokens for sosotalk write routes when only a refresh token exists', async () => {
+    const request = new NextRequest('http://localhost:3000/sosotalk/write', {
+      headers: {
+        cookie: 'refreshToken=refresh-token',
+      },
+    });
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      headers: {
+        getSetCookie: () => ['accessToken=renewed-token; Path=/; HttpOnly'],
+      },
+    } as Response);
+
+    const response = await proxy(request);
+
+    expect(fetchSpy).toHaveBeenCalledWith(new URL('/api/auth/refresh', request.url), {
+      method: 'POST',
+      headers: { cookie: 'refreshToken=refresh-token' },
+    });
+    expect(response.headers.get('set-cookie')).toContain('accessToken=renewed-token');
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('includes sosotalk write routes in the matcher config', () => {
+    expect(config.matcher).toEqual(['/mypage/:path*', '/sosotalk/write', '/sosotalk/write/:path*']);
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,8 +8,9 @@ import { NextResponse } from 'next/server';
  * accessToken이 없으면 /api/auth/refresh를 호출하여 갱신합니다.
  */
 export async function proxy(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-  const isProtectedRoute = pathname.startsWith('/mypage');
+  const { pathname, search } = request.nextUrl;
+  const callbackUrl = encodeURIComponent(`${pathname}${search}`);
+  const isProtectedRoute = pathname.startsWith('/mypage') || pathname.startsWith('/sosotalk/write');
 
   if (!isProtectedRoute) {
     return NextResponse.next();
@@ -17,7 +18,6 @@ export async function proxy(request: NextRequest) {
 
   const hasRefreshToken = request.cookies.has('refreshToken');
   if (!hasRefreshToken) {
-    const callbackUrl = encodeURIComponent(pathname);
     return NextResponse.redirect(new URL(`/login?callbackUrl=${callbackUrl}`, request.url));
   }
 
@@ -33,7 +33,6 @@ export async function proxy(request: NextRequest) {
   });
 
   if (!refreshRes.ok) {
-    const callbackUrl = encodeURIComponent(pathname);
     return NextResponse.redirect(new URL(`/login?callbackUrl=${callbackUrl}`, request.url));
   }
 
@@ -46,5 +45,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/mypage/:path*'],
+  matcher: ['/mypage/:path*', '/sosotalk/write', '/sosotalk/write/:path*'],
 };

--- a/src/widgets/auth/login-require-modal/login-require-modal.tsx
+++ b/src/widgets/auth/login-require-modal/login-require-modal.tsx
@@ -8,11 +8,12 @@ import { AlertModal } from '@/shared/ui/alert-modal/alert-modal';
 export const LoginRequireModal = () => {
   const router = useRouter();
   const pathname = usePathname();
-  const { isLoginRequired, setLoginRequired } = useAuthStore();
+  const { isLoginRequired, loginRequiredCallbackUrl, setLoginRequired } = useAuthStore();
 
   const handleConfirm = () => {
     setLoginRequired(false);
-    router.push(`/login?callbackUrl=${encodeURIComponent(pathname ?? '')}`);
+    const callbackUrl = loginRequiredCallbackUrl ?? pathname ?? '';
+    router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   };
 
   const handleCancel = () => {

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { SosoTalkMainPage } from './sosotalk-main-page';
 
 const mockUseSosoTalkMainPage = jest.fn();
 const mockFilterBar = jest.fn();
+const mockOpenLoginRequired = jest.fn();
 
 jest.mock('react-intersection-observer', () => ({
   useInView: () => ({
@@ -50,8 +52,10 @@ describe('SosoTalkMainPage', () => {
       selector({
         isAuthenticated: true,
         isInitialized: true,
+        openLoginRequired: mockOpenLoginRequired,
       })
     );
+    mockOpenLoginRequired.mockClear();
     mockUseSosoTalkMainPage.mockReturnValue({
       activeSort: 'latest',
       activeTab: 'all',
@@ -185,19 +189,21 @@ describe('SosoTalkMainPage', () => {
 
     expect(screen.getByText('모든 게시글을 불러왔어요.')).toBeInTheDocument();
   });
-  it('redirects unauthenticated users to login from the write button', () => {
+
+  it('비로그인 사용자가 작성 버튼을 누르면 로그인 유도 모달을 연다', async () => {
+    const user = userEvent.setup();
     mockUseAuthStore.mockImplementation((selector: (state: unknown) => unknown) =>
       selector({
         isAuthenticated: false,
         isInitialized: true,
+        openLoginRequired: mockOpenLoginRequired,
       })
     );
 
     render(<SosoTalkMainPage />);
 
-    expect(screen.getByRole('link', { name: '게시글 작성' })).toHaveAttribute(
-      'href',
-      '/login?callbackUrl=%2Fsosotalk%2Fwrite'
-    );
+    await user.click(screen.getByRole('button', { name: '게시글 작성' }));
+
+    expect(mockOpenLoginRequired).toHaveBeenCalledWith('/sosotalk/write');
   });
 });

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx
@@ -16,6 +16,14 @@ jest.mock('./model', () => ({
   useSosoTalkMainPage: () => mockUseSosoTalkMainPage(),
 }));
 
+jest.mock('@/entities/auth', () => ({
+  useAuthStore: jest.fn(),
+}));
+
+const { useAuthStore: mockUseAuthStore } = jest.requireMock('@/entities/auth') as {
+  useAuthStore: jest.Mock;
+};
+
 jest.mock('../sosotalk-banner', () => ({
   SosoTalkBanner: (props: Record<string, unknown>) => (
     <div data-testid="sosotalk-banner">{String(props.alt)}</div>
@@ -38,6 +46,12 @@ jest.mock('../sosotalk-filter-bar', () => ({
 
 describe('SosoTalkMainPage', () => {
   beforeEach(() => {
+    mockUseAuthStore.mockImplementation((selector: (state: unknown) => unknown) =>
+      selector({
+        isAuthenticated: true,
+        isInitialized: true,
+      })
+    );
     mockUseSosoTalkMainPage.mockReturnValue({
       activeSort: 'latest',
       activeTab: 'all',
@@ -170,5 +184,20 @@ describe('SosoTalkMainPage', () => {
     render(<SosoTalkMainPage />);
 
     expect(screen.getByText('모든 게시글을 불러왔어요.')).toBeInTheDocument();
+  });
+  it('redirects unauthenticated users to login from the write button', () => {
+    mockUseAuthStore.mockImplementation((selector: (state: unknown) => unknown) =>
+      selector({
+        isAuthenticated: false,
+        isInitialized: true,
+      })
+    );
+
+    render(<SosoTalkMainPage />);
+
+    expect(screen.getByRole('link', { name: '게시글 작성' })).toHaveAttribute(
+      'href',
+      '/login?callbackUrl=%2Fsosotalk%2Fwrite'
+    );
   });
 });

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
@@ -28,7 +28,6 @@ interface SosoTalkMainPageProps {
 const SOSOTALK_BANNER_IMAGE =
   'https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=1600&auto=format&fit=crop';
 const SOSOTALK_WRITE_PATH = '/sosotalk/write';
-const SOSOTALK_WRITE_LOGIN_PATH = `/login?callbackUrl=${encodeURIComponent(SOSOTALK_WRITE_PATH)}`;
 
 export const SosoTalkMainPage = ({
   className,
@@ -38,6 +37,7 @@ export const SosoTalkMainPage = ({
 }: SosoTalkMainPageProps) => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const isInitialized = useAuthStore((state) => state.isInitialized);
+  const openLoginRequired = useAuthStore((state) => state.openLoginRequired);
   const { ref, inView } = useInView({
     threshold: 0.5,
     root: null,
@@ -54,8 +54,7 @@ export const SosoTalkMainPage = ({
     setActiveSort,
     setActiveTab,
   } = useSosoTalkMainPage({ initialData, initialTab, initialSort });
-  const writeHref =
-    !isInitialized || isAuthenticated ? SOSOTALK_WRITE_PATH : SOSOTALK_WRITE_LOGIN_PATH;
+  const shouldRenderWriteLink = !isInitialized || isAuthenticated;
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
@@ -127,19 +126,33 @@ export const SosoTalkMainPage = ({
         </div>
       </main>
 
-      <Button
-        asChild
-        variant="ghost"
-        className={cn(
-          'bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 fixed right-5 bottom-[calc(20px+env(safe-area-inset-bottom))] z-50 h-14 rounded-full px-5 text-base font-bold text-white shadow-lg hover:text-white',
-          'md:right-8 md:bottom-8 md:h-16 md:px-7 md:text-lg'
-        )}
-      >
-        <Link href={writeHref}>
+      {shouldRenderWriteLink ? (
+        <Button
+          asChild
+          variant="ghost"
+          className={cn(
+            'bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 fixed right-5 bottom-[calc(20px+env(safe-area-inset-bottom))] z-50 h-14 rounded-full px-5 text-base font-bold text-white shadow-lg hover:text-white',
+            'md:right-8 md:bottom-8 md:h-16 md:px-7 md:text-lg'
+          )}
+        >
+          <Link href={SOSOTALK_WRITE_PATH}>
+            <Plus className="size-5" aria-hidden />
+            게시글 작성
+          </Link>
+        </Button>
+      ) : (
+        <Button
+          variant="ghost"
+          className={cn(
+            'bg-sosoeat-orange-600 hover:bg-sosoeat-orange-700 fixed right-5 bottom-[calc(20px+env(safe-area-inset-bottom))] z-50 h-14 rounded-full px-5 text-base font-bold text-white shadow-lg hover:text-white',
+            'md:right-8 md:bottom-8 md:h-16 md:px-7 md:text-lg'
+          )}
+          onClick={() => openLoginRequired(SOSOTALK_WRITE_PATH)}
+        >
           <Plus className="size-5" aria-hidden />
           게시글 작성
-        </Link>
-      </Button>
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 
 import { Plus } from 'lucide-react';
 
+import { useAuthStore } from '@/entities/auth';
 import type { GetSosoTalkPostListResponse } from '@/entities/post';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
@@ -26,6 +27,8 @@ interface SosoTalkMainPageProps {
 
 const SOSOTALK_BANNER_IMAGE =
   'https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=1600&auto=format&fit=crop';
+const SOSOTALK_WRITE_PATH = '/sosotalk/write';
+const SOSOTALK_WRITE_LOGIN_PATH = `/login?callbackUrl=${encodeURIComponent(SOSOTALK_WRITE_PATH)}`;
 
 export const SosoTalkMainPage = ({
   className,
@@ -33,6 +36,8 @@ export const SosoTalkMainPage = ({
   initialTab,
   initialSort,
 }: SosoTalkMainPageProps) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const isInitialized = useAuthStore((state) => state.isInitialized);
   const { ref, inView } = useInView({
     threshold: 0.5,
     root: null,
@@ -49,6 +54,8 @@ export const SosoTalkMainPage = ({
     setActiveSort,
     setActiveTab,
   } = useSosoTalkMainPage({ initialData, initialTab, initialSort });
+  const writeHref =
+    !isInitialized || isAuthenticated ? SOSOTALK_WRITE_PATH : SOSOTALK_WRITE_LOGIN_PATH;
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
@@ -128,7 +135,7 @@ export const SosoTalkMainPage = ({
           'md:right-8 md:bottom-8 md:h-16 md:px-7 md:text-lg'
         )}
       >
-        <Link href="/sosotalk/write">
+        <Link href={writeHref}>
           <Plus className="size-5" aria-hidden />
           게시글 작성
         </Link>


### PR DESCRIPTION
## PR 제목: [Fix]: 비로그인 사용자의 소소톡 작성 접근을 로그인 모달로 가드

### ✅ 유형 (Type)

다음 중 PR의 성격에 해당하는 항목에 `[x]`를 표시해주세요.

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 정리 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 테스트, 라이브러리 업데이트, 설정 등

### 🔷 변경 사항 (Changes)

- 비로그인 상태에서 주소창으로 `/sosotalk/write` 또는 `/sosotalk/write?postId=...`에 직접 접근해도 작성 페이지로 진입되던 문제를 수정했습니다.
- `proxy.ts`에서 소소톡 작성 경로를 보호 라우트에 포함해, 비로그인 사용자는 `/login?callbackUrl=...`로 리다이렉트되도록 변경했습니다.
- 소소톡 메인 우측 하단 `게시글 작성` 버튼은 비로그인 시 즉시 로그인 페이지로 이동하지 않고, 기존 게시글 액션과 동일하게 로그인 유도 모달을 먼저 띄우도록 변경했습니다.
- 로그인 유도 모달 확인 시 `/sosotalk/write`를 callbackUrl로 넘길 수 있도록 인증 스토어와 모달 로직을 보완했습니다.

### 🧪 테스트 방법 (How to Test)

1. 로그아웃 상태에서 `/sosotalk` 페이지로 이동합니다.
2. 우측 하단 `게시글 작성` 버튼을 클릭합니다.
3. 로그인 유도 모달이 먼저 노출되는지 확인합니다.
4. 모달에서 확인을 누르면 로그인 페이지로 이동하는지 확인합니다.
5. 로그인 후 소소톡 작성 페이지(`/sosotalk/write`)로 정상 복귀하는지 확인합니다.
6. 로그아웃 상태에서 주소창에 `/sosotalk/write` 또는 `/sosotalk/write?postId=12`를 직접 입력합니다.
7. 로그인 페이지로 리다이렉트되고 callbackUrl이 유지되는지 확인합니다.

> 추가 검증
>
> - `npm run type-check`
> - `npm test -- --runInBand src/widgets/sosotalk/ui/sosotalk-main-page/sosotalk-main-page.test.tsx src/proxy.test.ts`

### 📸 스크린샷 또는 영상 (Optional)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
| 비로그인 상태에서도 작성 페이지 직접 진입 가능 | 비로그인 시 로그인 페이지로 리다이렉트 |
| 작성 버튼 클릭 시 즉시 로그인 이동 | 작성 버튼 클릭 시 로그인 유도 모달 노출 |

### 💬 기타 참고 사항 (Notes)

- [x] **코드 리뷰 시 함께 확인이 필요한 부분이 있다면 명시해주세요.**
- 로그인 유도 모달에 callbackUrl을 지정할 수 있도록 인증 스토어 상태를 확장했습니다.
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**
