### PR TITLE
[Refactor]: 홈·검색 페이지 Suspense 스트리밍 적용 및 Pretendard 폰트 로컬화

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,7 +4,9 @@ import type { Metadata } from 'next';
 
 import { SearchParams } from 'nuqs';
 
-import { MeetingSearchBanner, SearchScreenFetcher, SearchScreenSkeleton } from '@/widgets/search';
+import { MeetingSearchBanner, SearchScreenSkeleton } from '@/widgets/search';
+
+import { SearchScreenFetcher } from './search-screen-fetcher.server';
 
 export const metadata: Metadata = {
   title: '모임 검색',

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,10 +1,12 @@
+import { Suspense } from 'react';
+
 import type { Metadata } from 'next';
 
 import { SearchParams } from 'nuqs';
 
 import { getMeetingSearchParams } from '@/features/search';
 import { getInitialSearchData } from '@/features/search/index.server';
-import { MeetingSearchBanner, SearchScreen } from '@/widgets/search';
+import { MeetingSearchBanner , SearchScreenFetcher , SearchScreenSkeleton } from '@/widgets/search';
 
 export const metadata: Metadata = {
   title: '모임 검색',
@@ -44,7 +46,7 @@ type PageProps = {
 
 export default async function Page({ searchParams }: PageProps) {
   const requestParams = await getMeetingSearchParams(searchParams);
-  const initialData = await getInitialSearchData(requestParams);
+  const initialData = getInitialSearchData(requestParams);
 
   return (
     <div className="bg-sosoeat-gray-100 flex w-full flex-col items-center justify-center">
@@ -55,10 +57,9 @@ export default async function Page({ searchParams }: PageProps) {
         aria-label="search-results"
         className="flex w-full flex-col items-center justify-center gap-4 px-4 pt-4"
       >
-        <SearchScreen
-          initialData={initialData}
-          initialDefaultDateStartIso={requestParams.dateStart}
-        />
+        <Suspense fallback={<SearchScreenSkeleton />}>
+          <SearchScreenFetcher initialData={initialData} />
+        </Suspense>
       </section>
     </div>
   );

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,9 +4,7 @@ import type { Metadata } from 'next';
 
 import { SearchParams } from 'nuqs';
 
-import { getMeetingSearchParams } from '@/features/search';
-import { getInitialSearchData } from '@/features/search/index.server';
-import { MeetingSearchBanner , SearchScreenFetcher , SearchScreenSkeleton } from '@/widgets/search';
+import { MeetingSearchBanner, SearchScreenFetcher, SearchScreenSkeleton } from '@/widgets/search';
 
 export const metadata: Metadata = {
   title: '모임 검색',
@@ -45,9 +43,6 @@ type PageProps = {
 };
 
 export default async function Page({ searchParams }: PageProps) {
-  const requestParams = await getMeetingSearchParams(searchParams);
-  const initialData = getInitialSearchData(requestParams);
-
   return (
     <div className="bg-sosoeat-gray-100 flex w-full flex-col items-center justify-center">
       <section aria-label="search-banner" className="w-full">
@@ -58,7 +53,7 @@ export default async function Page({ searchParams }: PageProps) {
         className="flex w-full flex-col items-center justify-center gap-4 px-4 pt-4"
       >
         <Suspense fallback={<SearchScreenSkeleton />}>
-          <SearchScreenFetcher initialData={initialData} />
+          <SearchScreenFetcher searchParams={searchParams} />
         </Suspense>
       </section>
     </div>

--- a/src/app/search/search-screen-fetcher.server.tsx
+++ b/src/app/search/search-screen-fetcher.server.tsx
@@ -2,8 +2,7 @@ import { SearchParams } from 'nuqs';
 
 import { getMeetingSearchParams } from '@/features/search';
 import { getInitialSearchData } from '@/features/search/index.server';
-
-import { SearchScreen } from './search-screen';
+import { SearchScreen } from '@/widgets/search';
 
 export const SearchScreenFetcher = async ({
   searchParams,

--- a/src/features/search/model/use-search-state.ts
+++ b/src/features/search/model/use-search-state.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { startOfDay, startOfMinute } from 'date-fns';
 import {

--- a/src/widgets/search/index.ts
+++ b/src/widgets/search/index.ts
@@ -1,3 +1,5 @@
 export { EmptyPage } from './ui/empty-page';
 export { MeetingSearchBanner } from './ui/meeting-search-banner/meeting-search-banner';
 export { SearchScreen } from './ui/search-screen/search-screen';
+export { SearchScreenFetcher } from './ui/search-screen/search-screen-fetcher.server';
+export { SearchScreenSkeleton } from './ui/search-screen/search-screen-skeleton';

--- a/src/widgets/search/index.ts
+++ b/src/widgets/search/index.ts
@@ -1,5 +1,4 @@
 export { EmptyPage } from './ui/empty-page';
 export { MeetingSearchBanner } from './ui/meeting-search-banner/meeting-search-banner';
 export { SearchScreen } from './ui/search-screen/search-screen';
-export { SearchScreenFetcher } from './ui/search-screen/search-screen-fetcher.server';
 export { SearchScreenSkeleton } from './ui/search-screen/search-screen-skeleton';

--- a/src/widgets/search/ui/search-screen/search-screen-fetcher.server.tsx
+++ b/src/widgets/search/ui/search-screen/search-screen-fetcher.server.tsx
@@ -1,13 +1,19 @@
-import { MeetingListResult } from '@/entities/meeting';
+import { SearchParams } from 'nuqs';
+
+import { getMeetingSearchParams } from '@/features/search';
+import { getInitialSearchData } from '@/features/search/index.server';
 
 import { SearchScreen } from './search-screen';
 
 export const SearchScreenFetcher = async ({
-  initialData,
+  searchParams,
 }: {
-  initialData: Promise<MeetingListResult | null>;
+  searchParams: Promise<SearchParams>;
 }) => {
-  const resolvedInitialData = await initialData;
+  const requestParams = await getMeetingSearchParams(searchParams);
+  const initialData = await getInitialSearchData(requestParams);
 
-  return <SearchScreen initialData={resolvedInitialData} />;
+  return (
+    <SearchScreen initialData={initialData} initialDefaultDateStartIso={requestParams.dateStart} />
+  );
 };

--- a/src/widgets/search/ui/search-screen/search-screen-fetcher.server.tsx
+++ b/src/widgets/search/ui/search-screen/search-screen-fetcher.server.tsx
@@ -1,0 +1,13 @@
+import { MeetingListResult } from '@/entities/meeting';
+
+import { SearchScreen } from './search-screen';
+
+export const SearchScreenFetcher = async ({
+  initialData,
+}: {
+  initialData: Promise<MeetingListResult | null>;
+}) => {
+  const resolvedInitialData = await initialData;
+
+  return <SearchScreen initialData={resolvedInitialData} />;
+};

--- a/src/widgets/search/ui/search-screen/search-screen-skeleton.tsx
+++ b/src/widgets/search/ui/search-screen/search-screen-skeleton.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from '@/shared/ui/skeleton';
+
+import SearchSkeleton from './search-skeleton';
+
+export function SearchScreenSkeleton() {
+  return (
+    <div className="w-full max-w-[1140px]">
+      <div className="flex w-full flex-col gap-4 px-4 md:px-0">
+        {/* SearchBar */}
+        <Skeleton className="h-12 w-full rounded-xl" />
+
+        {/* MeetingFilterBar */}
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-20 rounded-full" />
+          <Skeleton className="h-9 w-24 rounded-full" />
+          <Skeleton className="h-9 w-20 rounded-full" />
+          <Skeleton className="h-9 w-20 rounded-full" />
+        </div>
+
+        {/* 카드 목록 */}
+        <SearchSkeleton />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## PR 제목: [Refactor]: 홈·검색 페이지 Suspense 스트리밍 적용 및 Pretendard 폰트 로컬화

### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [ ] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

관련 이슈: #435

- **홈 페이지 Suspense 스트리밍 적용**: `await`로 블로킹되던 초기 데이터 fetch를 중간 서버 컴포넌트(`*Fetcher`)로 분리하여, 배너는 즉시 렌더링되고 콘텐츠는 스트리밍으로 로드되도록 변경
- **검색 페이지 동일 패턴 적용**: `SearchScreenFetcher` 서버 컴포넌트 추가, `SearchScreenSkeleton`을 Suspense fallback으로 사용
- **Pretendard 폰트 로컬화**: CDN 의존성 제거, subset 폰트 파일을 로컬에 포함하여 초기 로딩 최적화

### 🧪 테스트 방법 (How to Test)

1. 로컬 환경에서 `npm run dev` 실행
2. `/` (홈) 및 `/search` 페이지 접속
3. 배너가 먼저 노출되고, 카드 목록은 스켈레톤 → 실제 데이터 순서로 나타나는지 확인
4. 느린 네트워크(DevTools → Network → Slow 3G)에서 스트리밍 동작 확인

### 📸 스크린샷 또는 영상 (Optional)

(UI 변경 없음 — 스켈레톤 fallback 추가로 체감 성능 개선)

### 🚨 기타 참고 사항 (Notes)

- [x] `SearchScreenFetcher`는 `.server.tsx` 확장자로 클라이언트 번들에서 제외됨
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**