### PR TITLE
[Fix]: 모바일 지역 스크롤 선택 버그 + 달력 버튼 간격 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ src/graphify-out/cache/
 .env.sentry-build-plugin
 
 .opencode
+
+.next-qa/
+.next-webpack-qa/

--- a/src/features/search/ui/region-select-modal/region-cascade-select.tsx
+++ b/src/features/search/ui/region-select-modal/region-cascade-select.tsx
@@ -82,12 +82,10 @@ function RegionItem({ region: r, value, onChange }: RegionItemProps) {
             didScrollRef.current = false;
           }}
           onPointerMove={(e) => {
-            if (!startPosRef.current) return;
-            const d = Math.hypot(
-              e.clientX - startPosRef.current.x,
-              e.clientY - startPosRef.current.y
-            );
-            if (d > 5) didScrollRef.current = true;
+            if (!startPosRef.current || didScrollRef.current) return;
+            const dx = e.clientX - startPosRef.current.x;
+            const dy = e.clientY - startPosRef.current.y;
+            if (dx * dx + dy * dy > 25) didScrollRef.current = true;
           }}
         >
           <DropdownMenuGroup>

--- a/src/features/search/ui/region-select-modal/region-cascade-select.tsx
+++ b/src/features/search/ui/region-select-modal/region-cascade-select.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 import Image from 'next/image';
 
@@ -32,6 +32,95 @@ export interface RegionCascadeSelectProps {
   className?: string;
 }
 
+interface RegionItemProps {
+  region: KoreaRegionRegion & { districts: string[] };
+  value: RegionSelection;
+  onChange: (next: RegionSelection) => void;
+}
+
+function RegionItem({ region: r, value, onChange }: RegionItemProps) {
+  const didScrollRef = useRef(false);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  const selectedDistricts = (value ?? [])
+    .filter((s) => s.province === r.name)
+    .map((s) => s.district);
+
+  const hasSelection = selectedDistricts.length > 0;
+
+  return (
+    <li>
+      <DropdownMenu>
+        <DropdownMenuTrigger className={cn(triggerClass, hasSelection && triggerSelectedClass)}>
+          <span className="min-w-0 flex-1 truncate">
+            {hasSelection ? `${r.name} · ${selectedDistricts.join(', ')}` : r.name}
+          </span>
+          {hasSelection ? (
+            <Check
+              className="text-sosoeat-orange-600 pointer-events-none size-6 shrink-0"
+              strokeWidth={2.25}
+              aria-hidden
+            />
+          ) : (
+            <Image
+              src="/icons/arrow-down.svg"
+              alt=""
+              width={24}
+              height={24}
+              className="shrink-0"
+              aria-hidden
+            />
+          )}
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          align="start"
+          sideOffset={4}
+          className="max-h-[min(60vh,320px)] overflow-y-auto"
+          onPointerDown={(e) => {
+            startPosRef.current = { x: e.clientX, y: e.clientY };
+            didScrollRef.current = false;
+          }}
+          onPointerMove={(e) => {
+            if (!startPosRef.current) return;
+            const d = Math.hypot(
+              e.clientX - startPosRef.current.x,
+              e.clientY - startPosRef.current.y
+            );
+            if (d > 5) didScrollRef.current = true;
+          }}
+        >
+          <DropdownMenuGroup>
+            {r.districts.map((district) => (
+              <DropdownMenuCheckboxItem
+                key={district}
+                checked={selectedDistricts.includes(district)}
+                className="hover:bg-accent cursor-pointer py-3 text-base transition-colors md:py-1"
+                onSelect={(e) => {
+                  if (didScrollRef.current) e.preventDefault();
+                }}
+                onCheckedChange={(checked) => {
+                  const next = (value ?? []).filter(
+                    (s) => !(s.province === r.name && s.district === district)
+                  );
+
+                  if (checked) {
+                    onChange([...next, { province: r.name, district }]);
+                  } else {
+                    onChange(next.length > 0 ? next : null);
+                  }
+                }}
+              >
+                {district}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </li>
+  );
+}
+
 export function RegionCascadeSelect({
   regions,
   value,
@@ -53,72 +142,9 @@ export function RegionCascadeSelect({
       role="list"
       aria-label="시·도 목록"
     >
-      {sortedRegions.map((r) => {
-        const selectedDistricts = (value ?? [])
-          .filter((s) => s.province === r.name)
-          .map((s) => s.district);
-
-        const hasSelection = selectedDistricts.length > 0;
-
-        return (
-          <li key={r.id}>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                className={cn(triggerClass, hasSelection && triggerSelectedClass)}
-              >
-                <span className="min-w-0 flex-1 truncate">
-                  {hasSelection ? `${r.name} · ${selectedDistricts.join(', ')}` : r.name}
-                </span>
-                {hasSelection ? (
-                  <Check
-                    className="text-sosoeat-orange-600 pointer-events-none size-6 shrink-0"
-                    strokeWidth={2.25}
-                    aria-hidden
-                  />
-                ) : (
-                  <Image
-                    src="/icons/arrow-down.svg"
-                    alt=""
-                    width={24}
-                    height={24}
-                    className="shrink-0"
-                    aria-hidden
-                  />
-                )}
-              </DropdownMenuTrigger>
-
-              <DropdownMenuContent
-                align="start"
-                sideOffset={4}
-                className="max-h-[min(60vh,320px)] overflow-y-auto"
-              >
-                <DropdownMenuGroup>
-                  {r.districts.map((district) => (
-                    <DropdownMenuCheckboxItem
-                      key={district}
-                      checked={selectedDistricts.includes(district)}
-                      className="hover:bg-accent cursor-pointer py-3 text-base transition-colors md:py-1"
-                      onCheckedChange={(checked) => {
-                        const next = (value ?? []).filter(
-                          (s) => !(s.province === r.name && s.district === district)
-                        );
-
-                        if (checked) {
-                          onChange([...next, { province: r.name, district }]);
-                        } else {
-                          onChange(next.length > 0 ? next : null);
-                        }
-                      }}
-                    >
-                      {district}
-                    </DropdownMenuCheckboxItem>
-                  ))}
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </li>
-        );
-      })}
+      {sortedRegions.map((r) => (
+        <RegionItem key={r.id} region={r} value={value} onChange={onChange} />
+      ))}
     </ul>
   );
 }

--- a/src/shared/lib/amplitude-runtime.ts
+++ b/src/shared/lib/amplitude-runtime.ts
@@ -2,12 +2,15 @@ import type { AuthUser } from '../types/auth';
 
 type AmplitudeAnalyticsModule = typeof import('@amplitude/analytics-browser');
 type AmplitudeSessionReplayPluginModule = typeof import('@amplitude/plugin-session-replay-browser');
+type AmplitudeEngagementModule = typeof import('@amplitude/engagement-browser');
 
 let amplitudeAnalyticsModulePromise: Promise<AmplitudeAnalyticsModule> | null = null;
 let amplitudeSessionReplayPluginModulePromise: Promise<AmplitudeSessionReplayPluginModule> | null =
   null;
+let amplitudeEngagementModulePromise: Promise<AmplitudeEngagementModule> | null = null;
 let isAmplitudeInitialized = false;
 let isSessionReplayAdded = false;
+let isEngagementAdded = false;
 
 const AMPLITUDE_API_KEY = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY;
 
@@ -25,6 +28,14 @@ async function getSessionReplayPlugin() {
   }
 
   return amplitudeSessionReplayPluginModulePromise;
+}
+
+async function getEngagementModule() {
+  if (!amplitudeEngagementModulePromise) {
+    amplitudeEngagementModulePromise = import('@amplitude/engagement-browser');
+  }
+
+  return amplitudeEngagementModulePromise;
 }
 
 function isAmplitudeEnabled() {
@@ -48,6 +59,21 @@ async function addSessionReplayPlugin() {
   ).promise;
 
   isSessionReplayAdded = true;
+}
+
+async function addEngagementPlugin() {
+  if (isEngagementAdded) {
+    return;
+  }
+
+  const [amplitude, engagement] = await Promise.all([
+    getAmplitudeAnalytics(),
+    getEngagementModule(),
+  ]);
+
+  await amplitude.add(engagement.plugin()).promise;
+
+  isEngagementAdded = true;
 }
 
 export async function initAmplitudeRuntime() {
@@ -85,6 +111,7 @@ export async function initAmplitudeRuntime() {
     }).promise;
 
     void addSessionReplayPlugin();
+    void addEngagementPlugin();
   } catch (error) {
     isAmplitudeInitialized = false;
 

--- a/src/shared/ui/date-picker/detail-date-picker.constants.ts
+++ b/src/shared/ui/date-picker/detail-date-picker.constants.ts
@@ -12,7 +12,7 @@ export const DETAIL_DATE_PICKER_CALENDAR_CLASS =
 
 export const DETAIL_DATE_PICKER_CHEVRON_CLASS = 'text-foreground h-1.75 w-3.75';
 
-export const DETAIL_DATE_PICKER_ACTIONS_CLASS = 'flex w-full justify-center gap-2';
+export const DETAIL_DATE_PICKER_ACTIONS_CLASS = 'flex w-full justify-center gap-2 mt-3';
 
 export const DETAIL_DATE_PICKER_ACTION_BUTTON_CLASS = 'h-10 w-29.5 text-sm font-semibold';
 

--- a/src/shared/ui/safeHtml/safe-html.tsx
+++ b/src/shared/ui/safeHtml/safe-html.tsx
@@ -1,0 +1,7 @@
+'use client';
+import DOMPurify from 'dompurify';
+
+export function SafeHtml({ html, className }: { html: string; className?: string }) {
+  const clean = DOMPurify.sanitize(html);
+  return <div className={className} dangerouslySetInnerHTML={{ __html: clean }} />;
+}

--- a/src/shared/ui/safeHtml/safe-html.tsx
+++ b/src/shared/ui/safeHtml/safe-html.tsx
@@ -1,5 +1,5 @@
 'use client';
-import DOMPurify from 'dompurify';
+import DOMPurify from 'isomorphic-dompurify';
 
 export function SafeHtml({ html, className }: { html: string; className?: string }) {
   const clean = DOMPurify.sanitize(html);

--- a/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail-body.tsx
+++ b/src/widgets/sosotalk/ui/sosotalk-post-detail/sosotalk-post-detail/sosotalk-post-detail-body.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import Image from 'next/image';
 
-import DOMPurify from 'isomorphic-dompurify';
+import { SafeHtml } from '@/shared/ui/safeHtml/safe-html';
 
 import type { SosoTalkPostBodyProps } from './sosotalk-post-detail.types';
 
@@ -16,13 +16,11 @@ export function SosoTalkPostDetailBody({
   imageUrl,
   children,
 }: SosoTalkPostDetailBodyProps) {
-  const normalizedContentHtml = DOMPurify.sanitize(contentHtml.trim());
-
   return (
     <section className="border-sosoeat-gray-300 mt-6 flex flex-col gap-5 border-t pt-5 md:mt-8 md:gap-6 md:pt-6">
-      <div
+      <SafeHtml
+        html={contentHtml.trim()}
         className="text-sosoeat-gray-800 prose prose-p:my-0 prose-p:min-h-[1.85em] prose-strong:font-bold prose-em:italic prose-u:underline max-w-none text-lg font-normal [&_li]:my-1 [&_li]:pl-1 [&_li>p]:my-0 [&_ol]:my-0 [&_ol]:list-outside [&_ol]:list-decimal [&_ol]:pl-6 [&_p]:whitespace-pre-wrap [&_p+ol]:mt-3 [&_p+ul]:mt-3 [&_ul]:my-0 [&_ul]:list-outside [&_ul]:list-disc [&_ul]:pl-6"
-        dangerouslySetInnerHTML={{ __html: normalizedContentHtml }}
       />
 
       {imageUrl ? (


### PR DESCRIPTION
## PR 제목: [Fix]: 모바일 지역 스크롤 선택 버그 + 달력 버튼 간격 수정

### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [x] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

closes #443

**버그 1 — 모바일 지역 선택 스크롤 중 의도치 않은 선택 (#443)**

- 원인: `DropdownMenuContent` 안에서 손가락 스크롤 시 `pointerup` 이벤트가 스크롤 종료 위치의 `DropdownMenuCheckboxItem`을 선택함
- `RegionCascadeSelect`의 각 시·도 항목을 `RegionItem` 서브 컴포넌트로 추출 (`useRef` 사용을 위해)
- `DropdownMenuContent`에 `onPointerDown` / `onPointerMove` 핸들러 추가 — 이동 거리 5px 초과 시 스크롤로 판정
- `DropdownMenuCheckboxItem.onSelect`에서 스크롤 중이면 `e.preventDefault()` 호출 → Radix `checkForDefaultPrevented` 메커니즘으로 `onCheckedChange` 차단

**버그 2 — 달력 초기화/적용 버튼이 날짜와 너무 가까움 (#443)**

- `DETAIL_DATE_PICKER_ACTIONS_CLASS`에 `mt-3` 추가하여 달력 날짜 행과 버튼 사이 12px 여백 확보

**기타**

- `amplitude-runtime.ts`: Amplitude Engagement 플러그인 lazy 로딩 추가

### 🧪 테스트 방법 (How to Test)

**지역 스크롤 버그**

1. 모바일 기기(또는 Chrome DevTools 모바일 에뮬레이션)에서 검색 페이지 접속
2. 지역 필터 버튼 클릭 → 시·도 드롭다운 열기
3. 드롭다운 내 구·군 목록을 손가락으로 위아래 스크롤
4. 스크롤 후 손가락을 떼도 구·군이 선택되지 않아야 함
5. 탭(짧게 터치)으로만 구·군이 선택되는지 확인

**달력 버튼 간격**

1. 검색 페이지에서 날짜 필터 클릭
2. 달력 날짜 선택 후 초기화/적용 버튼 확인
3. 날짜 행과 버튼 사이에 충분한 여백이 보여야 함

### 📸 스크린샷 또는 영상 (Optional)

(첨부 예정)

| 변경 전 (Before) | 변경 후 (After) |
| :--------------: | :-------------: |
|                  |                 |

### 🚨 기타 참고 사항 (Notes)

- [x] **`RegionItem` 서브 컴포넌트 분리가 Radix 포인터 이벤트 처리의 핵심입니다 — `useRef`는 `.map()` 안에서 쓸 수 없기 때문입니다.**
- [ ] 배포 시점에 고려해야 할 사항이 있다면 명시해주세요.