### PR TITLE
[Fix]: 하이드레이션 에러, 검색 필터, OG 이미지 3종 버그 수정

### DIFF
--- a/src/entities/location/ui/location-map-preview.tsx
+++ b/src/entities/location/ui/location-map-preview.tsx
@@ -19,9 +19,7 @@ interface LocationMapPreviewProps {
 }
 
 export function LocationMapPreview({ latitude, longitude, className }: LocationMapPreviewProps) {
-  const [sdkReady, setSdkReady] = useState(
-    () => typeof window !== 'undefined' && !!window.kakao?.maps
-  );
+  const [sdkReady, setSdkReady] = useState(false);
   const appKey = process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY ?? '';
 
   return (

--- a/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
+++ b/src/features/notifications/ui/notification/notification-panel/notification-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { X } from 'lucide-react';
@@ -42,16 +42,15 @@ const DESKTOP_SCROLL_CLASS =
   'overflow-x-hidden overflow-y-auto [scrollbar-width:thin] [scrollbar-color:#cccccc_transparent] h-[360px]';
 
 function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(() =>
-    typeof window !== 'undefined' ? window.matchMedia('(max-width: 767px)').matches : false
+  return useSyncExternalStore(
+    (callback) => {
+      const mq = window.matchMedia('(max-width: 767px)');
+      mq.addEventListener('change', callback);
+      return () => mq.removeEventListener('change', callback);
+    },
+    () => window.matchMedia('(max-width: 767px)').matches,
+    () => false
   );
-  useEffect(() => {
-    const mq = window.matchMedia('(max-width: 767px)');
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-  return isMobile;
 }
 
 interface NotificationPanelContentProps {

--- a/src/features/search/model/search-param.ts
+++ b/src/features/search/model/search-param.ts
@@ -30,7 +30,7 @@ export const getMeetingSearchParams = async (searchParams: Promise<unknown>) => 
     typeFilter: typeFilter === 'all' ? undefined : typeFilter,
     dateEnd: dateEnd ? dateEnd.toISOString() : undefined,
     dateStart: finalDateStart.toISOString(),
-    search,
+    keyword: search,
   };
 
   return requestParams;

--- a/src/shared/lib/default-social-image.tsx
+++ b/src/shared/lib/default-social-image.tsx
@@ -16,8 +16,7 @@ export function createDefaultSocialImage() {
         display: 'flex',
         position: 'relative',
         overflow: 'hidden',
-        background:
-          'radial-gradient(circle at top left, rgba(255, 190, 92, 0.35), transparent 32%), linear-gradient(135deg, #fff8f1 0%, #fff1e6 55%, #ffe2cf 100%)',
+        backgroundImage: 'linear-gradient(135deg, #fff8f1 0%, #fff1e6 55%, #ffe2cf 100%)',
         color: '#2d241f',
         fontFamily: 'sans-serif',
       }}

--- a/src/widgets/meeting-detail/ui/meeting-location-section/_components/kakao-map-loader.tsx
+++ b/src/widgets/meeting-detail/ui/meeting-location-section/_components/kakao-map-loader.tsx
@@ -19,9 +19,7 @@ interface KakaoMapLoaderProps {
 }
 
 export function KakaoMapLoader({ appKey, latitude, longitude }: KakaoMapLoaderProps) {
-  const [sdkReady, setSdkReady] = useState(
-    () => typeof window !== 'undefined' && !!window.kakao?.maps
-  );
+  const [sdkReady, setSdkReady] = useState(false);
 
   return (
     <>


### PR DESCRIPTION
## PR 제목: [Fix]: 하이드레이션 에러, 검색 필터, OG 이미지 3종 버그 수정

### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [ ] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

**1. React 하이드레이션 에러 #418 수정** — 관련 이슈: #451

- `useState` 초기값에서 브라우저 전용 API(`window.matchMedia`, `window.kakao`) 사용으로 SSR과 클라이언트 초기 렌더링 결과가 달라 발생
- `useIsMobile` 훅을 `useSyncExternalStore`로 교체 (서버 스냅샷 `() => false` 명시)
- kakao map 2곳을 `useState(false)` 로 수정
- 수정 파일: `notification-panel.tsx`, `location-map-preview.tsx`, `kakao-map-loader.tsx`

**2. 검색 키워드 URL 파라미터로 직접 접근 시 필터 미적용** — 관련 이슈: #452

- `/search?search=키워드` 직접 접근 시 서버 사이드 초기 fetch에서 `search` 필드를 사용했으나 API는 `keyword` 필드를 요구
- TypeScript 구조적 타이핑 특성상 컴파일 에러 없이 무시되어 필터링 안 됨
- `search-param.ts` 반환 객체에서 `search` → `keyword: search` 1줄 수정
- 수정 파일: `src/features/search/model/search-param.ts`

**3. 주소 공유 시 OG 이미지 미표시** — 관련 이슈: #453

- `default-social-image.tsx`의 `background` 단축 속성에 콤마 구분 다중 그라디언트 사용
- Satori(`next/og` 내부 렌더러)가 다중 `background` 값을 지원하지 않아 `/opengraph-image` 라우트 오작동
- `backgroundImage: 'linear-gradient(...)'` 단일 값으로 교체, 장식용 circle div들이 warm highlight 유지
- 수정 파일: `src/shared/lib/default-social-image.tsx`

### 🧪 테스트 방법 (How to Test)

**하이드레이션 에러:**
1. 배포 환경에서 Chrome 콘솔 열기
2. 알림 패널 토글, 모임 상세 페이지(지도 포함) 접속
3. `Minified React error #418` 또는 hydration 관련 에러 없음 확인

**검색 필터:**
1. 브라우저에서 `/search?search=삼겹살` 직접 접속
2. 초기 렌더링부터 "삼겹살" 관련 모임만 표시되는지 확인 (새로고침 후 잠깐 전체 목록 보이던 증상 사라짐)

**OG 이미지:**
1. 배포 후 `https://www.opengraph.xyz` 접속
2. `https://sosoeat.vercel.app` URL 입력
3. 소소잇 브랜드 OG 이미지가 정상 표시되는지 확인
4. 카카오톡에 URL 붙여넣기 → 미리보기 이미지 표시 확인

### 🚨 기타 참고 사항 (Notes)

- [ ] **코드 리뷰 시 특별히 확인이 필요한 부분이 있다면 명시해주세요.**
- [ ] **배포 시점에 고려해야 할 사항이 있다면 명시해주세요.**