### PR TITLE
[Refactor]: next/font/local 제거 — unicode-range 미지원으로 CSS @font-face 방식 유지 (#475)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import localFont from 'next/font/local';
 import Script from 'next/script';
 
 // eslint-disable-next-line feature-sliced/absolute-relative
@@ -17,38 +16,7 @@ import { Providers } from './providers';
 
 import './globals.css';
 
-const pretendard = localFont({
-  src: [
-    // critical subsets — benchmark top 5 (가장 느렸던 = 가장 많이 쓰이는)
-    {
-      path: '../../public/fonts/subsets/PretendardVariable.subset.91.woff2',
-      weight: '45 920',
-      style: 'normal',
-    },
-    {
-      path: '../../public/fonts/subsets/PretendardVariable.subset.88.woff2',
-      weight: '45 920',
-      style: 'normal',
-    },
-    {
-      path: '../../public/fonts/subsets/PretendardVariable.subset.90.woff2',
-      weight: '45 920',
-      style: 'normal',
-    },
-    {
-      path: '../../public/fonts/subsets/PretendardVariable.subset.81.woff2',
-      weight: '45 920',
-      style: 'normal',
-    },
-    {
-      path: '../../public/fonts/subsets/PretendardVariable.subset.89.woff2',
-      weight: '45 920',
-      style: 'normal',
-    },
-  ],
-  display: 'optional',
-  variable: '--font-pretendard-local',
-});
+const PRELOAD_SUBSETS = ['91', '88', '90', '81', '89'];
 
 const metadataBase = new URL(process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000');
 
@@ -98,7 +66,19 @@ export default async function RootLayout({
   ]);
 
   return (
-    <html className={pretendard.variable} lang="ko">
+    <html lang="ko">
+      <head>
+        {PRELOAD_SUBSETS.map((n) => (
+          <link
+            key={n}
+            rel="preload"
+            href={`/fonts/subsets/PretendardVariable.subset.${n}.woff2`}
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+        ))}
+      </head>
       <body className="flex min-h-screen min-w-[375px] flex-col overscroll-none">
         <Script src="https://accounts.google.com/gsi/client" strategy="afterInteractive" />
         <NuqsAdapter>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import localFont from 'next/font/local';
 import Script from 'next/script';
 
 // eslint-disable-next-line feature-sliced/absolute-relative
@@ -15,6 +16,39 @@ import { NavigationBar } from '@/widgets/navigation-bar';
 import { Providers } from './providers';
 
 import './globals.css';
+
+const pretendard = localFont({
+  src: [
+    // critical subsets — benchmark top 5 (가장 느렸던 = 가장 많이 쓰이는)
+    {
+      path: '../../public/fonts/subsets/PretendardVariable.subset.91.woff2',
+      weight: '45 920',
+      style: 'normal',
+    },
+    {
+      path: '../../public/fonts/subsets/PretendardVariable.subset.88.woff2',
+      weight: '45 920',
+      style: 'normal',
+    },
+    {
+      path: '../../public/fonts/subsets/PretendardVariable.subset.90.woff2',
+      weight: '45 920',
+      style: 'normal',
+    },
+    {
+      path: '../../public/fonts/subsets/PretendardVariable.subset.81.woff2',
+      weight: '45 920',
+      style: 'normal',
+    },
+    {
+      path: '../../public/fonts/subsets/PretendardVariable.subset.89.woff2',
+      weight: '45 920',
+      style: 'normal',
+    },
+  ],
+  display: 'optional',
+  variable: '--font-pretendard-local',
+});
 
 const metadataBase = new URL(process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000');
 
@@ -64,7 +98,7 @@ export default async function RootLayout({
   ]);
 
   return (
-    <html lang="ko">
+    <html className={pretendard.variable} lang="ko">
       <body className="flex min-h-screen min-w-[375px] flex-col overscroll-none">
         <Script src="https://accounts.google.com/gsi/client" strategy="afterInteractive" />
         <NuqsAdapter>

--- a/src/app/pretendard-subset.css
+++ b/src/app/pretendard-subset.css
@@ -967,23 +967,6 @@
   font-style: normal;
   font-display: swap;
   font-weight: 45 920;
-  src: url(/fonts/subsets/PretendardVariable.subset.81.woff2) format('woff2-variations');
-  unicode-range:
-    U+24, U+60, U+3b9, U+3bb, U+3bd, U+2191, U+2606, U+300c-300d, U+3131, U+3134, U+3139,
-    U+3141-3142, U+3148, U+3161, U+3163, U+321c, U+4eba, U+5317, U+ac31, U+ac77, U+ac9f, U+acb9,
-    U+acf0-acf1, U+acfd, U+ad73, U+af3d, U+b00c, U+b04a, U+b057, U+b0c4, U+b188, U+b1cc, U+b214,
-    U+b2db, U+b2ee, U+b304, U+b4ed, U+b518, U+b5bc, U+b625, U+b69c-b69d, U+b7ac, U+b801, U+b86c,
-    U+b959, U+b95c, U+b985, U+ba48, U+bb58, U+bc0c, U+bc38, U+bc85, U+bc9a, U+bf40, U+c068, U+c0bd,
-    U+c0cc, U+c12f, U+c149, U+c1e0, U+c22b, U+c22d, U+c250, U+c2fc, U+c300, U+c313, U+c370, U+c3d8,
-    U+c557, U+c580, U+c5e3, U+c62e, U+c634, U+c6f0, U+c74d, U+c783, U+c78e, U+c796, U+c7bc, U+c92c,
-    U+ca4c, U+cc1c, U+cc54, U+cc59, U+ce04, U+cf30, U+cfc4, U+d140, U+d321, U+d38c, U+d399, U+d54f,
-    U+d587, U+d5d0, U+d6e8, U+d770;
-}
-@font-face {
-  font-family: 'Pretendard Variable';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 45 920;
   src: url(/fonts/subsets/PretendardVariable.subset.82.woff2) format('woff2-variations');
   unicode-range:
     U+d7, U+ea, U+fc, U+2192, U+25bc, U+3000, U+3137, U+3145, U+315c, U+7f8e, U+ac13, U+ac71,
@@ -1080,66 +1063,5 @@
     U+c904, U+c990, U+c9dc, U+cc38, U+cc44, U+cca0, U+cd1d, U+cd95, U+cda9, U+ce5c, U+cf00, U+cf58,
     U+d150, U+d22c, U+d305, U+d328, U+d37c, U+d3f0, U+d551, U+d5a5, U+d5c8, U+d5d8, U+d63c, U+d64d,
     U+d669, U+d734, U+d76c;
-}
-@font-face {
-  font-family: 'Pretendard Variable';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 45 920;
-  src: url(/fonts/subsets/PretendardVariable.subset.88.woff2) format('woff2-variations');
-  unicode-range:
-    U+26, U+2b, U+3e, U+40, U+7e, U+ac01, U+ac19, U+ac1d, U+aca0, U+aca9, U+acb0, U+ad8c, U+ae09,
-    U+ae38, U+ae40, U+aed8, U+b09c, U+b0a0, U+b108, U+b204, U+b298, U+b2d8, U+b2eb-b2ec, U+b2f4,
-    U+b313, U+b358, U+b450, U+b4e0, U+b54c, U+b610, U+b780, U+b78c, U+b791, U+b8e8, U+b958, U+b974,
-    U+b984, U+b9b0, U+b9bc-b9bd, U+b9ce, U+ba70, U+bbfc, U+bc0f, U+bc15, U+bc1b, U+bc31, U+bc95,
-    U+bcc0, U+bcc4, U+bd81, U+bd88, U+c0c8, U+c11d, U+c13c, U+c158, U+c18d, U+c1a1, U+c21c, U+c4f0,
-    U+c54a, U+c560, U+c5b8, U+c5c8, U+c5f4, U+c628, U+c62c, U+c678, U+c6cc, U+c808, U+c810, U+c885,
-    U+c88b, U+c900, U+c988, U+c99d, U+c9c8, U+cc3d-cc3e, U+cc45, U+cd08, U+ce20, U+cee4, U+d074,
-    U+d0a4, U+d0dd, U+d2b9, U+d3b8, U+d3c9, U+d488, U+d544, U+d559, U+d56d, U+d588, U+d615, U+d648,
-    U+d655, U+d658, U+d65c;
-}
-@font-face {
-  font-family: 'Pretendard Variable';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 45 920;
-  src: url(/fonts/subsets/PretendardVariable.subset.89.woff2) format('woff2-variations');
-  unicode-range:
-    U+d, U+7c, U+ac10, U+ac15, U+ac74, U+ac80, U+ac83, U+acc4, U+ad11, U+ad50, U+ad6d, U+adfc,
-    U+ae00, U+ae08, U+ae4c, U+b0a8, U+b124, U+b144, U+b178, U+b274, U+b2a5, U+b2e8, U+b2f9, U+b354,
-    U+b370, U+b418, U+b41c, U+b4f1, U+b514, U+b798, U+b808, U+b824-b825, U+b8cc, U+b978, U+b9d0,
-    U+b9e4, U+baa9, U+bb3c, U+bc18, U+bc1c, U+bc30, U+bc84, U+bcf5, U+bcf8, U+bd84, U+be0c, U+be14,
-    U+c0b0, U+c0c9, U+c0dd, U+c124, U+c2dd, U+c2e4, U+c2ec, U+c54c, U+c57c-c57d, U+c591,
-    U+c5c5-c5c6, U+c5ed, U+c608, U+c640, U+c6b8, U+c6d4, U+c784, U+c7ac, U+c800-c801, U+c9c1,
-    U+c9d1, U+cc28, U+cc98, U+cc9c, U+ccad, U+cd5c, U+cd94, U+cd9c, U+cde8, U+ce68, U+cf54, U+d0dc,
-    U+d14c, U+d1a0, U+d1b5, U+d2f0, U+d30c, U+d310, U+d398, U+d45c, U+d50c, U+d53c, U+d560, U+d568,
-    U+d589, U+d604, U+d6c4, U+d788;
-}
-@font-face {
-  font-family: 'Pretendard Variable';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 45 920;
-  src: url(/fonts/subsets/PretendardVariable.subset.90.woff2) format('woff2-variations');
-  unicode-range:
-    U+ac04, U+ac1c, U+ac70, U+ac8c, U+acbd, U+acf5, U+acfc, U+ad00, U+ad6c, U+adf8, U+b098, U+b0b4,
-    U+b294, U+b2c8, U+b300, U+b3c4, U+b3d9, U+b4dc, U+b4e4, U+b77c, U+b7ec, U+b85d, U+b97c, U+b9c8,
-    U+b9cc, U+ba54, U+ba74, U+ba85, U+baa8, U+bb34, U+bb38, U+bbf8, U+bc14, U+bc29, U+bc88, U+bcf4,
-    U+bd80, U+be44, U+c0c1, U+c11c, U+c120, U+c131, U+c138, U+c18c, U+c218, U+c2b5, U+c2e0, U+c544,
-    U+c548, U+c5b4, U+c5d0, U+c5ec, U+c5f0, U+c601, U+c624, U+c694, U+c6a9, U+c6b0, U+c6b4, U+c6d0,
-    U+c704, U+c720, U+c73c, U+c740, U+c744, U+c74c, U+c758, U+c77c, U+c785, U+c788, U+c790-c791,
-    U+c7a5, U+c804, U+c815, U+c81c, U+c870, U+c8fc, U+c911, U+c9c4, U+ccb4, U+ce58, U+ce74, U+d06c,
-    U+d0c0, U+d130, U+d2b8, U+d3ec, U+d504, U+d55c, U+d569, U+d574, U+d638, U+d654, U+d68c;
-}
-@font-face {
-  font-family: 'Pretendard Variable';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 45 920;
-  src: url(/fonts/subsets/PretendardVariable.subset.91.woff2) format('woff2-variations');
-  unicode-range:
-    U+20-22, U+27-2a, U+2c-39, U+3a-3b, U+3f, U+41-4e, U+4f-5d, U+61-7b, U+7d, U+a0-a1, U+ab,
-    U+ad-ae, U+b7, U+bb, U+bf, U+2013-2014, U+201c-201d, U+2122, U+ac00, U+ace0, U+ae30, U+b2e4,
-    U+b85c, U+b9ac, U+c0ac, U+c2a4, U+c2dc, U+c774, U+c778, U+c9c0, U+d558;
 }
 /*# sourceMappingURL=/sm/49af798104dba87a942919357f383e653ce9152ba9bdc9bbfa8ba846a1b04235.map */

--- a/src/app/theme.css
+++ b/src/app/theme.css
@@ -68,9 +68,9 @@
 
   /* ── Font Family ───────────────────────────────── */
   --font-pretendard:
-    var(--font-pretendard-local), -apple-system, BlinkMacSystemFont, system-ui, Roboto,
-    'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+    'Pretendard Variable', -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue',
+    'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
   --font-sans: var(--font-pretendard);
   --font-mono:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',

--- a/src/app/theme.css
+++ b/src/app/theme.css
@@ -67,7 +67,6 @@
   --color-sidebar-ring: var(--sidebar-ring);
 
   /* ── Font Family ───────────────────────────────── */
-  --font-pretendard-local: 'Pretendard Variable';
   --font-pretendard:
     var(--font-pretendard-local), -apple-system, BlinkMacSystemFont, system-ui, Roboto,
     'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',

--- a/src/features/notifications/model/notification.queries.test.ts
+++ b/src/features/notifications/model/notification.queries.test.ts
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+
+import { notificationApi } from '../api/notifications.api';
+
+import { useUnreadCount } from './notification.queries';
+
+jest.mock('../api/notifications.api', () => ({
+  notificationApi: {
+    getUnreadCount: jest.fn().mockResolvedValue(0),
+  },
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: jest.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useUnreadCount', () => {
+  beforeEach(() => {
+    (useQuery as jest.Mock).mockReturnValue({ data: 0, isLoading: false });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('refetchInterval이 30초로 설정된다', () => {
+    renderHook(() => useUnreadCount(0, true), { wrapper: createWrapper() });
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refetchInterval: 1000 * 30,
+        staleTime: 1000 * 30,
+      })
+    );
+  });
+
+  it('enabled=false면 쿼리가 비활성화된다', () => {
+    renderHook(() => useUnreadCount(0, false), { wrapper: createWrapper() });
+
+    expect(useQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('getUnreadCount를 queryFn으로 사용한다', () => {
+    renderHook(() => useUnreadCount(0, true), { wrapper: createWrapper() });
+
+    const call = (useQuery as jest.Mock).mock.calls[0][0];
+    expect(call.queryFn).toBe(notificationApi.getUnreadCount);
+  });
+});

--- a/src/features/notifications/model/notification.queries.ts
+++ b/src/features/notifications/model/notification.queries.ts
@@ -28,7 +28,7 @@ export const useNotificationInfiniteList = (
 ) =>
   useInfiniteQuery({
     ...getNotificationInfiniteQueryOptions(options),
-    staleTime: 1000 * 60,
+    staleTime: 1000 * 30,
     gcTime: 1000 * 60 * 5,
   });
 
@@ -49,7 +49,8 @@ export const useUnreadCount = (initialCount = 0, enabled = true) =>
     queryFn: notificationApi.getUnreadCount,
     initialData: initialCount,
     initialDataUpdatedAt: MODULE_LOAD_TIME,
-    staleTime: 1000 * 60,
+    staleTime: 1000 * 30,
     gcTime: 1000 * 60 * 5,
+    refetchInterval: 1000 * 30,
     enabled,
   });

--- a/src/widgets/search/ui/meeting-search-banner/meeting-search-banner.tsx
+++ b/src/widgets/search/ui/meeting-search-banner/meeting-search-banner.tsx
@@ -8,7 +8,7 @@ const bannerShellClass =
   'relative h-48 w-full overflow-hidden rounded-xlsm:h-56 md:h-[244px] md:max-w-[1140px] md:rounded-2xl';
 
 const headlineClass =
-  'font-pretendard-local text-3xl leading-[1.2] font-extrabold tracking-[-0.03em] text-white  md:text-[46px] md:leading-[55px] md:tracking-[-1.38px]';
+  'text-3xl leading-[1.2] font-extrabold tracking-[-0.03em] text-white  md:text-[46px] md:leading-[55px] md:tracking-[-1.38px]';
 
 const subtitleWrapClass =
   'mt-2 hidden max-w-[273px] text-base leading-7 font-normal text-white/80 md:block';
@@ -42,7 +42,7 @@ export function MeetingSearchBanner({ className }: MeetingSearchBannerProps) {
             <div
               className={subtitleWrapClass}
               style={{
-                fontFamily: "'Noto Sans KR', var(--font-pretendard-local), sans-serif",
+                fontFamily: "'Noto Sans KR', 'Pretendard Variable', sans-serif",
               }}
             >
               {'가고 싶었던 맛집, 혼자 가기 아쉬웠죠? 모여요에서 같이 먹을 사람을 찾아보세요.'}


### PR DESCRIPTION
### 📌 유형 (Type)

- [ ] **Feat (기능):** 새로운 기능 추가
- [x] **Fix (버그 수정):** 버그 수정
- [x] **Refactor (리팩토링):** 코드 구조/개선 (기능 변경 없음)
- [ ] **Docs (문서):** 문서 관련 변경 (README, Wiki 등)
- [ ] **Style (스타일):** 코드 포맷, 세미콜론 누락 등 (코드 동작에 영향 없음)
- [ ] **Chore (기타):** 빌드 시스템, 라이브러리 업데이트, 설정 등

### 📝 변경 사항 (Changes)

closes #475

#### 문제

`next/font/local`은 `unicode-range`를 지원하지 않는다. 동일한 `font-weight: 45 920`, `font-style: normal`로 5개 서브셋을 등록하면, Next.js는 `unicode-range` 없는 5개의 `@font-face` 규칙을 생성한다. CSS 캐스케이드에 의해 마지막으로 선언된 `subset.89`가 모든 글자를 담당하게 되어, subset.89에 없는 한글 글자들은 `Apple SD Gothic Neo` 등 시스템 폰트로 폴백된다.

또한 `theme.css`의 font-family 체인에 `'Pretendard Variable'`이 없었기 때문에, `pretendard-subset.css`의 unicode-range 정의가 실제로는 사용되지 않고 있었다.

#### 해결

- `layout.tsx`: `localFont` 제거, critical 서브셋 5개에 `<link rel="preload">` 직접 삽입
- `theme.css`: `var(--font-pretendard-local)` → `'Pretendard Variable'` — `pretendard-subset.css`의 unicode-range 정의가 실제로 적용됨
- `meeting-search-banner.tsx`: `--font-pretendard-local` 참조 제거
- `pretendard-subset.css`: **변경 없음** — 92개 서브셋의 unicode-range 정의 유지

#### preload vs next/font/local

`next/font/local`의 자동 preload 효과는 `<link rel="preload">`로 동일하게 재현 가능하다. `next/font/local`이 `unicode-range`를 지원하지 않는 이상, 서브셋 폰트에 이 API를 사용하는 것은 구조적으로 불가능하다.

### 🧪 테스트 방법 (How to Test)

1. `npm run dev` 로 개발 서버 실행
2. DevTools → Network 탭 → Font 필터 선택
3. 페이지 새로고침 후 `PretendardVariable.subset.81/88/89/90/91.woff2` 5개 파일이 초기에 요청되는지 확인
4. 홈/검색 페이지에서 모든 한글이 Pretendard로 렌더링되는지 확인 (시스템 폰트 폴백 없음)

### 🚨 기타 참고 사항 (Notes)

- `next/font/local`의 `unicode-range` 지원은 [GitHub 이슈](https://github.com/vercel/next.js/discussions/47840)로 오픈되어 있으나 미지원 상태